### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/models/dpn.py
+++ b/models/dpn.py
@@ -167,14 +167,14 @@ class DualPathBlock(nn.Module):
         self.num_1x1_c = num_1x1_c
         self.inc = inc
         self.b = b
-        if block_type is 'proj':
+        if block_type == 'proj':
             self.key_stride = 1
             self.has_proj = True
-        elif block_type is 'down':
+        elif block_type == 'down':
             self.key_stride = 2
             self.has_proj = True
         else:
-            assert block_type is 'normal'
+            assert block_type == 'normal'
             self.key_stride = 1
             self.has_proj = False
 


### PR DESCRIPTION
Identity is not the same thing as equality in Python.  In these instances, we want the latter.

Use ==/!= to compare str, bytes, and int literals.

$ __python__
```python
>>> proj = "pro"
>>> proj += "j"
>>> proj
'proj'
>>> proj == 'proj'
True
>>> proj is 'proj'
False
>>> 0 == 0.0
True
>>> 0 is 0.0
False
```
[flake8](http://flake8.pycqa.org) testing of https://github.com/rwightman/pytorch-image-models on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./data/loader.py:48:23: F823 local variable 'input' defined as a builtin referenced before assignment
                yield input, target
                      ^
./models/dpn.py:170:12: F632 use ==/!= to compare str, bytes, and int literals
        if block_type is 'proj':
           ^
./models/dpn.py:173:14: F632 use ==/!= to compare str, bytes, and int literals
        elif block_type is 'down':
             ^
./models/dpn.py:177:20: F632 use ==/!= to compare str, bytes, and int literals
            assert block_type is 'normal'
                   ^
3     F632 use ==/!= to compare str, bytes, and int literals
1     F823 local variable 'input' defined as a builtin referenced before assignment
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree