### PR TITLE
Avoid shadowing builtin: input --> curr_input

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -34,6 +34,7 @@ class PrefetchLoader:
     def __iter__(self):
         stream = torch.cuda.Stream()
         first = True
+        curr_input = None
 
         for next_input, next_target in self.loader:
             with torch.cuda.stream(stream):
@@ -44,15 +45,15 @@ class PrefetchLoader:
                     next_input = self.random_erasing(next_input)
 
             if not first:
-                yield input, target
+                yield curr_input, target
             else:
                 first = False
 
             torch.cuda.current_stream().wait_stream(stream)
-            input = next_input
+            curr_input = next_input
             target = next_target
 
-        yield input, target
+        yield curr_input, target
 
     def __len__(self):
         return len(self.loader)


### PR DESCRIPTION
__input()__ is a builtin in Python so it is not a suitable variable name.  Also, initialize the variable before referring to it.

[flake8](http://flake8.pycqa.org) testing of https://github.com/rwightman/pytorch-image-models on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./data/loader.py:47:23: F823 local variable 'input' defined as a builtin referenced before assignment
                yield input, target
                      ^
1     F823 local variable 'input' defined as a builtin referenced before assignment
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree