### PR TITLE
Replace `getattr` with `hasattr` in `get_state_dict`

### DIFF
--- a/timm/utils.py
+++ b/timm/utils.py
@@ -18,7 +18,7 @@ def get_state_dict(model):
     if isinstance(model, ModelEma):
         return get_state_dict(model.ema)
     else:
-        return model.module.state_dict() if getattr(model, 'module') else model.state_dict()
+        return model.module.state_dict() if hasattr(model, 'module') else model.state_dict()
 
 
 class CheckpointSaver:


### PR DESCRIPTION
Avoid throwing an `AttributeError: '...' object has no attribute 'module'` on non-(Distributed)DataParallel modules.