### PR TITLE
Blur

### DIFF
--- a/timm/models/layers/__init__.py
+++ b/timm/models/layers/__init__.py
@@ -15,3 +15,4 @@ from .adaptive_avgmax_pool import \
 from .drop import DropBlock2d, DropPath, drop_block_2d, drop_path
 from .test_time_pool import TestTimePoolHead, apply_test_time_pool
 from .split_batchnorm import SplitBatchNorm2d, convert_splitbn_model
+from .blurpool import BlurPool2d

--- a/timm/models/layers/blurpool.py
+++ b/timm/models/layers/blurpool.py
@@ -17,7 +17,7 @@ class BlurPool2d(nn.Module):
     Corresponds to the Downsample class, which does blurring and subsampling
     Args:
         channels = Number of input channels
-        blur_filter_size (int): binomial filter size for blurring. currently supports 3(default) and 5.
+        blur_filter_size (int): binomial filter size for blurring. currently supports 3 (default) and 5.
         stride (int): downsampling filter stride
     Shape:
     Returns:

--- a/timm/models/layers/blurpool.py
+++ b/timm/models/layers/blurpool.py
@@ -1,14 +1,17 @@
-'''
+"""
 BlurPool layer inspired by
-Kornia's Max_BlurPool2d
-and
-Making Convolutional Networks Shift-Invariant Again :cite:`zhang2019shiftinvar`
+ - Kornia's Max_BlurPool2d
+ - Making Convolutional Networks Shift-Invariant Again :cite:`zhang2019shiftinvar`
 
-'''
+Hacked together by Chris Ha and Ross Wightman
+"""
+
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import numpy as np
+from .padding import get_padding
 
 
 class BlurPool2d(nn.Module):
@@ -25,30 +28,30 @@ class BlurPool2d(nn.Module):
     Examples:
     """
 
-    def __init__(self, channels=None, blur_filter_size=3, stride=2) -> None:
+    def __init__(self, channels, blur_filter_size=3, stride=2) -> None:
         super(BlurPool2d, self).__init__()
-        assert blur_filter_size in [3, 5]
+        assert blur_filter_size > 1
         self.channels = channels
         self.blur_filter_size = blur_filter_size
         self.stride = stride
 
-        if blur_filter_size == 3:
-            pad_size = [1] * 4
-            blur_matrix = torch.Tensor([[1., 2., 1]]) / 4  # binomial filter b2
-        else:
-            pad_size = [2] * 4
-            blur_matrix = torch.Tensor([[1., 4., 6., 4., 1.]]) / 16  # binomial filter b4
-
+        pad_size = [get_padding(blur_filter_size, stride, dilation=1)] * 4
         self.padding = nn.ReflectionPad2d(pad_size)
-        blur_filter = blur_matrix * blur_matrix.T
+
+        blur_matrix = (np.poly1d((0.5, 0.5)) ** (blur_filter_size - 1)).coeffs
+        blur_filter = torch.Tensor(blur_matrix[:, None] * blur_matrix[None, :])
+        # FIXME figure a clean hack to prevent the filter from getting saved in weights, but still
+        # plays nice with recursive module apply for fn like .cuda(), .type(), etc -RW
         self.register_buffer('blur_filter', blur_filter[None, None, :, :].repeat((self.channels, 1, 1, 1)))
 
     def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:  # type: ignore
         if not torch.is_tensor(input_tensor):
-            raise TypeError("Input input type is not a torch.Tensor. Got {}"
-                            .format(type(input_tensor)))
+            raise TypeError("Input input type is not a torch.Tensor. Got {}".format(type(input_tensor)))
         if not len(input_tensor.shape) == 4:
-            raise ValueError("Invalid input shape, we expect BxCxHxW. Got: {}"
-                             .format(input_tensor.shape))
+            raise ValueError("Invalid input shape, we expect BxCxHxW. Got: {}".format(input_tensor.shape))
         # apply blur_filter on input
-        return F.conv2d(self.padding(input_tensor), self.blur_filter, stride=self.stride, groups=input_tensor.shape[1])
+        return F.conv2d(
+            self.padding(input_tensor),
+            self.blur_filter.type(input_tensor.dtype),
+            stride=self.stride,
+            groups=input_tensor.shape[1])

--- a/timm/models/layers/blurpool.py
+++ b/timm/models/layers/blurpool.py
@@ -49,7 +49,7 @@ class BlurPool2d(nn.Module):
         self.blur_filter = fn(self.blur_filter)
 
     def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:  # type: ignore
+        C = input_tensor.shape[1]
         return F.conv2d(
             self.padding(input_tensor),
-            self.blur_filter.type(input_tensor.dtype).expand(C, -1, -1, -1),
-            stride=self.stride, groups=input_tensor.shape[1])
+            self.blur_filter.type(input_tensor.dtype).expand(C, -1, -1, -1), stride=self.stride, groups=C)

--- a/timm/models/layers/blurpool.py
+++ b/timm/models/layers/blurpool.py
@@ -1,0 +1,68 @@
+'''independent attempt to implement
+
+MaxBlurPool2d in a more general fashion(separate maxpooling from BlurPool)
+which was again inspired by
+Making Convolutional Networks Shift-Invariant Again :cite:`zhang2019shiftinvar`
+
+'''
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class BlurPool2d(nn.Module):
+    r"""Creates a module that computes blurs and downsample a given feature map.
+    See :cite:`zhang2019shiftinvar` for more details.
+    Corresponds to the Downsample class, which does blurring and subsampling
+    Args:
+        channels = Number of input channels
+        blur_filter_size (int): filter size for blurring. currently supports either 3 or 5 (most common)
+                                defaults to 3.
+        stride (int): downsampling filter stride
+    Shape:
+    Returns:
+        torch.Tensor: the transformed tensor.
+    Examples:
+    """
+
+    def __init__(self, channels=None, blur_filter_size=3, stride=2) -> None:
+        super(BlurPool2d, self).__init__()
+        assert blur_filter_size in [3, 5]
+        self.channels = channels
+        self.blur_filter_size = blur_filter_size
+        self.stride = stride
+
+        if blur_filter_size == 3:
+            pad_size = [1] * 4
+            blur_matrix = torch.Tensor([[1., 2., 1]]) / 4 # binomial kernel b2
+        else:
+            pad_size = [2] * 4
+            blur_matrix = torch.Tensor([[1., 4., 6., 4., 1.]]) / 16 # binomial filter kernel b4
+
+        self.padding = nn.ReflectionPad2d(pad_size)
+        blur_filter = blur_matrix * blur_matrix.T
+        self.register_buffer('blur_filter', blur_filter[None, None, :, :].repeat((self.channels, 1, 1, 1)))
+
+    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor: # type: ignore
+        if not torch.is_tensor(input_tensor):
+            raise TypeError("Input input type is not a torch.Tensor. Got {}"
+                            .format(type(input_tensor)))
+        if not len(input_tensor.shape) == 4:
+            raise ValueError("Invalid input shape, we expect BxCxHxW. Got: {}"
+                             .format(input_tensor.shape))
+        # apply blur_filter on input
+        return F.conv2d(self.padding(input_tensor), self.blur_filter, stride=self.stride, groups=input_tensor.shape[1])
+
+
+######################
+# functional interface
+######################
+
+
+'''def blur_pool2d() -> torch.Tensor:
+    r"""Creates a module that computes pools and blurs and downsample a given
+    feature map.
+    See :class:`~kornia.contrib.MaxBlurPool2d` for details.
+    """
+    return BlurPool2d(kernel_size, ceil_mode)(input)'''

--- a/timm/models/resnet.py
+++ b/timm/models/resnet.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 
 from .registry import register_model
 from .helpers import load_pretrained
-from .layers import SelectAdaptivePool2d, DropBlock2d, DropPath, AvgPool2dSame, create_attn
+from .layers import SelectAdaptivePool2d, DropBlock2d, DropPath, AvgPool2dSame, create_attn, BlurPool2d
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
 
 
@@ -104,6 +104,8 @@ default_cfgs = {
         interpolation='bicubic'),
     'ecaresnet18': _cfg(),
     'ecaresnet50': _cfg(),
+    'resnetblur18': _cfg(),
+    'resnetblur50': _cfg()
 }
 
 
@@ -117,7 +119,7 @@ class BasicBlock(nn.Module):
 
     def __init__(self, inplanes, planes, stride=1, downsample=None, cardinality=1, base_width=64,
                  reduce_first=1, dilation=1, first_dilation=None, act_layer=nn.ReLU, norm_layer=nn.BatchNorm2d,
-                 attn_layer=None, drop_block=None, drop_path=None):
+                 attn_layer=None, drop_block=None, drop_path=None, blur=False):
         super(BasicBlock, self).__init__()
 
         assert cardinality == 1, 'BasicBlock only supports cardinality of 1'
@@ -125,10 +127,19 @@ class BasicBlock(nn.Module):
         first_planes = planes // reduce_first
         outplanes = planes * self.expansion
         first_dilation = first_dilation or dilation
+        self.blur = blur
 
-        self.conv1 = nn.Conv2d(
+        if blur and stride==2:
+            self.conv1 = nn.Conv2d(
+                inplanes, first_planes, kernel_size=3, stride=1, padding=first_dilation,
+                dilation=first_dilation, bias=False)
+            self.blurpool=BlurPool2d(channels=first_planes)
+        else:
+            self.conv1 = nn.Conv2d(
             inplanes, first_planes, kernel_size=3, stride=stride, padding=first_dilation,
             dilation=first_dilation, bias=False)
+            self.blurpool = None
+        
         self.bn1 = norm_layer(first_planes)
         self.act1 = act_layer(inplace=True)
         self.conv2 = nn.Conv2d(
@@ -154,7 +165,11 @@ class BasicBlock(nn.Module):
         x = self.bn1(x)
         if self.drop_block is not None:
             x = self.drop_block(x)
-        x = self.act1(x)
+        if self.blurpool is not None:
+            x = self.act1(x)
+            x = self.blurpool(x)
+        else:
+            x = self.act1(x)
 
         x = self.conv2(x)
         x = self.bn2(x)
@@ -181,20 +196,30 @@ class Bottleneck(nn.Module):
 
     def __init__(self, inplanes, planes, stride=1, downsample=None, cardinality=1, base_width=64,
                  reduce_first=1, dilation=1, first_dilation=None, act_layer=nn.ReLU, norm_layer=nn.BatchNorm2d,
-                 attn_layer=None, drop_block=None, drop_path=None):
+                 attn_layer=None, drop_block=None, drop_path=None, blur=False):
         super(Bottleneck, self).__init__()
 
         width = int(math.floor(planes * (base_width / 64)) * cardinality)
         first_planes = width // reduce_first
         outplanes = planes * self.expansion
         first_dilation = first_dilation or dilation
+        self.blur = blur
 
         self.conv1 = nn.Conv2d(inplanes, first_planes, kernel_size=1, bias=False)
         self.bn1 = norm_layer(first_planes)
         self.act1 = act_layer(inplace=True)
-        self.conv2 = nn.Conv2d(
-            first_planes, width, kernel_size=3, stride=stride,
-            padding=first_dilation, dilation=first_dilation, groups=cardinality, bias=False)
+
+        if blur and stride==2:
+            self.conv2 = nn.Conv2d(
+                first_planes, width, kernel_size=3, stride=1,
+                padding=first_dilation, dilation=first_dilation, groups=cardinality, bias=False)
+            self.blurpool = BlurPool2d(channels=width)
+        else:
+            self.conv2 = nn.Conv2d(
+                first_planes, width, kernel_size=3, stride=stride,
+                padding=first_dilation, dilation=first_dilation, groups=cardinality, bias=False)
+            self.blurpool = None
+
         self.bn2 = norm_layer(width)
         self.act2 = act_layer(inplace=True)
         self.conv3 = nn.Conv2d(width, outplanes, kernel_size=1, bias=False)
@@ -345,12 +370,19 @@ class ResNet(nn.Module):
         Dropout probability before classifier, for training
     global_pool : str, default 'avg'
         Global pooling type. One of 'avg', 'max', 'avgmax', 'catavgmax'
+    blur : str, default ''
+        Location of Blurring:
+        * '', default - Not applied
+        * 'max' - only stem layer MaxPool will be blurred
+        * 'strided' - only strided convolutions in the downsampling blocks (assembled-cnn style)
+        * 'max_strided' - on both stem MaxPool and strided convolutions (zhang2019shiftinvar style for ResNets)
+
     """
     def __init__(self, block, layers, num_classes=1000, in_chans=3,
                  cardinality=1, base_width=64, stem_width=64, stem_type='',
                  block_reduce_first=1, down_kernel_size=1, avg_down=False, output_stride=32,
                  act_layer=nn.ReLU, norm_layer=nn.BatchNorm2d, drop_rate=0.0, drop_path_rate=0.,
-                 drop_block_rate=0., global_pool='avg', zero_init_last_bn=True, block_args=None):
+                 drop_block_rate=0., global_pool='avg', blur='', zero_init_last_bn=True, block_args=None):
         block_args = block_args or dict()
         self.num_classes = num_classes
         deep_stem = 'deep' in stem_type
@@ -359,6 +391,7 @@ class ResNet(nn.Module):
         self.base_width = base_width
         self.drop_rate = drop_rate
         self.expansion = block.expansion
+        self.blur = 'strided' in blur
         super(ResNet, self).__init__()
 
         # Stem
@@ -379,7 +412,13 @@ class ResNet(nn.Module):
             self.conv1 = nn.Conv2d(in_chans, self.inplanes, kernel_size=7, stride=2, padding=3, bias=False)
         self.bn1 = norm_layer(self.inplanes)
         self.act1 = act_layer(inplace=True)
-        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        # Stem Blur
+        if 'max' in blur :
+            self.maxpool = nn.Sequential(*[
+            nn.MaxPool2d(kernel_size=3, stride=1, padding=1),
+            BlurPool2d(channels=self.inplanes)])
+        else :
+            self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
 
         # Feature Blocks
         dp = DropPath(drop_path_rate) if drop_path_rate else None
@@ -432,7 +471,7 @@ class ResNet(nn.Module):
         block_kwargs = dict(
             cardinality=self.cardinality, base_width=self.base_width, reduce_first=reduce_first,
             dilation=dilation, **kwargs)
-        layers = [block(self.inplanes, planes, stride, downsample, first_dilation=first_dilation, **block_kwargs)]
+        layers = [block(self.inplanes, planes, stride, downsample, first_dilation=first_dilation, blur=self.blur, **block_kwargs)]
         self.inplanes = planes * block.expansion
         layers += [block(self.inplanes, planes, **block_kwargs) for _ in range(1, blocks)]
 
@@ -1021,4 +1060,22 @@ def ecaresnet50(pretrained=False, num_classes=1000, in_chans=3, **kwargs):
     model.default_cfg = default_cfg
     if pretrained:
         load_pretrained(model, default_cfg, num_classes, in_chans)
+    return model
+
+@register_model
+def resnetblur18(pretrained=False, num_classes=1000, in_chans=3, **kwargs):
+    """Constructs a ResNet-18 model. With original style blur
+    """
+    default_cfg = default_cfgs['resnetblur18']
+    model = ResNet(BasicBlock, [2, 2, 2, 2], num_classes=num_classes, in_chans=in_chans, blur='max_strided',**kwargs)
+    model.default_cfg = default_cfg
+    return model
+
+@register_model
+def resnetblur50(pretrained=False, num_classes=1000, in_chans=3, **kwargs):
+    """Constructs a ResNet-50 model. With assembled-cnn style blur
+    """
+    default_cfg = default_cfgs['resnetblur18']
+    model = ResNet(Bottleneck, [3, 4, 6, 3], num_classes=num_classes, in_chans=in_chans, blur='strided', **kwargs)
+    model.default_cfg = default_cfg
     return model


### PR DESCRIPTION
Continuing my attempts at Issue #90, 
I implemented a blur pool layer for future integration.
Although I wanted to copy Kornia's [implementation ](https://github.com/kornia/kornia/blob/master/kornia/contrib/max_blur_pool.py) I found that they tightly coupled max pooling with the downsampling. Also it had an internal dependency on for pyramid downsampling.

As the original [implementation ](https://github.com/adobe/antialiased-cnns) suggests three different strategies for antialiasing(each involving Max and average pooling and strided convolution), I had to decouple the code both from both max pooling and the internal dependency.

I ended up re-implementing the whole thing.
However, I did end up making several design choices.
First of all, I only implemented two most common binomial filters(3 and 5) for downsampling.
(Kornia seems to have implemented one while the original repo implements 7)

This is because the original paper says the most common meaning filters to be used would be the filters of 3 and 5, and since the code base I'm working up to(#90) tested only 3 and 5 (and settled for 3). It is not to hard to implement other filters should the need arise.

Secondly, I removed most options for several padding strategies since neither kornia, the original anti-aliasing paper nor #90 discusses the tradeoffs for each padding and just used the original reflective padding strategy. 
I thought about the consequences of the various padding strategies but it seems that only the makes original one makes sense.


Currently the blurpool function is not used by ResNet as intended.

This is because further design choices are necessary.
Although potentially any and all maxpool, avg-pool and s=2 strided conv can be blurred with this,
the original paper and #90 show that it is both unnecessary and inefficient.

So my next step would be to implement this in the style of #90(certain downsampling strided convs only) and only exposing a boolean argument somewhere.

Next, it would be implemented as value argument to enable either Vanilla, #90 style, and the original paper style (all? strided convs and maxpools).

I guess I'd need to make some design decisions and then see how it works.

In the meantime I would like for you to look at the code and point out improvements or changes you would like to see before I move forward.