### PR TITLE
minor PR to fix typos found in #116 and resnet.py

### DIFF
--- a/timm/models/layers/create_attn.py
+++ b/timm/models/layers/create_attn.py
@@ -17,7 +17,7 @@ def create_attn(attn_type, channels, **kwargs):
                 module_cls = SEModule
             elif attn_type == 'eca':
                 module_cls = EcaModule
-            elif attn_type == 'eca':
+            elif attn_type == 'ceca':
                 module_cls = CecaModule
             elif attn_type == 'cbam':
                 module_cls = CbamModule

--- a/timm/models/resnet.py
+++ b/timm/models/resnet.py
@@ -121,7 +121,7 @@ class BasicBlock(nn.Module):
         super(BasicBlock, self).__init__()
 
         assert cardinality == 1, 'BasicBlock only supports cardinality of 1'
-        assert base_width == 64, 'BasicBlock doest not support changing base width'
+        assert base_width == 64, 'BasicBlock does not support changing base width'
         first_planes = planes // reduce_first
         outplanes = planes * self.expansion
         first_dilation = first_dilation or dilation


### PR DESCRIPTION
Properly rebased my previous typo fix and added #116 
'eca'->'ceca'
and
doest not-> does not

I thought it didn't make sense to just resend the same PR rebased(as it was so low value in the first place)
but now that another typo, this time functionally relevant, was found I decided to roll them both into a signal PR.
