### PR TITLE
added MultiEpochsDataLoader

### DIFF
--- a/train.py
+++ b/train.py
@@ -198,6 +198,8 @@ parser.add_argument('--eval-metric', default='top1', type=str, metavar='EVAL_MET
 parser.add_argument('--tta', type=int, default=0, metavar='N',
                     help='Test/inference time augmentation (oversampling) factor. 0=None (default: 0)')
 parser.add_argument("--local_rank", default=0, type=int)
+parser.add_argument('--use-multi-epochs-loader', action='store_true', default=False,
+                    help='use the multi-epochs-loader to save time at the beginning of every epoch')
 
 
 def _parse_args():
@@ -391,6 +393,7 @@ def main():
         distributed=args.distributed,
         collate_fn=collate_fn,
         pin_memory=args.pin_mem,
+        use_multi_epochs_loader=args.use_multi_epochs_loader
     )
 
     eval_dir = os.path.join(args.data, 'val')


### PR DESCRIPTION
Hi.

I have added a feature that is called MultiEpochsDataLoader. When using the data loader of pytorch, at the beginning of every epoch, we have to wait a lot and the training speed is very low from the first iteration. It is because the pytorch data loader is reinitialized from scratch. 

In this feature, we do not waste time, and just the first initialization of the the dataloader at the first epoch takes time, but for the next epochs, the first iteration of every new epoch is as fast as the iterations in the middle of an epoch.

Example when using the MultiEpochsDataLoader:

First epoch:

<img width="994" alt="Screen Shot 2020-05-05 at 14 36 55" src="https://user-images.githubusercontent.com/25453124/81062171-3289d880-8ede-11ea-896f-954727479b5f.png">

Next epochs
<img width="1008" alt="Screen Shot 2020-05-05 at 14 37 33" src="https://user-images.githubusercontent.com/25453124/81062378-82689f80-8ede-11ea-9fd4-78f42d7f0bb2.png">

This can save more than 10 seconds per epoch, that is almost an hour of training when training a network with 300 epochs. (for example, training on 8 V100 is quite expensive, so saving an hour every time we need to train is quite nice)


I have tested the feature on a training of ecaresnetlight