### PR TITLE
Setup Github Action to instantiate and run a forward pass with each registered model.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python: ['3.8', '3.7']
+        python: ['3.8']
+        torch: ['1.5.0']
+        torchvision: ['0.6.0']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -21,10 +23,18 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python }}
-    - name: Install dependencies
+    - name: Install testing dependencies
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-timeout
+    - name: Install torch on mac
+      if: startsWith(matrix.os, 'macOS')
+      run: pip install torch==${{ matrix.torch }} torchvision==${{ matrix.torchvision }}
+    - name: Install torch on ubuntu
+      if: startsWith(matrix.os, 'ubuntu')
+      run: pip install torch==${{ matrix.torch }}+cpu torchvision==${{ matrix.torchvision }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    - name: Install requirements
+      run: |
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install scipy
         pip install git+https://github.com/mapillary/inplace_abn.git@v1.0.11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Python tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: Run tests on ${{ matrix.os }} with Python ${{ matrix.python }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        python: ['3.8', '3.7']
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run tests
+      run: |
+        pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
+        pip install pytest pytest-timeout
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install scipy
+        pip install git+https://github.com/mapillary/inplace_abn.git@v1.0.11
     - name: Run tests
       run: |
-        pytest
+        pytest -vv --durations=0 ./tests

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,19 @@
+import pytest
+import torch
+
+from timm import list_models, create_model
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize('model_name', list_models())
+@pytest.mark.parametrize('batch_size', [1])
+def test_model_forward(model_name, batch_size):
+  """Run a single forward pass with each model"""
+  model = create_model(model_name, pretrained=False)
+  model.eval()
+
+  inputs = torch.randn((batch_size, *model.default_cfg['input_size']))
+  outputs = model(inputs)
+
+  assert outputs.shape[0] == batch_size
+  assert not torch.isnan(outputs).any(), 'Output included NaNs'


### PR DESCRIPTION
This adds a github action to run a test suite, which at the moment only instantiates each model and runs a forward pass.

Here's how that looks live: https://github.com/michalwols/pytorch-image-models/runs/651871707?check_suite_focus=true

Results include timing for each model:
![image](https://user-images.githubusercontent.com/1071969/81258000-acb37d80-9002-11ea-9989-278f0fbc4cea.png)


The runners are really underpowered so it might make sense to pick the smallest variant of each model class to keep the runtime of the action reasonable. 

I added a timeout of 60s for each model, which they all comfortably pass on my laptop but it should probably be changed for the CI env since it will lead to flaky tests. 