### PR TITLE
Update activations.py

### DIFF
--- a/timm/models/layers/activations.py
+++ b/timm/models/layers/activations.py
@@ -18,7 +18,7 @@ if _USE_MEM_EFFICIENT_ISH:
     # recomputing torch.sigmoid(x) in backward instead of saving it.
     @torch.jit.script
     def swish_jit_fwd(x):
-        return x.mul(torch.sigmoid(x))
+        return x.mul_(torch.sigmoid(x))
 
 
     @torch.jit.script
@@ -50,7 +50,7 @@ if _USE_MEM_EFFICIENT_ISH:
 
     @torch.jit.script
     def mish_jit_fwd(x):
-        return x.mul(torch.tanh(F.softplus(x)))
+        return x.mul_(torch.tanh(F.softplus(x)))
 
 
     @torch.jit.script


### PR DESCRIPTION
This minor change makes swish and mish inplace by default and saves a lot of memory during training in my tests.

It seems to increase backward time slightly (~2-3%) but it's definitely worth the memory saved 

```
EffNet B1 (proposed): 7.79M params
Mean of 10 runs 10 iters each BS=64, SZ=224 +AMP:
	 30.38+-0.02 msecs Forward. 156.21+-3.28 msecs Backward. Max memory: 2901.41Mb. 342.99 imgs/sec
EffNet B1 (current): 7.79M params
Mean of 10 runs 10 iters each BS=64, SZ=224 +AMP:
	 30.54+-0.31 msecs Forward. 161.67+-1.89 msecs Backward. Max memory: 3927.02Mb. 332.98 imgs/sec
```