### PR TITLE
Bug fix: test_time_pool would be set to a non-False value

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -73,7 +73,7 @@ def main():
                  (args.model, sum([m.numel() for m in model.parameters()])))
 
     config = resolve_data_config(vars(args), model=model)
-    model, test_time_pool = model, False if args.no_test_pool else apply_test_time_pool(model, config)
+    model, test_time_pool = (model, False) if args.no_test_pool else apply_test_time_pool(model, config)
 
     if args.num_gpu > 1:
         model = torch.nn.DataParallel(model, device_ids=list(range(args.num_gpu))).cuda()

--- a/validate.py
+++ b/validate.py
@@ -139,7 +139,7 @@ def validate(args):
     _logger.info('Model %s created, param count: %d' % (args.model, param_count))
 
     data_config = resolve_data_config(vars(args), model=model)
-    model, test_time_pool = model, False if args.no_test_pool else apply_test_time_pool(model, data_config)
+    model, test_time_pool = (model, False) if args.no_test_pool else apply_test_time_pool(model, data_config)
 
     if args.torchscript:
         torch.jit.optimized_execution(True)


### PR DESCRIPTION
If `args.no_test_pool` is False but `apply_test_time_pool()` returns False because test-time pooling is not available, then the local variable `test_time_pool` would not be set to True or False but to a copy of the model. In turn, this would cause the `crop_pct` to be set to 1.0 further down in the code. This bug causes the results from validate.py to be slightly different from the validation score shown during training due to the different crop rectangle (unless training happened to use `crop_pct = 1.0`, of course).

Also possibly the cause of this issue: https://github.com/rwightman/pytorch-image-models/issues/235
