### PR TITLE
Fix a bug with accuracy retrieving from RealLabels

### DIFF
--- a/timm/data/real_labels.py
+++ b/timm/data/real_labels.py
@@ -37,6 +37,6 @@ class RealLabelsImagenet:
 
     def get_accuracy(self, k=None):
         if k is None:
-            return {k: float(np.mean(self.is_correct[k] for k in self.topk))}
+            return {k: float(np.mean(self.is_correct[k])) * 100 for k in self.topk}
         else:
             return float(np.mean(self.is_correct[k])) * 100


### PR DESCRIPTION
Calling `get_accuracy` method without arguments caused a TypeError