### PR TITLE
Add model-index files

### DIFF
--- a/modelindex/.templates/code_snippets.md
+++ b/modelindex/.templates/code_snippets.md
@@ -1,0 +1,62 @@
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('{{ model_name }}', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `{{ model_name }}`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('{{ model_name }}', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.

--- a/modelindex/.templates/models/adversarial-inception-v3.md
+++ b/modelindex/.templates/models/adversarial-inception-v3.md
@@ -51,12 +51,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Adversarial Inception v3
+  Paper:
+    Title: Adversarial Attacks and Defences Competition
+    URL: https://paperswithcode.com/paper/adversarial-attacks-and-defences-competition
 Models:
 - Name: adv_inception_v3
+  In Collection: Adversarial Inception v3
   Metadata:
     FLOPs: 7352418880
-    Training Data:
-    - ImageNet
+    Parameters: 23830000
+    File Size: 95549439
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -70,20 +77,20 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 95549439
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: adv_inception_v3
     Crop Pct: '0.875'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L456
-  In Collection: Adversarial Inception v3
-Collections:
-- Name: Adversarial Inception v3
-  Paper:
-    title: Adversarial Attacks and Defences Competition
-    url: https://paperswithcode.com//paper/adversarial-attacks-and-defences-competition
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/adv_inception_v3-9e27bd63.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.58%
+      Top 5 Accuracy: 93.74%
 -->

--- a/modelindex/.templates/models/adversarial-inception-v3.md
+++ b/modelindex/.templates/models/adversarial-inception-v3.md
@@ -1,0 +1,89 @@
+# Summary
+
+**Inception v3** is a convolutional neural network architecture from the Inception family that makes several improvements including using [Label Smoothing](https://paperswithcode.com/method/label-smoothing), Factorized 7 x 7 convolutions, and the use of an [auxiliary classifer](https://paperswithcode.com/method/auxiliary-classifier) to propagate label information lower down the network (along with the use of batch normalization for layers in the sidehead). The key building block is an [Inception Module](https://paperswithcode.com/method/inception-v3-module).
+
+This particular model was trained for study of adversarial examples (adversarial training).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1804-00097,
+  author    = {Alexey Kurakin and
+               Ian J. Goodfellow and
+               Samy Bengio and
+               Yinpeng Dong and
+               Fangzhou Liao and
+               Ming Liang and
+               Tianyu Pang and
+               Jun Zhu and
+               Xiaolin Hu and
+               Cihang Xie and
+               Jianyu Wang and
+               Zhishuai Zhang and
+               Zhou Ren and
+               Alan L. Yuille and
+               Sangxia Huang and
+               Yao Zhao and
+               Yuzhe Zhao and
+               Zhonglin Han and
+               Junjiajia Long and
+               Yerkebulan Berdibekov and
+               Takuya Akiba and
+               Seiya Tokui and
+               Motoki Abe},
+  title     = {Adversarial Attacks and Defences Competition},
+  journal   = {CoRR},
+  volume    = {abs/1804.00097},
+  year      = {2018},
+  url       = {http://arxiv.org/abs/1804.00097},
+  archivePrefix = {arXiv},
+  eprint    = {1804.00097},
+  timestamp = {Thu, 31 Oct 2019 16:31:22 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1804-00097.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: adv_inception_v3
+  Metadata:
+    FLOPs: 7352418880
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 95549439
+    Tasks:
+    - Image Classification
+    ID: adv_inception_v3
+    Crop Pct: '0.875'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L456
+  In Collection: Adversarial Inception v3
+Collections:
+- Name: Adversarial Inception v3
+  Paper:
+    title: Adversarial Attacks and Defences Competition
+    url: https://papperswithcode.com//paper/adversarial-attacks-and-defences-competition
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/adversarial-inception-v3.md
+++ b/modelindex/.templates/models/adversarial-inception-v3.md
@@ -83,7 +83,7 @@ Collections:
 - Name: Adversarial Inception v3
   Paper:
     title: Adversarial Attacks and Defences Competition
-    url: https://papperswithcode.com//paper/adversarial-attacks-and-defences-competition
+    url: https://paperswithcode.com//paper/adversarial-attacks-and-defences-competition
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/advprop.md
+++ b/modelindex/.templates/models/advprop.md
@@ -1,0 +1,384 @@
+# Summary
+
+**AdvProp** is an adversarial training scheme which treats adversarial examples as additional examples, to prevent overfitting. Key to the method is the usage of a separate auxiliary batch norm for adversarial examples, as they have different underlying distributions to normal examples.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{xie2020adversarial,
+      title={Adversarial Examples Improve Image Recognition}, 
+      author={Cihang Xie and Mingxing Tan and Boqing Gong and Jiang Wang and Alan Yuille and Quoc V. Le},
+      year={2020},
+      eprint={1911.09665},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_b1_ap
+  Metadata:
+    FLOPs: 883633200
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 31515350
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b1_ap
+    LR: 0.256
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1344
+  In Collection: AdvProp
+- Name: tf_efficientnet_b2_ap
+  Metadata:
+    FLOPs: 1234321170
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 36800745
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b2_ap
+    LR: 0.256
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1354
+  In Collection: AdvProp
+- Name: tf_efficientnet_b3_ap
+  Metadata:
+    FLOPs: 2275247568
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49384538
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b3_ap
+    LR: 0.256
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1364
+  In Collection: AdvProp
+- Name: tf_efficientnet_b4_ap
+  Metadata:
+    FLOPs: 5749638672
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 77993585
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b4_ap
+    LR: 0.256
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1374
+  In Collection: AdvProp
+- Name: tf_efficientnet_b5_ap
+  Metadata:
+    FLOPs: 13176501888
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 122403150
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b5_ap
+    LR: 0.256
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1384
+  In Collection: AdvProp
+- Name: tf_efficientnet_b6_ap
+  Metadata:
+    FLOPs: 24180518488
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 173237466
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b6_ap
+    LR: 0.256
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1394
+  In Collection: AdvProp
+- Name: tf_efficientnet_b7_ap
+  Metadata:
+    FLOPs: 48205304880
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 266850607
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b7_ap
+    LR: 0.256
+    Crop Pct: '0.949'
+    Momentum: 0.9
+    Image Size: '600'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1405
+  In Collection: AdvProp
+- Name: tf_efficientnet_b8_ap
+  Metadata:
+    FLOPs: 80962956270
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 351412563
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b8_ap
+    LR: 0.128
+    Crop Pct: '0.954'
+    Momentum: 0.9
+    Image Size: '672'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1416
+  In Collection: AdvProp
+- Name: tf_efficientnet_b0_ap
+  Metadata:
+    FLOPs: 488688572
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 21385973
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b0_ap
+    LR: 0.256
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1334
+  In Collection: AdvProp
+Collections:
+- Name: AdvProp
+  Paper:
+    title: Adversarial Examples Improve Image Recognition
+    url: https://papperswithcode.com//paper/adversarial-examples-improve-image
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/advprop.md
+++ b/modelindex/.templates/models/advprop.md
@@ -22,333 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: AdvProp
+  Paper:
+    Title: Adversarial Examples Improve Image Recognition
+    URL: https://paperswithcode.com/paper/adversarial-examples-improve-image
 Models:
-- Name: tf_efficientnet_b1_ap
-  Metadata:
-    FLOPs: 883633200
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 31515350
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b1_ap
-    LR: 0.256
-    Crop Pct: '0.882'
-    Momentum: 0.9
-    Image Size: '240'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1344
-  In Collection: AdvProp
-- Name: tf_efficientnet_b2_ap
-  Metadata:
-    FLOPs: 1234321170
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 36800745
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b2_ap
-    LR: 0.256
-    Crop Pct: '0.89'
-    Momentum: 0.9
-    Image Size: '260'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1354
-  In Collection: AdvProp
-- Name: tf_efficientnet_b3_ap
-  Metadata:
-    FLOPs: 2275247568
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49384538
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b3_ap
-    LR: 0.256
-    Crop Pct: '0.904'
-    Momentum: 0.9
-    Image Size: '300'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1364
-  In Collection: AdvProp
-- Name: tf_efficientnet_b4_ap
-  Metadata:
-    FLOPs: 5749638672
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 77993585
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b4_ap
-    LR: 0.256
-    Crop Pct: '0.922'
-    Momentum: 0.9
-    Image Size: '380'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1374
-  In Collection: AdvProp
-- Name: tf_efficientnet_b5_ap
-  Metadata:
-    FLOPs: 13176501888
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 122403150
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b5_ap
-    LR: 0.256
-    Crop Pct: '0.934'
-    Momentum: 0.9
-    Image Size: '456'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1384
-  In Collection: AdvProp
-- Name: tf_efficientnet_b6_ap
-  Metadata:
-    FLOPs: 24180518488
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 173237466
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b6_ap
-    LR: 0.256
-    Crop Pct: '0.942'
-    Momentum: 0.9
-    Image Size: '528'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1394
-  In Collection: AdvProp
-- Name: tf_efficientnet_b7_ap
-  Metadata:
-    FLOPs: 48205304880
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 266850607
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b7_ap
-    LR: 0.256
-    Crop Pct: '0.949'
-    Momentum: 0.9
-    Image Size: '600'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1405
-  In Collection: AdvProp
-- Name: tf_efficientnet_b8_ap
-  Metadata:
-    FLOPs: 80962956270
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 351412563
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b8_ap
-    LR: 0.128
-    Crop Pct: '0.954'
-    Momentum: 0.9
-    Image Size: '672'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1416
-  In Collection: AdvProp
 - Name: tf_efficientnet_b0_ap
+  In Collection: AdvProp
   Metadata:
     FLOPs: 488688572
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 5290000
+    File Size: 21385973
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -359,13 +45,23 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 21385973
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b0_ap
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -373,12 +69,387 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1334
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b0_ap-f262efe1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.1%
+      Top 5 Accuracy: 93.26%
+- Name: tf_efficientnet_b1_ap
   In Collection: AdvProp
-Collections:
-- Name: AdvProp
-  Paper:
-    title: Adversarial Examples Improve Image Recognition
-    url: https://paperswithcode.com//paper/adversarial-examples-improve-image
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 883633200
+    Parameters: 7790000
+    File Size: 31515350
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b1_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1344
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b1_ap-44ef0a3d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.28%
+      Top 5 Accuracy: 94.3%
+- Name: tf_efficientnet_b2_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 1234321170
+    Parameters: 9110000
+    File Size: 36800745
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b2_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1354
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b2_ap-2f8e7636.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.3%
+      Top 5 Accuracy: 95.03%
+- Name: tf_efficientnet_b3_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 2275247568
+    Parameters: 12230000
+    File Size: 49384538
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b3_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1364
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b3_ap-aad25bdd.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.82%
+      Top 5 Accuracy: 95.62%
+- Name: tf_efficientnet_b4_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 5749638672
+    Parameters: 19340000
+    File Size: 77993585
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b4_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1374
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b4_ap-dedb23e6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.26%
+      Top 5 Accuracy: 96.39%
+- Name: tf_efficientnet_b5_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 13176501888
+    Parameters: 30390000
+    File Size: 122403150
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b5_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1384
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_ap-9e82fae8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.25%
+      Top 5 Accuracy: 96.97%
+- Name: tf_efficientnet_b6_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 24180518488
+    Parameters: 43040000
+    File Size: 173237466
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b6_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1394
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b6_ap-4ffb161f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.79%
+      Top 5 Accuracy: 97.14%
+- Name: tf_efficientnet_b7_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 48205304880
+    Parameters: 66349999
+    File Size: 266850607
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b7_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.949'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '600'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1405
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b7_ap-ddb28fec.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.12%
+      Top 5 Accuracy: 97.25%
+- Name: tf_efficientnet_b8_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 80962956270
+    Parameters: 87410000
+    File Size: 351412563
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b8_ap
+    LR: 0.128
+    Epochs: 350
+    Crop Pct: '0.954'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '672'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1416
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b8_ap-00e169fa.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.37%
+      Top 5 Accuracy: 97.3%
 -->

--- a/modelindex/.templates/models/advprop.md
+++ b/modelindex/.templates/models/advprop.md
@@ -378,7 +378,7 @@ Collections:
 - Name: AdvProp
   Paper:
     title: Adversarial Examples Improve Image Recognition
-    url: https://papperswithcode.com//paper/adversarial-examples-improve-image
+    url: https://paperswithcode.com//paper/adversarial-examples-improve-image
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/big-transfer.md
+++ b/modelindex/.templates/models/big-transfer.md
@@ -22,50 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Big Transfer
+  Paper:
+    Title: 'Big Transfer (BiT): General Visual Representation Learning'
+    URL: https://paperswithcode.com/paper/large-scale-learning-of-general-visual
 Models:
-- Name: resnetv2_152x4_bitm
-  Metadata:
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
-    Architecture:
-    - 1x1 Convolution
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Group Normalization
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    - Weight Standardization
-    File Size: 3746270104
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnetv2_152x4_bitm
-    Crop Pct: '1.0'
-    Image Size: '480'
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L465
-  Config: ''
+- Name: resnetv2_101x1_bitm
   In Collection: Big Transfer
-- Name: resnetv2_152x2_bitm
   Metadata:
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    FLOPs: 5330896
+    Parameters: 44540000
+    File Size: 178256468
     Architecture:
     - 1x1 Convolution
     - Bottleneck Residual Block
@@ -78,29 +47,125 @@ Models:
     - Residual Connection
     - Softmax
     - Weight Standardization
-    File Size: 945476668
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
+    ID: resnetv2_101x1_bitm
+    LR: 0.03
+    Epochs: 90
+    Layers: 101
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Batch Size: 4096
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L444
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R101x1-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.21%
+      Top 5 Accuracy: 96.47%
+- Name: resnetv2_101x3_bitm
+  In Collection: Big Transfer
+  Metadata:
+    FLOPs: 15988688
+    Parameters: 387930000
+    File Size: 1551830100
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
+    ID: resnetv2_101x3_bitm
+    LR: 0.03
+    Epochs: 90
+    Layers: 101
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Batch Size: 4096
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L451
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R101x3-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.38%
+      Top 5 Accuracy: 97.37%
+- Name: resnetv2_152x2_bitm
+  In Collection: Big Transfer
+  Metadata:
+    FLOPs: 10659792
+    Parameters: 236340000
+    File Size: 945476668
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
     ID: resnetv2_152x2_bitm
     Crop Pct: '1.0'
     Image Size: '480'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L458
-  Config: ''
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R152x2-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.4%
+      Top 5 Accuracy: 97.43%
+- Name: resnetv2_152x4_bitm
   In Collection: Big Transfer
-- Name: resnetv2_50x1_bitm
   Metadata:
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
+    FLOPs: 21317584
+    Parameters: 936530000
+    File Size: 3746270104
     Architecture:
     - 1x1 Convolution
     - Bottleneck Residual Block
@@ -113,72 +178,80 @@ Models:
     - Residual Connection
     - Softmax
     - Weight Standardization
-    File Size: 102242668
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
+    ID: resnetv2_152x4_bitm
+    Crop Pct: '1.0'
+    Image Size: '480'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L465
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R152x4-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.95%
+      Top 5 Accuracy: 97.45%
+- Name: resnetv2_50x1_bitm
+  In Collection: Big Transfer
+  Metadata:
+    FLOPs: 5330896
+    Parameters: 25550000
+    File Size: 102242668
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
     ID: resnetv2_50x1_bitm
     LR: 0.03
+    Epochs: 90
     Layers: 50
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '480'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L430
-  Config: ''
-  In Collection: Big Transfer
-- Name: resnetv2_101x3_bitm
-  Metadata:
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
-    Architecture:
-    - 1x1 Convolution
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Group Normalization
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    - Weight Standardization
-    File Size: 1551830100
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnetv2_101x3_bitm
-    LR: 0.03
-    Layers: 101
-    Crop Pct: '1.0'
-    Momentum: 0.9
-    Image Size: '480'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L451
-  Config: ''
-  In Collection: Big Transfer
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R50x1-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.19%
+      Top 5 Accuracy: 95.63%
 - Name: resnetv2_50x3_bitm
+  In Collection: Big Transfer
   Metadata:
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
+    FLOPs: 15988688
+    Parameters: 217320000
+    File Size: 869321580
     Architecture:
     - 1x1 Convolution
     - Bottleneck Residual Block
@@ -191,65 +264,32 @@ Models:
     - Residual Connection
     - Softmax
     - Weight Standardization
-    File Size: 869321580
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
     ID: resnetv2_50x3_bitm
     LR: 0.03
+    Epochs: 90
     Layers: 50
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '480'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L437
-  Config: ''
-  In Collection: Big Transfer
-- Name: resnetv2_101x1_bitm
-  Metadata:
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
-    Architecture:
-    - 1x1 Convolution
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Group Normalization
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    - Weight Standardization
-    File Size: 178256468
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnetv2_101x1_bitm
-    LR: 0.03
-    Layers: 101
-    Crop Pct: '1.0'
-    Momentum: 0.9
-    Image Size: '480'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L444
-  Config: ''
-  In Collection: Big Transfer
-Collections:
-- Name: Big Transfer
-  Paper:
-    title: 'Big Transfer (BiT): General Visual Representation Learning'
-    url: https://paperswithcode.com//paper/large-scale-learning-of-general-visual
-  type: model-index
-Type: model-index
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R50x3-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.75%
+      Top 5 Accuracy: 97.12%
 -->

--- a/modelindex/.templates/models/big-transfer.md
+++ b/modelindex/.templates/models/big-transfer.md
@@ -1,0 +1,255 @@
+# Summary
+
+**Big Transfer (BiT)** is a type of pretraining recipe that pre-trains  on a large supervised source dataset, and fine-tunes the weights on the target task. Models are trained on the JFT-300M dataset. The finetuned models contained in this collection are finetuned on ImageNet.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{kolesnikov2020big,
+      title={Big Transfer (BiT): General Visual Representation Learning}, 
+      author={Alexander Kolesnikov and Lucas Beyer and Xiaohua Zhai and Joan Puigcerver and Jessica Yung and Sylvain Gelly and Neil Houlsby},
+      year={2020},
+      eprint={1912.11370},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: resnetv2_152x4_bitm
+  Metadata:
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 3746270104
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_152x4_bitm
+    Crop Pct: '1.0'
+    Image Size: '480'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L465
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_152x2_bitm
+  Metadata:
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 945476668
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_152x2_bitm
+    Crop Pct: '1.0'
+    Image Size: '480'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L458
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_50x1_bitm
+  Metadata:
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 102242668
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_50x1_bitm
+    LR: 0.03
+    Layers: 50
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L430
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_101x3_bitm
+  Metadata:
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 1551830100
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_101x3_bitm
+    LR: 0.03
+    Layers: 101
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L451
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_50x3_bitm
+  Metadata:
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 869321580
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_50x3_bitm
+    LR: 0.03
+    Layers: 50
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L437
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_101x1_bitm
+  Metadata:
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 178256468
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_101x1_bitm
+    LR: 0.03
+    Layers: 101
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L444
+  Config: ''
+  In Collection: Big Transfer
+Collections:
+- Name: Big Transfer
+  Paper:
+    title: 'Big Transfer (BiT): General Visual Representation Learning'
+    url: https://papperswithcode.com//paper/large-scale-learning-of-general-visual
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/big-transfer.md
+++ b/modelindex/.templates/models/big-transfer.md
@@ -249,7 +249,7 @@ Collections:
 - Name: Big Transfer
   Paper:
     title: 'Big Transfer (BiT): General Visual Representation Learning'
-    url: https://papperswithcode.com//paper/large-scale-learning-of-general-visual
+    url: https://paperswithcode.com//paper/large-scale-learning-of-general-visual
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/csp-darknet.md
+++ b/modelindex/.templates/models/csp-darknet.md
@@ -24,22 +24,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: CSP DarkNet
+  Paper:
+    Title: 'YOLOv4: Optimal Speed and Accuracy of Object Detection'
+    URL: https://paperswithcode.com/paper/yolov4-optimal-speed-and-accuracy-of-object
 Models:
 - Name: cspdarknet53
+  In Collection: CSP DarkNet
   Metadata:
     FLOPs: 8545018880
-    Batch Size: 128
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - CutMix
-    - Label Smoothing
-    - Mosaic
-    - Polynomial Learning Rate Decay
-    - SGD with Momentum
-    - Self-Adversarial Training
-    - Weight Decay
-    Training Resources: 1x NVIDIA RTX 2070 GPU
+    Parameters: 27640000
+    File Size: 110775135
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -48,14 +45,25 @@ Models:
     - Mish
     - Residual Connection
     - Softmax
-    File Size: 110775135
     Tasks:
     - Image Classification
+    Training Techniques:
+    - CutMix
+    - Label Smoothing
+    - Mosaic
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Self-Adversarial Training
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 1x NVIDIA RTX 2070 GPU
     ID: cspdarknet53
     LR: 0.1
     Layers: 53
     Crop Pct: '0.887'
     Momentum: 0.9
+    Batch Size: 128
     Image Size: '256'
     Warmup Steps: 1000
     Weight Decay: 0.0005
@@ -63,12 +71,11 @@ Models:
     Training Steps: 8000000
     FPS (GPU RTX 2070): 66
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L441
-  In Collection: CSP DarkNet
-Collections:
-- Name: CSP DarkNet
-  Paper:
-    title: 'YOLOv4: Optimal Speed and Accuracy of Object Detection'
-    url: https://paperswithcode.com//paper/yolov4-optimal-speed-and-accuracy-of-object
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/cspdarknet53_ra_256-d05c7c21.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.05%
+      Top 5 Accuracy: 95.09%
 -->

--- a/modelindex/.templates/models/csp-darknet.md
+++ b/modelindex/.templates/models/csp-darknet.md
@@ -1,0 +1,74 @@
+# Summary
+
+**CSPDarknet53** is a convolutional neural network and backbone for object detection that uses [DarkNet-53](https://paperswithcode.com/method/darknet-53). It employs a CSPNet strategy to partition the feature map of the base layer into two parts and then merges them through a cross-stage hierarchy. The use of a split and merge strategy allows for more gradient flow through the network. 
+
+This CNN is used as the backbone for [YOLOv4](https://paperswithcode.com/method/yolov4).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{bochkovskiy2020yolov4,
+      title={YOLOv4: Optimal Speed and Accuracy of Object Detection}, 
+      author={Alexey Bochkovskiy and Chien-Yao Wang and Hong-Yuan Mark Liao},
+      year={2020},
+      eprint={2004.10934},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: cspdarknet53
+  Metadata:
+    FLOPs: 8545018880
+    Batch Size: 128
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - CutMix
+    - Label Smoothing
+    - Mosaic
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Self-Adversarial Training
+    - Weight Decay
+    Training Resources: 1x NVIDIA RTX 2070 GPU
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Mish
+    - Residual Connection
+    - Softmax
+    File Size: 110775135
+    Tasks:
+    - Image Classification
+    ID: cspdarknet53
+    LR: 0.1
+    Layers: 53
+    Crop Pct: '0.887'
+    Momentum: 0.9
+    Image Size: '256'
+    Warmup Steps: 1000
+    Weight Decay: 0.0005
+    Interpolation: bilinear
+    Training Steps: 8000000
+    FPS (GPU RTX 2070): 66
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L441
+  In Collection: CSP DarkNet
+Collections:
+- Name: CSP DarkNet
+  Paper:
+    title: 'YOLOv4: Optimal Speed and Accuracy of Object Detection'
+    url: https://papperswithcode.com//paper/yolov4-optimal-speed-and-accuracy-of-object
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/csp-darknet.md
+++ b/modelindex/.templates/models/csp-darknet.md
@@ -68,7 +68,7 @@ Collections:
 - Name: CSP DarkNet
   Paper:
     title: 'YOLOv4: Optimal Speed and Accuracy of Object Detection'
-    url: https://papperswithcode.com//paper/yolov4-optimal-speed-and-accuracy-of-object
+    url: https://paperswithcode.com//paper/yolov4-optimal-speed-and-accuracy-of-object
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/csp-resnet.md
+++ b/modelindex/.templates/models/csp-resnet.md
@@ -1,0 +1,72 @@
+# Summary
+
+**CSPResNet** is a convolutional neural network where we apply the Cross Stage Partial Network (CSPNet) approach to [ResNet](https://paperswithcode.com/method/resnet). The CSPNet partitions the feature map of the base layer into two parts and then merges them through a cross-stage hierarchy. The use of a split and merge strategy allows for more gradient flow through the network.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{wang2019cspnet,
+      title={CSPNet: A New Backbone that can Enhance Learning Capability of CNN}, 
+      author={Chien-Yao Wang and Hong-Yuan Mark Liao and I-Hau Yeh and Yueh-Hua Wu and Ping-Yang Chen and Jun-Wei Hsieh},
+      year={2019},
+      eprint={1911.11929},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: cspresnet50
+  Metadata:
+    FLOPs: 5924992000
+    Batch Size: 128
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 86679303
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: cspresnet50
+    LR: 0.1
+    Layers: 50
+    Crop Pct: '0.887'
+    Momentum: 0.9
+    Image Size: '256'
+    Weight Decay: 0.005
+    Interpolation: bilinear
+    Training Steps: 8000000
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L415
+  Config: ''
+  In Collection: CSP ResNet
+Collections:
+- Name: CSP ResNet
+  Paper:
+    title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
+    url: https://papperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/csp-resnet.md
+++ b/modelindex/.templates/models/csp-resnet.md
@@ -22,19 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: CSP ResNet
+  Paper:
+    Title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
+    URL: https://paperswithcode.com/paper/cspnet-a-new-backbone-that-can-enhance
 Models:
 - Name: cspresnet50
+  In Collection: CSP ResNet
   Metadata:
     FLOPs: 5924992000
-    Batch Size: 128
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Polynomial Learning Rate Decay
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 21620000
+    File Size: 86679303
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -46,27 +46,31 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 86679303
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: cspresnet50
     LR: 0.1
     Layers: 50
     Crop Pct: '0.887'
     Momentum: 0.9
+    Batch Size: 128
     Image Size: '256'
     Weight Decay: 0.005
     Interpolation: bilinear
     Training Steps: 8000000
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L415
-  Config: ''
-  In Collection: CSP ResNet
-Collections:
-- Name: CSP ResNet
-  Paper:
-    title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
-    url: https://paperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/cspresnet50_ra-d3e8d487.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.57%
+      Top 5 Accuracy: 94.71%
 -->

--- a/modelindex/.templates/models/csp-resnet.md
+++ b/modelindex/.templates/models/csp-resnet.md
@@ -66,7 +66,7 @@ Collections:
 - Name: CSP ResNet
   Paper:
     title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
-    url: https://papperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
+    url: https://paperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/csp-resnext.md
+++ b/modelindex/.templates/models/csp-resnext.md
@@ -66,7 +66,7 @@ Collections:
 - Name: CSP ResNeXt
   Paper:
     title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
-    url: https://papperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
+    url: https://paperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/csp-resnext.md
+++ b/modelindex/.templates/models/csp-resnext.md
@@ -1,0 +1,72 @@
+# Summary
+
+**CSPResNeXt** is a convolutional neural network where we apply the Cross Stage Partial Network (CSPNet) approach to [ResNeXt](https://paperswithcode.com/method/resnext). The CSPNet partitions the feature map of the base layer into two parts and then merges them through a cross-stage hierarchy. The use of a split and merge strategy allows for more gradient flow through the network.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{wang2019cspnet,
+      title={CSPNet: A New Backbone that can Enhance Learning Capability of CNN}, 
+      author={Chien-Yao Wang and Hong-Yuan Mark Liao and I-Hau Yeh and Yueh-Hua Wu and Ping-Yang Chen and Jun-Wei Hsieh},
+      year={2019},
+      eprint={1911.11929},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: cspresnext50
+  Metadata:
+    FLOPs: 3962945536
+    Batch Size: 128
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 1x GPU
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 82562887
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: cspresnext50
+    LR: 0.1
+    Layers: 50
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.005
+    Interpolation: bilinear
+    Training Steps: 8000000
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L430
+  Config: ''
+  In Collection: CSP ResNeXt
+Collections:
+- Name: CSP ResNeXt
+  Paper:
+    title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
+    url: https://papperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/csp-resnext.md
+++ b/modelindex/.templates/models/csp-resnext.md
@@ -22,19 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: CSP ResNeXt
+  Paper:
+    Title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
+    URL: https://paperswithcode.com/paper/cspnet-a-new-backbone-that-can-enhance
 Models:
 - Name: cspresnext50
+  In Collection: CSP ResNeXt
   Metadata:
     FLOPs: 3962945536
-    Batch Size: 128
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Polynomial Learning Rate Decay
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 1x GPU
+    Parameters: 20570000
+    File Size: 82562887
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -46,27 +46,32 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 82562887
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 1x GPU
     ID: cspresnext50
     LR: 0.1
     Layers: 50
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 128
     Image Size: '224'
     Weight Decay: 0.005
     Interpolation: bilinear
     Training Steps: 8000000
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L430
-  Config: ''
-  In Collection: CSP ResNeXt
-Collections:
-- Name: CSP ResNeXt
-  Paper:
-    title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
-    url: https://paperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/cspresnext50_ra_224-648b4713.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.05%
+      Top 5 Accuracy: 94.94%
 -->

--- a/modelindex/.templates/models/densenet.md
+++ b/modelindex/.templates/models/densenet.md
@@ -43,12 +43,195 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: DenseNet
+  Paper:
+    Title: Densely Connected Convolutional Networks
+    URL: https://paperswithcode.com/paper/densely-connected-convolutional-networks
 Models:
-- Name: densenetblur121d
+- Name: densenet121
+  In Collection: DenseNet
   Metadata:
-    FLOPs: 3947812864
+    FLOPs: 3641843200
+    Parameters: 7980000
+    File Size: 32376726
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
     Training Data:
     - ImageNet
+    ID: densenet121
+    LR: 0.1
+    Epochs: 90
+    Layers: 121
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L295
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/densenet121_ra-50efcf5c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.56%
+      Top 5 Accuracy: 92.65%
+- Name: densenet161
+  In Collection: DenseNet
+  Metadata:
+    FLOPs: 9931959264
+    Parameters: 28680000
+    File Size: 115730790
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: densenet161
+    LR: 0.1
+    Epochs: 90
+    Layers: 161
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L347
+  Weights: https://download.pytorch.org/models/densenet161-8d451a50.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.36%
+      Top 5 Accuracy: 93.63%
+- Name: densenet169
+  In Collection: DenseNet
+  Metadata:
+    FLOPs: 4316945792
+    Parameters: 14150000
+    File Size: 57365526
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: densenet169
+    LR: 0.1
+    Epochs: 90
+    Layers: 169
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L327
+  Weights: https://download.pytorch.org/models/densenet169-b2777c0a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.9%
+      Top 5 Accuracy: 93.02%
+- Name: densenet201
+  In Collection: DenseNet
+  Metadata:
+    FLOPs: 5514321024
+    Parameters: 20010000
+    File Size: 81131730
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: densenet201
+    LR: 0.1
+    Epochs: 90
+    Layers: 201
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L337
+  Weights: https://download.pytorch.org/models/densenet201-c1103571.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.29%
+      Top 5 Accuracy: 93.48%
+- Name: densenetblur121d
+  In Collection: DenseNet
+  Metadata:
+    FLOPs: 3947812864
+    Parameters: 8000000
+    File Size: 32456500
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -60,25 +243,28 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 32456500
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: densenetblur121d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L305
-  In Collection: DenseNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/densenetblur121d_ra-100dcfbc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.59%
+      Top 5 Accuracy: 93.2%
 - Name: tv_densenet121
+  In Collection: DenseNet
   Metadata:
     FLOPs: 3641843200
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    Parameters: 7980000
+    File Size: 32342954
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -90,172 +276,30 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 32342954
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tv_densenet121
     LR: 0.1
+    Epochs: 90
     Crop Pct: '0.875'
     LR Gamma: 0.1
     Momentum: 0.9
+    Batch Size: 32
     Image Size: '224'
     LR Step Size: 30
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L379
-  In Collection: DenseNet
-- Name: densenet121
-  Metadata:
-    FLOPs: 3641843200
-    Epochs: 90
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Kaiming Initialization
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: ''
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Block
-    - Dense Connections
-    - Dropout
-    - Max Pooling
-    - ReLU
-    - Softmax
-    File Size: 32376726
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: densenet121
-    LR: 0.1
-    Layers: 121
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L295
-  Config: ''
-  In Collection: DenseNet
-- Name: densenet201
-  Metadata:
-    FLOPs: 5514321024
-    Epochs: 90
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Kaiming Initialization
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Block
-    - Dense Connections
-    - Dropout
-    - Max Pooling
-    - ReLU
-    - Softmax
-    File Size: 81131730
-    Tasks:
-    - Image Classification
-    ID: densenet201
-    LR: 0.1
-    Layers: 201
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L337
-  In Collection: DenseNet
-- Name: densenet169
-  Metadata:
-    FLOPs: 4316945792
-    Epochs: 90
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Kaiming Initialization
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Block
-    - Dense Connections
-    - Dropout
-    - Max Pooling
-    - ReLU
-    - Softmax
-    File Size: 57365526
-    Tasks:
-    - Image Classification
-    ID: densenet169
-    LR: 0.1
-    Layers: 169
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L327
-  In Collection: DenseNet
-- Name: densenet161
-  Metadata:
-    FLOPs: 9931959264
-    Epochs: 90
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Kaiming Initialization
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Block
-    - Dense Connections
-    - Dropout
-    - Max Pooling
-    - ReLU
-    - Softmax
-    File Size: 115730790
-    Tasks:
-    - Image Classification
-    ID: densenet161
-    LR: 0.1
-    Layers: 161
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L347
-  In Collection: DenseNet
-Collections:
-- Name: DenseNet
-  Paper:
-    title: Densely Connected Convolutional Networks
-    url: https://paperswithcode.com//paper/densely-connected-convolutional-networks
-  type: model-index
-Type: model-index
+  Weights: https://download.pytorch.org/models/densenet121-a639ec97.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.74%
+      Top 5 Accuracy: 92.15%
 -->

--- a/modelindex/.templates/models/densenet.md
+++ b/modelindex/.templates/models/densenet.md
@@ -1,0 +1,261 @@
+# Summary
+
+**DenseNet** is a type of convolutional neural network that utilises dense connections between layers, through [Dense Blocks](http://www.paperswithcode.com/method/dense-block), where we connect *all layers* (with matching feature-map sizes) directly with each other. To preserve the feed-forward nature, each layer obtains additional inputs from all preceding layers and passes on its own feature-maps to all subsequent layers.
+
+The **DenseNet Blur** variant in this collection by Ross Wightman employs [Blur Pooling](http://www.paperswithcode.com/method/blur-pooling)
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/HuangLW16a,
+  author    = {Gao Huang and
+               Zhuang Liu and
+               Kilian Q. Weinberger},
+  title     = {Densely Connected Convolutional Networks},
+  journal   = {CoRR},
+  volume    = {abs/1608.06993},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1608.06993},
+  archivePrefix = {arXiv},
+  eprint    = {1608.06993},
+  timestamp = {Mon, 10 Sep 2018 15:49:32 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/HuangLW16a.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+```
+@misc{rw2019timm,
+  author = {Ross Wightman},
+  title = {PyTorch Image Models},
+  year = {2019},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  doi = {10.5281/zenodo.4414861},
+  howpublished = {\url{https://github.com/rwightman/pytorch-image-models}}
+}
+```
+
+<!--
+Models:
+- Name: densenetblur121d
+  Metadata:
+    FLOPs: 3947812864
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Blur Pooling
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 32456500
+    Tasks:
+    - Image Classification
+    ID: densenetblur121d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L305
+  In Collection: DenseNet
+- Name: tv_densenet121
+  Metadata:
+    FLOPs: 3641843200
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 32342954
+    Tasks:
+    - Image Classification
+    ID: tv_densenet121
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L379
+  In Collection: DenseNet
+- Name: densenet121
+  Metadata:
+    FLOPs: 3641843200
+    Epochs: 90
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 32376726
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: densenet121
+    LR: 0.1
+    Layers: 121
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L295
+  Config: ''
+  In Collection: DenseNet
+- Name: densenet201
+  Metadata:
+    FLOPs: 5514321024
+    Epochs: 90
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 81131730
+    Tasks:
+    - Image Classification
+    ID: densenet201
+    LR: 0.1
+    Layers: 201
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L337
+  In Collection: DenseNet
+- Name: densenet169
+  Metadata:
+    FLOPs: 4316945792
+    Epochs: 90
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 57365526
+    Tasks:
+    - Image Classification
+    ID: densenet169
+    LR: 0.1
+    Layers: 169
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L327
+  In Collection: DenseNet
+- Name: densenet161
+  Metadata:
+    FLOPs: 9931959264
+    Epochs: 90
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 115730790
+    Tasks:
+    - Image Classification
+    ID: densenet161
+    LR: 0.1
+    Layers: 161
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L347
+  In Collection: DenseNet
+Collections:
+- Name: DenseNet
+  Paper:
+    title: Densely Connected Convolutional Networks
+    url: https://papperswithcode.com//paper/densely-connected-convolutional-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/densenet.md
+++ b/modelindex/.templates/models/densenet.md
@@ -255,7 +255,7 @@ Collections:
 - Name: DenseNet
   Paper:
     title: Densely Connected Convolutional Networks
-    url: https://papperswithcode.com//paper/densely-connected-convolutional-networks
+    url: https://paperswithcode.com//paper/densely-connected-convolutional-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/dla.md
+++ b/modelindex/.templates/models/dla.md
@@ -1,0 +1,482 @@
+# Summary
+
+Extending  “shallow” skip connections, **Dense Layer Aggregation (DLA)** incorporates more depth and sharing. The authors introduce two structures for deep layer aggregation (DLA): iterative deep aggregation (IDA) and hierarchical deep aggregation (HDA). These structures are expressed through an architectural framework, independent of the choice of backbone, for compatibility with current and future networks. 
+
+IDA focuses on fusing resolutions and scales while HDA focuses on merging features from all modules and channels. IDA follows the base hierarchy to refine resolution and aggregate scale stage-bystage. HDA assembles its own hierarchy of tree-structured connections that cross and merge stages to aggregate different levels of representation. 
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{yu2019deep,
+      title={Deep Layer Aggregation}, 
+      author={Fisher Yu and Dequan Wang and Evan Shelhamer and Trevor Darrell},
+      year={2019},
+      eprint={1707.06484},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: dla60
+  Metadata:
+    FLOPs: 4256251880
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 89560235
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60
+    LR: 0.1
+    Layers: 60
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L394
+  Config: ''
+  In Collection: DLA
+- Name: dla46_c
+  Metadata:
+    FLOPs: 583277288
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 5307963
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla46_c
+    LR: 0.1
+    Layers: 46
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L369
+  Config: ''
+  In Collection: DLA
+- Name: dla102x2
+  Metadata:
+    FLOPs: 9343847400
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 167645295
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla102x2
+    LR: 0.1
+    Layers: 102
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L426
+  Config: ''
+  In Collection: DLA
+- Name: dla102
+  Metadata:
+    FLOPs: 7192952808
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 135290579
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla102
+    LR: 0.1
+    Layers: 102
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L410
+  Config: ''
+  In Collection: DLA
+- Name: dla102x
+  Metadata:
+    FLOPs: 5886821352
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 107552695
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla102x
+    LR: 0.1
+    Layers: 102
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L418
+  Config: ''
+  In Collection: DLA
+- Name: dla169
+  Metadata:
+    FLOPs: 11598004200
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 216547113
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla169
+    LR: 0.1
+    Layers: 169
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L434
+  Config: ''
+  In Collection: DLA
+- Name: dla46x_c
+  Metadata:
+    FLOPs: 544052200
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 4387641
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla46x_c
+    LR: 0.1
+    Layers: 46
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L378
+  Config: ''
+  In Collection: DLA
+- Name: dla60_res2net
+  Metadata:
+    FLOPs: 4147578504
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 84886593
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60_res2net
+    Layers: 60
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L346
+  Config: ''
+  In Collection: DLA
+- Name: dla60_res2next
+  Metadata:
+    FLOPs: 3485335272
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 69639245
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60_res2next
+    Layers: 60
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L354
+  Config: ''
+  In Collection: DLA
+- Name: dla34
+  Metadata:
+    FLOPs: 3070105576
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 63228658
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla34
+    LR: 0.1
+    Layers: 32
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L362
+  Config: ''
+  In Collection: DLA
+- Name: dla60x
+  Metadata:
+    FLOPs: 3544204264
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 70883139
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60x
+    LR: 0.1
+    Layers: 60
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L402
+  Config: ''
+  In Collection: DLA
+- Name: dla60x_c
+  Metadata:
+    FLOPs: 593325032
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 5454396
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60x_c
+    LR: 0.1
+    Layers: 60
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L386
+  Config: ''
+  In Collection: DLA
+Collections:
+- Name: DLA
+  Paper:
+    title: Deep Layer Aggregation
+    url: https://papperswithcode.com//paper/deep-layer-aggregation
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/dla.md
+++ b/modelindex/.templates/models/dla.md
@@ -24,133 +24,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: DLA
+  Paper:
+    Title: Deep Layer Aggregation
+    URL: https://paperswithcode.com/paper/deep-layer-aggregation
 Models:
-- Name: dla60
-  Metadata:
-    FLOPs: 4256251880
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - DLA Bottleneck Residual Block
-    - DLA Residual Block
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 89560235
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: dla60
-    LR: 0.1
-    Layers: 60
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L394
-  Config: ''
-  In Collection: DLA
-- Name: dla46_c
-  Metadata:
-    FLOPs: 583277288
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - DLA Bottleneck Residual Block
-    - DLA Residual Block
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 5307963
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: dla46_c
-    LR: 0.1
-    Layers: 46
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L369
-  Config: ''
-  In Collection: DLA
-- Name: dla102x2
-  Metadata:
-    FLOPs: 9343847400
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - DLA Bottleneck Residual Block
-    - DLA Residual Block
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 167645295
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: dla102x2
-    LR: 0.1
-    Layers: 102
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L426
-  Config: ''
-  In Collection: DLA
 - Name: dla102
+  In Collection: DLA
   Metadata:
     FLOPs: 7192952808
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 33270000
+    File Size: 135290579
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -163,32 +49,38 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 135290579
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: dla102
     LR: 0.1
+    Epochs: 120
     Layers: 102
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L410
-  Config: ''
-  In Collection: DLA
+  Weights: http://dl.yf.io/dla/models/imagenet/dla102-d94d9790.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.03%
+      Top 5 Accuracy: 93.95%
 - Name: dla102x
+  In Collection: DLA
   Metadata:
     FLOPs: 5886821352
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 26310000
+    File Size: 107552695
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -201,32 +93,38 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 107552695
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: dla102x
     LR: 0.1
+    Epochs: 120
     Layers: 102
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L418
-  Config: ''
+  Weights: http://dl.yf.io/dla/models/imagenet/dla102x-ad62be81.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.51%
+      Top 5 Accuracy: 94.23%
+- Name: dla102x2
   In Collection: DLA
-- Name: dla169
   Metadata:
-    FLOPs: 11598004200
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    FLOPs: 9343847400
+    Parameters: 41280000
+    File Size: 167645295
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -239,32 +137,82 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 216547113
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
+    ID: dla102x2
+    LR: 0.1
+    Epochs: 120
+    Layers: 102
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L426
+  Weights: http://dl.yf.io/dla/models/imagenet/dla102x2-262837b6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.44%
+      Top 5 Accuracy: 94.65%
+- Name: dla169
+  In Collection: DLA
+  Metadata:
+    FLOPs: 11598004200
+    Parameters: 53390000
+    File Size: 216547113
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: dla169
     LR: 0.1
+    Epochs: 120
     Layers: 169
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L434
-  Config: ''
+  Weights: http://dl.yf.io/dla/models/imagenet/dla169-0914e092.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.69%
+      Top 5 Accuracy: 94.33%
+- Name: dla34
   In Collection: DLA
-- Name: dla46x_c
   Metadata:
-    FLOPs: 544052200
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    FLOPs: 3070105576
+    Parameters: 15740000
+    File Size: 63228658
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -277,30 +225,123 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 4387641
     Tasks:
     - Image Classification
-    Training Time: ''
-    ID: dla46x_c
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: dla34
     LR: 0.1
+    Epochs: 120
+    Layers: 32
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L362
+  Weights: http://dl.yf.io/dla/models/imagenet/dla34-ba72cf86.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.62%
+      Top 5 Accuracy: 92.06%
+- Name: dla46_c
+  In Collection: DLA
+  Metadata:
+    FLOPs: 583277288
+    Parameters: 1300000
+    File Size: 5307963
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: dla46_c
+    LR: 0.1
+    Epochs: 120
     Layers: 46
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L369
+  Weights: http://dl.yf.io/dla/models/imagenet/dla46_c-2bfd52c3.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 64.87%
+      Top 5 Accuracy: 86.29%
+- Name: dla46x_c
+  In Collection: DLA
+  Metadata:
+    FLOPs: 544052200
+    Parameters: 1070000
+    File Size: 4387641
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: dla46x_c
+    LR: 0.1
+    Epochs: 120
+    Layers: 46
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L378
-  Config: ''
+  Weights: http://dl.yf.io/dla/models/imagenet/dla46x_c-d761bae7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 65.98%
+      Top 5 Accuracy: 86.99%
+- Name: dla60
   In Collection: DLA
-- Name: dla60_res2net
   Metadata:
-    FLOPs: 4147578504
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    FLOPs: 4256251880
+    Parameters: 22040000
+    File Size: 89560235
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -313,27 +354,76 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 84886593
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: dla60
+    LR: 0.1
+    Epochs: 120
+    Layers: 60
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L394
+  Weights: http://dl.yf.io/dla/models/imagenet/dla60-24839fc4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.04%
+      Top 5 Accuracy: 93.32%
+- Name: dla60_res2net
+  In Collection: DLA
+  Metadata:
+    FLOPs: 4147578504
+    Parameters: 20850000
+    File Size: 84886593
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: dla60_res2net
     Layers: 60
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L346
-  Config: ''
-  In Collection: DLA
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net_dla60_4s-d88db7f9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.46%
+      Top 5 Accuracy: 94.21%
 - Name: dla60_res2next
+  In Collection: DLA
   Metadata:
     FLOPs: 3485335272
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 17030000
+    File Size: 69639245
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -346,67 +436,32 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 69639245
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: dla60_res2next
     Layers: 60
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L354
-  Config: ''
-  In Collection: DLA
-- Name: dla34
-  Metadata:
-    FLOPs: 3070105576
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - DLA Bottleneck Residual Block
-    - DLA Residual Block
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 63228658
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: dla34
-    LR: 0.1
-    Layers: 32
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L362
-  Config: ''
-  In Collection: DLA
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2next_dla60_4s-d327927b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.44%
+      Top 5 Accuracy: 94.16%
 - Name: dla60x
+  In Collection: DLA
   Metadata:
     FLOPs: 3544204264
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 17350000
+    File Size: 70883139
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -419,32 +474,37 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 70883139
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: dla60x
     LR: 0.1
+    Epochs: 120
     Layers: 60
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L402
-  Config: ''
-  In Collection: DLA
+  Weights: http://dl.yf.io/dla/models/imagenet/dla60x-d15cacda.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.25%
+      Top 5 Accuracy: 94.02%
 - Name: dla60x_c
+  In Collection: DLA
   Metadata:
     FLOPs: 593325032
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 1320000
+    File Size: 5454396
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -457,26 +517,29 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 5454396
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: dla60x_c
     LR: 0.1
+    Epochs: 120
     Layers: 60
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L386
-  Config: ''
-  In Collection: DLA
-Collections:
-- Name: DLA
-  Paper:
-    title: Deep Layer Aggregation
-    url: https://paperswithcode.com//paper/deep-layer-aggregation
-  type: model-index
-Type: model-index
+  Weights: http://dl.yf.io/dla/models/imagenet/dla60x_c-b870c45c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 67.91%
+      Top 5 Accuracy: 88.42%
 -->

--- a/modelindex/.templates/models/dla.md
+++ b/modelindex/.templates/models/dla.md
@@ -476,7 +476,7 @@ Collections:
 - Name: DLA
   Paper:
     title: Deep Layer Aggregation
-    url: https://papperswithcode.com//paper/deep-layer-aggregation
+    url: https://paperswithcode.com//paper/deep-layer-aggregation
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/dpn.md
+++ b/modelindex/.templates/models/dpn.md
@@ -1,0 +1,209 @@
+# Summary
+
+A **Dual Path Network (DPN)** is a convolutional neural network which presents a new topology of connection paths internally. The intuition is that [ResNets](https://paperswithcode.com/method/resnet) enables feature re-usage while DenseNet enables new feature exploration, and both are important for learning good representations. To enjoy the benefits from both path topologies, Dual Path Networks share common features while maintaining the flexibility to explore new features through dual path architectures. 
+
+The principal building block is an [DPN Block](https://paperswithcode.com/method/dpn-block).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{chen2017dual,
+      title={Dual Path Networks}, 
+      author={Yunpeng Chen and Jianan Li and Huaxin Xiao and Xiaojie Jin and Shuicheng Yan and Jiashi Feng},
+      year={2017},
+      eprint={1707.01629},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: dpn68
+  Metadata:
+    FLOPs: 2990567880
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 50761994
+    Tasks:
+    - Image Classification
+    ID: dpn68
+    LR: 0.316
+    Layers: 68
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L270
+  In Collection: DPN
+- Name: dpn68b
+  Metadata:
+    FLOPs: 2990567880
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 50781025
+    Tasks:
+    - Image Classification
+    ID: dpn68b
+    LR: 0.316
+    Layers: 68
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L278
+  In Collection: DPN
+- Name: dpn92
+  Metadata:
+    FLOPs: 8357659624
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 151248422
+    Tasks:
+    - Image Classification
+    ID: dpn92
+    LR: 0.316
+    Layers: 92
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L286
+  In Collection: DPN
+- Name: dpn131
+  Metadata:
+    FLOPs: 20586274792
+    Batch Size: 960
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 318016207
+    Tasks:
+    - Image Classification
+    ID: dpn131
+    LR: 0.316
+    Layers: 131
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L302
+  In Collection: DPN
+- Name: dpn107
+  Metadata:
+    FLOPs: 23524280296
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 348612331
+    Tasks:
+    - Image Classification
+    ID: dpn107
+    LR: 0.316
+    Layers: 107
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L310
+  In Collection: DPN
+- Name: dpn98
+  Metadata:
+    FLOPs: 15003675112
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 247021307
+    Tasks:
+    - Image Classification
+    ID: dpn98
+    LR: 0.4
+    Layers: 98
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L294
+  In Collection: DPN
+Collections:
+- Name: DPN
+  Paper:
+    title: Dual Path Networks
+    url: https://papperswithcode.com//paper/dual-path-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/dpn.md
+++ b/modelindex/.templates/models/dpn.md
@@ -24,133 +24,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: DPN
+  Paper:
+    Title: Dual Path Networks
+    URL: https://paperswithcode.com/paper/dual-path-networks
 Models:
-- Name: dpn68
-  Metadata:
-    FLOPs: 2990567880
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - DPN Block
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - Softmax
-    File Size: 50761994
-    Tasks:
-    - Image Classification
-    ID: dpn68
-    LR: 0.316
-    Layers: 68
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L270
-  In Collection: DPN
-- Name: dpn68b
-  Metadata:
-    FLOPs: 2990567880
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - DPN Block
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - Softmax
-    File Size: 50781025
-    Tasks:
-    - Image Classification
-    ID: dpn68b
-    LR: 0.316
-    Layers: 68
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L278
-  In Collection: DPN
-- Name: dpn92
-  Metadata:
-    FLOPs: 8357659624
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - DPN Block
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - Softmax
-    File Size: 151248422
-    Tasks:
-    - Image Classification
-    ID: dpn92
-    LR: 0.316
-    Layers: 92
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L286
-  In Collection: DPN
-- Name: dpn131
-  Metadata:
-    FLOPs: 20586274792
-    Batch Size: 960
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - DPN Block
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - Softmax
-    File Size: 318016207
-    Tasks:
-    - Image Classification
-    ID: dpn131
-    LR: 0.316
-    Layers: 131
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L302
-  In Collection: DPN
 - Name: dpn107
+  In Collection: DPN
   Metadata:
     FLOPs: 23524280296
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
+    Parameters: 86920000
+    File Size: 348612331
     Architecture:
     - Batch Normalization
     - Convolution
@@ -159,27 +45,35 @@ Models:
     - Global Average Pooling
     - Max Pooling
     - Softmax
-    File Size: 348612331
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
     ID: dpn107
     LR: 0.316
     Layers: 107
     Crop Pct: '0.875'
+    Batch Size: 1280
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L310
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn107_extra-1ac7121e2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.16%
+      Top 5 Accuracy: 94.91%
+- Name: dpn131
   In Collection: DPN
-- Name: dpn98
   Metadata:
-    FLOPs: 15003675112
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
+    FLOPs: 20586274792
+    Parameters: 79250000
+    File Size: 318016207
     Architecture:
     - Batch Normalization
     - Convolution
@@ -188,22 +82,175 @@ Models:
     - Global Average Pooling
     - Max Pooling
     - Softmax
-    File Size: 247021307
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
+    ID: dpn131
+    LR: 0.316
+    Layers: 131
+    Crop Pct: '0.875'
+    Batch Size: 960
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L302
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn131-71dfe43e0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.83%
+      Top 5 Accuracy: 94.71%
+- Name: dpn68
+  In Collection: DPN
+  Metadata:
+    FLOPs: 2990567880
+    Parameters: 12610000
+    File Size: 50761994
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
+    ID: dpn68
+    LR: 0.316
+    Layers: 68
+    Crop Pct: '0.875'
+    Batch Size: 1280
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L270
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn68-66bebafa7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.31%
+      Top 5 Accuracy: 92.97%
+- Name: dpn68b
+  In Collection: DPN
+  Metadata:
+    FLOPs: 2990567880
+    Parameters: 12610000
+    File Size: 50781025
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
+    ID: dpn68b
+    LR: 0.316
+    Layers: 68
+    Crop Pct: '0.875'
+    Batch Size: 1280
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L278
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/dpn68b_ra-a31ca160.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.21%
+      Top 5 Accuracy: 94.42%
+- Name: dpn92
+  In Collection: DPN
+  Metadata:
+    FLOPs: 8357659624
+    Parameters: 37670000
+    File Size: 151248422
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
+    ID: dpn92
+    LR: 0.316
+    Layers: 92
+    Crop Pct: '0.875'
+    Batch Size: 1280
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L286
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn92_extra-b040e4a9b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.99%
+      Top 5 Accuracy: 94.84%
+- Name: dpn98
+  In Collection: DPN
+  Metadata:
+    FLOPs: 15003675112
+    Parameters: 61570000
+    File Size: 247021307
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
     ID: dpn98
     LR: 0.4
     Layers: 98
     Crop Pct: '0.875'
+    Batch Size: 1280
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L294
-  In Collection: DPN
-Collections:
-- Name: DPN
-  Paper:
-    title: Dual Path Networks
-    url: https://paperswithcode.com//paper/dual-path-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn98-5b90dec4d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.65%
+      Top 5 Accuracy: 94.61%
 -->

--- a/modelindex/.templates/models/dpn.md
+++ b/modelindex/.templates/models/dpn.md
@@ -203,7 +203,7 @@ Collections:
 - Name: DPN
   Paper:
     title: Dual Path Networks
-    url: https://papperswithcode.com//paper/dual-path-networks
+    url: https://paperswithcode.com//paper/dual-path-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/ecaresnet.md
+++ b/modelindex/.templates/models/ecaresnet.md
@@ -22,18 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ECAResNet
+  Paper:
+    Title: 'ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks'
+    URL: https://paperswithcode.com/paper/eca-net-efficient-channel-attention-for-deep
 Models:
 - Name: ecaresnet101d
+  In Collection: ECAResNet
   Metadata:
     FLOPs: 10377193728
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x RTX 2080Ti GPUs
+    Parameters: 44570000
+    File Size: 178815067
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -47,27 +48,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 178815067
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x RTX 2080Ti GPUs
     ID: ecaresnet101d
     LR: 0.1
+    Epochs: 100
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1087
-  In Collection: ECAResNet
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45402/outputs/ECAResNet101D_281c5844.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.18%
+      Top 5 Accuracy: 96.06%
 - Name: ecaresnet101d_pruned
+  In Collection: ECAResNet
   Metadata:
     FLOPs: 4463972081
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 24880000
+    File Size: 99852736
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -81,26 +92,32 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 99852736
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: ecaresnet101d_pruned
     Layers: 101
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1097
-  Config: ''
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45610/outputs/ECAResNet101D_P_75a3370e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.82%
+      Top 5 Accuracy: 95.64%
+- Name: ecaresnet50d
   In Collection: ECAResNet
-- Name: ecaresnet50d_pruned
   Metadata:
-    FLOPs: 3250730657
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    FLOPs: 5591090432
+    Parameters: 25580000
+    File Size: 102579290
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -114,60 +131,76 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 79990436
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x RTX 2080Ti GPUs
+    ID: ecaresnet50d
+    LR: 0.1
+    Epochs: 100
+    Layers: 50
+    Crop Pct: '0.875'
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1045
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45402/outputs/ECAResNet50D_833caf58.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.61%
+      Top 5 Accuracy: 95.31%
+- Name: ecaresnet50d_pruned
+  In Collection: ECAResNet
+  Metadata:
+    FLOPs: 3250730657
+    Parameters: 19940000
+    File Size: 79990436
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: ecaresnet50d_pruned
     Layers: 50
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1055
-  In Collection: ECAResNet
-- Name: ecaresnet50d
-  Metadata:
-    FLOPs: 5591090432
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x RTX 2080Ti GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Efficient Channel Attention
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    - Squeeze-and-Excitation Block
-    File Size: 102579290
-    Tasks:
-    - Image Classification
-    ID: ecaresnet50d
-    LR: 0.1
-    Layers: 50
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1045
-  In Collection: ECAResNet
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45899/outputs/ECAResNet50D_P_9c67f710.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.71%
+      Top 5 Accuracy: 94.88%
 - Name: ecaresnetlight
+  In Collection: ECAResNet
   Metadata:
     FLOPs: 5276118784
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    Parameters: 30160000
+    File Size: 120956612
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -181,20 +214,23 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 120956612
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: ecaresnetlight
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1077
-  In Collection: ECAResNet
-Collections:
-- Name: ECAResNet
-  Paper:
-    title: 'ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks'
-    url: https://paperswithcode.com//paper/eca-net-efficient-channel-attention-for-deep
-  type: model-index
-Type: model-index
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45402/outputs/ECAResNetLight_4f34b35b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.46%
+      Top 5 Accuracy: 95.25%
 -->

--- a/modelindex/.templates/models/ecaresnet.md
+++ b/modelindex/.templates/models/ecaresnet.md
@@ -194,7 +194,7 @@ Collections:
 - Name: ECAResNet
   Paper:
     title: 'ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks'
-    url: https://papperswithcode.com//paper/eca-net-efficient-channel-attention-for-deep
+    url: https://paperswithcode.com//paper/eca-net-efficient-channel-attention-for-deep
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/ecaresnet.md
+++ b/modelindex/.templates/models/ecaresnet.md
@@ -1,0 +1,200 @@
+# Summary
+
+An **ECA ResNet** is a variant on a [ResNet](https://paperswithcode.com/method/resnet) that utilises an [Efficient Channel Attention module](https://paperswithcode.com/method/efficient-channel-attention). Efficient Channel Attention is an architectural unit based on [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) that reduces model complexity without dimensionality reduction. 
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{wang2020ecanet,
+      title={ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks}, 
+      author={Qilong Wang and Banggu Wu and Pengfei Zhu and Peihua Li and Wangmeng Zuo and Qinghua Hu},
+      year={2020},
+      eprint={1910.03151},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: ecaresnet101d
+  Metadata:
+    FLOPs: 10377193728
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x RTX 2080Ti GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 178815067
+    Tasks:
+    - Image Classification
+    ID: ecaresnet101d
+    LR: 0.1
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1087
+  In Collection: ECAResNet
+- Name: ecaresnet101d_pruned
+  Metadata:
+    FLOPs: 4463972081
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 99852736
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: ecaresnet101d_pruned
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1097
+  Config: ''
+  In Collection: ECAResNet
+- Name: ecaresnet50d_pruned
+  Metadata:
+    FLOPs: 3250730657
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 79990436
+    Tasks:
+    - Image Classification
+    ID: ecaresnet50d_pruned
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1055
+  In Collection: ECAResNet
+- Name: ecaresnet50d
+  Metadata:
+    FLOPs: 5591090432
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x RTX 2080Ti GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 102579290
+    Tasks:
+    - Image Classification
+    ID: ecaresnet50d
+    LR: 0.1
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1045
+  In Collection: ECAResNet
+- Name: ecaresnetlight
+  Metadata:
+    FLOPs: 5276118784
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 120956612
+    Tasks:
+    - Image Classification
+    ID: ecaresnetlight
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1077
+  In Collection: ECAResNet
+Collections:
+- Name: ECAResNet
+  Paper:
+    title: 'ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks'
+    url: https://papperswithcode.com//paper/eca-net-efficient-channel-attention-for-deep
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/efficientnet-pruned.md
+++ b/modelindex/.templates/models/efficientnet-pruned.md
@@ -117,7 +117,7 @@ Collections:
 - Name: EfficientNet Pruned
   Paper:
     title: Knapsack Pruning with Inner Distillation
-    url: https://papperswithcode.com//paper/knapsack-pruning-with-inner-distillation
+    url: https://paperswithcode.com//paper/knapsack-pruning-with-inner-distillation
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/efficientnet-pruned.md
+++ b/modelindex/.templates/models/efficientnet-pruned.md
@@ -40,12 +40,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: EfficientNet Pruned
+  Paper:
+    Title: Knapsack Pruning with Inner Distillation
+    URL: https://paperswithcode.com/paper/knapsack-pruning-with-inner-distillation
 Models:
 - Name: efficientnet_b1_pruned
+  In Collection: EfficientNet Pruned
   Metadata:
     FLOPs: 489653114
-    Training Data:
-    - ImageNet
+    Parameters: 6330000
+    File Size: 25595162
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -56,44 +63,28 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 25595162
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b1_pruned
     Crop Pct: '0.882'
     Image Size: '240'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1208
-  In Collection: EfficientNet Pruned
-- Name: efficientnet_b3_pruned
-  Metadata:
-    FLOPs: 1239590641
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 39770812
-    Tasks:
-    - Image Classification
-    ID: efficientnet_b3_pruned
-    Crop Pct: '0.904'
-    Image Size: '300'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1230
-  In Collection: EfficientNet Pruned
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45403/outputs/effnetb1_pruned_9ebb3fe6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.25%
+      Top 5 Accuracy: 93.84%
 - Name: efficientnet_b2_pruned
+  In Collection: EfficientNet Pruned
   Metadata:
     FLOPs: 878133915
-    Training Data:
-    - ImageNet
+    Parameters: 8310000
+    File Size: 33555005
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -104,20 +95,52 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 33555005
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b2_pruned
     Crop Pct: '0.89'
     Image Size: '260'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1219
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45403/outputs/effnetb2_pruned_203f55bc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.91%
+      Top 5 Accuracy: 94.86%
+- Name: efficientnet_b3_pruned
   In Collection: EfficientNet Pruned
-Collections:
-- Name: EfficientNet Pruned
-  Paper:
-    title: Knapsack Pruning with Inner Distillation
-    url: https://paperswithcode.com//paper/knapsack-pruning-with-inner-distillation
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 1239590641
+    Parameters: 9860000
+    File Size: 39770812
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_b3_pruned
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1230
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45403/outputs/effnetb3_pruned_5abcc29f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.86%
+      Top 5 Accuracy: 95.24%
 -->

--- a/modelindex/.templates/models/efficientnet-pruned.md
+++ b/modelindex/.templates/models/efficientnet-pruned.md
@@ -1,0 +1,123 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2), in addition to [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+This collection consists of pruned EfficientNet models.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2020efficientnet,
+      title={EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2020},
+      eprint={1905.11946},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+```
+@misc{rw2019timm,
+  author = {Ross Wightman},
+  title = {PyTorch Image Models},
+  year = {2019},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  doi = {10.5281/zenodo.4414861},
+  howpublished = {\url{https://github.com/rwightman/pytorch-image-models}}
+}
+```
+
+<!--
+Models:
+- Name: efficientnet_b1_pruned
+  Metadata:
+    FLOPs: 489653114
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 25595162
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b1_pruned
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1208
+  In Collection: EfficientNet Pruned
+- Name: efficientnet_b3_pruned
+  Metadata:
+    FLOPs: 1239590641
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 39770812
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b3_pruned
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1230
+  In Collection: EfficientNet Pruned
+- Name: efficientnet_b2_pruned
+  Metadata:
+    FLOPs: 878133915
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 33555005
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b2_pruned
+    Crop Pct: '0.89'
+    Image Size: '260'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1219
+  In Collection: EfficientNet Pruned
+Collections:
+- Name: EfficientNet Pruned
+  Paper:
+    title: Knapsack Pruning with Inner Distillation
+    url: https://papperswithcode.com//paper/knapsack-pruning-with-inner-distillation
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/efficientnet.md
+++ b/modelindex/.templates/models/efficientnet.md
@@ -248,7 +248,7 @@ Collections:
 - Name: EfficientNet
   Paper:
     title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/efficientnet.md
+++ b/modelindex/.templates/models/efficientnet.md
@@ -26,156 +26,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: EfficientNet
+  Paper:
+    Title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    URL: https://paperswithcode.com/paper/efficientnet-rethinking-model-scaling-for
 Models:
-- Name: efficientnet_b2a
-  Metadata:
-    FLOPs: 1452041554
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49369973
-    Tasks:
-    - Image Classification
-    ID: efficientnet_b2a
-    Crop Pct: '1.0'
-    Image Size: '288'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1029
-  In Collection: EfficientNet
-- Name: efficientnet_b3a
-  Metadata:
-    FLOPs: 2600628304
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49369973
-    Tasks:
-    - Image Classification
-    ID: efficientnet_b3a
-    Crop Pct: '1.0'
-    Image Size: '320'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1047
-  In Collection: EfficientNet
-- Name: efficientnet_em
-  Metadata:
-    FLOPs: 3935516480
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 27927309
-    Tasks:
-    - Image Classification
-    ID: efficientnet_em
-    Crop Pct: '0.882'
-    Image Size: '240'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1118
-  In Collection: EfficientNet
-- Name: efficientnet_lite0
-  Metadata:
-    FLOPs: 510605024
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 18820005
-    Tasks:
-    - Image Classification
-    ID: efficientnet_lite0
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1163
-  In Collection: EfficientNet
-- Name: efficientnet_es
-  Metadata:
-    FLOPs: 2317181824
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 22003339
-    Tasks:
-    - Image Classification
-    ID: efficientnet_es
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1110
-  In Collection: EfficientNet
-- Name: efficientnet_b3
-  Metadata:
-    FLOPs: 2327905920
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49369973
-    Tasks:
-    - Image Classification
-    ID: efficientnet_b3
-    Crop Pct: '0.904'
-    Image Size: '300'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1038
-  In Collection: EfficientNet
 - Name: efficientnet_b0
+  In Collection: EfficientNet
   Metadata:
     FLOPs: 511241564
-    Training Data:
-    - ImageNet
+    Parameters: 5290000
+    File Size: 21376743
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -186,21 +49,29 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 21376743
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b0
     Layers: 18
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1002
-  In Collection: EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b0_ra-3dd342df.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.71%
+      Top 5 Accuracy: 93.52%
 - Name: efficientnet_b1
+  In Collection: EfficientNet
   Metadata:
     FLOPs: 909691920
-    Training Data:
-    - ImageNet
+    Parameters: 7790000
+    File Size: 31502706
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -211,20 +82,28 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 31502706
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b1
     Crop Pct: '0.875'
     Image Size: '240'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1011
-  In Collection: EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b1-533bc792.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.71%
+      Top 5 Accuracy: 94.15%
 - Name: efficientnet_b2
+  In Collection: EfficientNet
   Metadata:
     FLOPs: 1265324514
-    Training Data:
-    - ImageNet
+    Parameters: 9110000
+    File Size: 36788104
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -235,20 +114,212 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 36788104
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b2
     Crop Pct: '0.875'
     Image Size: '260'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1020
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b2_ra-bcdf34b7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.38%
+      Top 5 Accuracy: 95.08%
+- Name: efficientnet_b2a
   In Collection: EfficientNet
-Collections:
-- Name: EfficientNet
-  Paper:
-    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 1452041554
+    Parameters: 9110000
+    File Size: 49369973
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_b2a
+    Crop Pct: '1.0'
+    Image Size: '288'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1029
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b3_ra2-cf984f9c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.61%
+      Top 5 Accuracy: 95.32%
+- Name: efficientnet_b3
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 2327905920
+    Parameters: 12230000
+    File Size: 49369973
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_b3
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1038
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b3_ra2-cf984f9c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.08%
+      Top 5 Accuracy: 96.03%
+- Name: efficientnet_b3a
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 2600628304
+    Parameters: 12230000
+    File Size: 49369973
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_b3a
+    Crop Pct: '1.0'
+    Image Size: '320'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1047
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b3_ra2-cf984f9c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.25%
+      Top 5 Accuracy: 96.11%
+- Name: efficientnet_em
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 3935516480
+    Parameters: 6900000
+    File Size: 27927309
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_em
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1118
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_em_ra2-66250f76.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.26%
+      Top 5 Accuracy: 94.79%
+- Name: efficientnet_es
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 2317181824
+    Parameters: 5440000
+    File Size: 22003339
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_es
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1110
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_es_ra-f111e99c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.09%
+      Top 5 Accuracy: 93.93%
+- Name: efficientnet_lite0
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 510605024
+    Parameters: 4650000
+    File Size: 18820005
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_lite0
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1163
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_lite0_ra-37913777.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.5%
+      Top 5 Accuracy: 92.51%
 -->

--- a/modelindex/.templates/models/efficientnet.md
+++ b/modelindex/.templates/models/efficientnet.md
@@ -1,0 +1,254 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2), in addition to [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2020efficientnet,
+      title={EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2020},
+      eprint={1905.11946},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: efficientnet_b2a
+  Metadata:
+    FLOPs: 1452041554
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49369973
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b2a
+    Crop Pct: '1.0'
+    Image Size: '288'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1029
+  In Collection: EfficientNet
+- Name: efficientnet_b3a
+  Metadata:
+    FLOPs: 2600628304
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49369973
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b3a
+    Crop Pct: '1.0'
+    Image Size: '320'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1047
+  In Collection: EfficientNet
+- Name: efficientnet_em
+  Metadata:
+    FLOPs: 3935516480
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 27927309
+    Tasks:
+    - Image Classification
+    ID: efficientnet_em
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1118
+  In Collection: EfficientNet
+- Name: efficientnet_lite0
+  Metadata:
+    FLOPs: 510605024
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 18820005
+    Tasks:
+    - Image Classification
+    ID: efficientnet_lite0
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1163
+  In Collection: EfficientNet
+- Name: efficientnet_es
+  Metadata:
+    FLOPs: 2317181824
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 22003339
+    Tasks:
+    - Image Classification
+    ID: efficientnet_es
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1110
+  In Collection: EfficientNet
+- Name: efficientnet_b3
+  Metadata:
+    FLOPs: 2327905920
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49369973
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b3
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1038
+  In Collection: EfficientNet
+- Name: efficientnet_b0
+  Metadata:
+    FLOPs: 511241564
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 21376743
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b0
+    Layers: 18
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1002
+  In Collection: EfficientNet
+- Name: efficientnet_b1
+  Metadata:
+    FLOPs: 909691920
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 31502706
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b1
+    Crop Pct: '0.875'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1011
+  In Collection: EfficientNet
+- Name: efficientnet_b2
+  Metadata:
+    FLOPs: 1265324514
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 36788104
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b2
+    Crop Pct: '0.875'
+    Image Size: '260'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1020
+  In Collection: EfficientNet
+Collections:
+- Name: EfficientNet
+  Paper:
+    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/ensemble-adversarial.md
+++ b/modelindex/.templates/models/ensemble-adversarial.md
@@ -1,0 +1,89 @@
+# Summary
+
+**Inception-ResNet-v2** is a convolutional neural architecture that builds on the Inception family of architectures but incorporates [residual connections](https://paperswithcode.com/method/residual-connection) (replacing the filter concatenation stage of the Inception architecture).
+
+This particular model was trained for study of adversarial examples (adversarial training).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1804-00097,
+  author    = {Alexey Kurakin and
+               Ian J. Goodfellow and
+               Samy Bengio and
+               Yinpeng Dong and
+               Fangzhou Liao and
+               Ming Liang and
+               Tianyu Pang and
+               Jun Zhu and
+               Xiaolin Hu and
+               Cihang Xie and
+               Jianyu Wang and
+               Zhishuai Zhang and
+               Zhou Ren and
+               Alan L. Yuille and
+               Sangxia Huang and
+               Yao Zhao and
+               Yuzhe Zhao and
+               Zhonglin Han and
+               Junjiajia Long and
+               Yerkebulan Berdibekov and
+               Takuya Akiba and
+               Seiya Tokui and
+               Motoki Abe},
+  title     = {Adversarial Attacks and Defences Competition},
+  journal   = {CoRR},
+  volume    = {abs/1804.00097},
+  year      = {2018},
+  url       = {http://arxiv.org/abs/1804.00097},
+  archivePrefix = {arXiv},
+  eprint    = {1804.00097},
+  timestamp = {Thu, 31 Oct 2019 16:31:22 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1804-00097.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: ens_adv_inception_resnet_v2
+  Metadata:
+    FLOPs: 16959133120
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 223774238
+    Tasks:
+    - Image Classification
+    ID: ens_adv_inception_resnet_v2
+    Crop Pct: '0.897'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_resnet_v2.py#L351
+  In Collection: Ensemble Adversarial
+Collections:
+- Name: Ensemble Adversarial
+  Paper:
+    title: Adversarial Attacks and Defences Competition
+    url: https://papperswithcode.com//paper/adversarial-attacks-and-defences-competition
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/ensemble-adversarial.md
+++ b/modelindex/.templates/models/ensemble-adversarial.md
@@ -83,7 +83,7 @@ Collections:
 - Name: Ensemble Adversarial
   Paper:
     title: Adversarial Attacks and Defences Competition
-    url: https://papperswithcode.com//paper/adversarial-attacks-and-defences-competition
+    url: https://paperswithcode.com//paper/adversarial-attacks-and-defences-competition
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/ensemble-adversarial.md
+++ b/modelindex/.templates/models/ensemble-adversarial.md
@@ -51,12 +51,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Ensemble Adversarial
+  Paper:
+    Title: Adversarial Attacks and Defences Competition
+    URL: https://paperswithcode.com/paper/adversarial-attacks-and-defences-competition
 Models:
 - Name: ens_adv_inception_resnet_v2
+  In Collection: Ensemble Adversarial
   Metadata:
     FLOPs: 16959133120
-    Training Data:
-    - ImageNet
+    Parameters: 55850000
+    File Size: 223774238
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -70,20 +77,20 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 223774238
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: ens_adv_inception_resnet_v2
     Crop Pct: '0.897'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_resnet_v2.py#L351
-  In Collection: Ensemble Adversarial
-Collections:
-- Name: Ensemble Adversarial
-  Paper:
-    title: Adversarial Attacks and Defences Competition
-    url: https://paperswithcode.com//paper/adversarial-attacks-and-defences-competition
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/ens_adv_inception_resnet_v2-2592a550.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 1.0%
+      Top 5 Accuracy: 17.32%
 -->

--- a/modelindex/.templates/models/ese-vovnet.md
+++ b/modelindex/.templates/models/ese-vovnet.md
@@ -24,54 +24,69 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ESE VovNet
+  Paper:
+    Title: 'CenterMask : Real-Time Anchor-Free Instance Segmentation'
+    URL: https://paperswithcode.com/paper/centermask-real-time-anchor-free-instance-1
 Models:
-- Name: ese_vovnet39b
-  Metadata:
-    FLOPs: 9089259008
-    Training Data:
-    - ImageNet
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - Max Pooling
-    - One-Shot Aggregation
-    - ReLU
-    File Size: 98397138
-    Tasks:
-    - Image Classification
-    ID: ese_vovnet39b
-    Layers: 39
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L371
-  In Collection: ESE VovNet
 - Name: ese_vovnet19b_dw
+  In Collection: ESE VovNet
   Metadata:
     FLOPs: 1711959904
-    Training Data:
-    - ImageNet
+    Parameters: 6540000
+    File Size: 26243175
     Architecture:
     - Batch Normalization
     - Convolution
     - Max Pooling
     - One-Shot Aggregation
     - ReLU
-    File Size: 26243175
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: ese_vovnet19b_dw
     Layers: 19
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L361
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/ese_vovnet19b_dw-a8741004.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.82%
+      Top 5 Accuracy: 93.28%
+- Name: ese_vovnet39b
   In Collection: ESE VovNet
-Collections:
-- Name: ESE VovNet
-  Paper:
-    title: 'CenterMask : Real-Time Anchor-Free Instance Segmentation'
-    url: https://paperswithcode.com//paper/centermask-real-time-anchor-free-instance-1
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 9089259008
+    Parameters: 24570000
+    File Size: 98397138
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Max Pooling
+    - One-Shot Aggregation
+    - ReLU
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: ese_vovnet39b
+    Layers: 39
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L371
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/ese_vovnet39b-f912fe73.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.31%
+      Top 5 Accuracy: 94.72%
 -->

--- a/modelindex/.templates/models/ese-vovnet.md
+++ b/modelindex/.templates/models/ese-vovnet.md
@@ -1,0 +1,77 @@
+# Summary
+
+**VoVNet** is a convolutional neural network that seeks to make [DenseNet](https://paperswithcode.com/method/densenet) more efficient by concatenating all features only once in the last feature map, which makes input size constant and enables enlarging new output channel. 
+
+Read about [one-shot aggregation here](https://paperswithcode.com/method/one-shot-aggregation).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{lee2019energy,
+      title={An Energy and GPU-Computation Efficient Backbone Network for Real-Time Object Detection}, 
+      author={Youngwan Lee and Joong-won Hwang and Sangrok Lee and Yuseok Bae and Jongyoul Park},
+      year={2019},
+      eprint={1904.09730},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: ese_vovnet39b
+  Metadata:
+    FLOPs: 9089259008
+    Training Data:
+    - ImageNet
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Max Pooling
+    - One-Shot Aggregation
+    - ReLU
+    File Size: 98397138
+    Tasks:
+    - Image Classification
+    ID: ese_vovnet39b
+    Layers: 39
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L371
+  In Collection: ESE VovNet
+- Name: ese_vovnet19b_dw
+  Metadata:
+    FLOPs: 1711959904
+    Training Data:
+    - ImageNet
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Max Pooling
+    - One-Shot Aggregation
+    - ReLU
+    File Size: 26243175
+    Tasks:
+    - Image Classification
+    ID: ese_vovnet19b_dw
+    Layers: 19
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L361
+  In Collection: ESE VovNet
+Collections:
+- Name: ESE VovNet
+  Paper:
+    title: 'CenterMask : Real-Time Anchor-Free Instance Segmentation'
+    url: https://papperswithcode.com//paper/centermask-real-time-anchor-free-instance-1
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/ese-vovnet.md
+++ b/modelindex/.templates/models/ese-vovnet.md
@@ -71,7 +71,7 @@ Collections:
 - Name: ESE VovNet
   Paper:
     title: 'CenterMask : Real-Time Anchor-Free Instance Segmentation'
-    url: https://papperswithcode.com//paper/centermask-real-time-anchor-free-instance-1
+    url: https://paperswithcode.com//paper/centermask-real-time-anchor-free-instance-1
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/fbnet.md
+++ b/modelindex/.templates/models/fbnet.md
@@ -24,18 +24,20 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: FBNet
+  Paper:
+    Title: 'FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural
+      Architecture Search'
+    URL: https://paperswithcode.com/paper/fbnet-hardware-aware-efficient-convnet-design
 Models:
 - Name: fbnetc_100
+  In Collection: FBNet
   Metadata:
     FLOPs: 508940064
-    Epochs: 360
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 5570000
+    File Size: 22525094
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -44,26 +46,31 @@ Models:
     - FBNet Block
     - Global Average Pooling
     - Softmax
-    File Size: 22525094
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: fbnetc_100
     LR: 0.1
+    Epochs: 360
     Layers: 22
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0005
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L985
-  In Collection: FBNet
-Collections:
-- Name: FBNet
-  Paper:
-    title: 'FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural
-      Architecture Search'
-    url: https://paperswithcode.com//paper/fbnet-hardware-aware-efficient-convnet-design
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/fbnetc_100-c345b898.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.12%
+      Top 5 Accuracy: 92.37%
 -->

--- a/modelindex/.templates/models/fbnet.md
+++ b/modelindex/.templates/models/fbnet.md
@@ -63,7 +63,7 @@ Collections:
   Paper:
     title: 'FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural
       Architecture Search'
-    url: https://papperswithcode.com//paper/fbnet-hardware-aware-efficient-convnet-design
+    url: https://paperswithcode.com//paper/fbnet-hardware-aware-efficient-convnet-design
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/fbnet.md
+++ b/modelindex/.templates/models/fbnet.md
@@ -1,0 +1,69 @@
+# Summary
+
+**FBNet** is a type of convolutional neural architectures discovered through [DNAS](https://paperswithcode.com/method/dnas) neural architecture search. It utilises a basic type of image model block inspired by [MobileNetv2](https://paperswithcode.com/method/mobilenetv2) that utilises depthwise convolutions and an inverted residual structure (see components).
+
+The principal building block is the [FBNet Block](https://paperswithcode.com/method/fbnet-block).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{wu2019fbnet,
+      title={FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural Architecture Search}, 
+      author={Bichen Wu and Xiaoliang Dai and Peizhao Zhang and Yanghan Wang and Fei Sun and Yiming Wu and Yuandong Tian and Peter Vajda and Yangqing Jia and Kurt Keutzer},
+      year={2019},
+      eprint={1812.03443},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: fbnetc_100
+  Metadata:
+    FLOPs: 508940064
+    Epochs: 360
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - FBNet Block
+    - Global Average Pooling
+    - Softmax
+    File Size: 22525094
+    Tasks:
+    - Image Classification
+    ID: fbnetc_100
+    LR: 0.1
+    Layers: 22
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0005
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L985
+  In Collection: FBNet
+Collections:
+- Name: FBNet
+  Paper:
+    title: 'FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural
+      Architecture Search'
+    url: https://papperswithcode.com//paper/fbnet-hardware-aware-efficient-convnet-design
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/gloun-inception-v3.md
+++ b/modelindex/.templates/models/gloun-inception-v3.md
@@ -1,0 +1,71 @@
+# Summary
+
+**Inception v3** is a convolutional neural network architecture from the Inception family that makes several improvements including using [Label Smoothing](https://paperswithcode.com/method/label-smoothing), Factorized 7 x 7 convolutions, and the use of an [auxiliary classifer](https://paperswithcode.com/method/auxiliary-classifier) to propagate label information lower down the network (along with the use of batch normalization for layers in the sidehead). The key building block is an [Inception Module](https://paperswithcode.com/method/inception-v3-module).
+
+The weights from this model were ported from Gluon.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/SzegedyVISW15,
+  author    = {Christian Szegedy and
+               Vincent Vanhoucke and
+               Sergey Ioffe and
+               Jonathon Shlens and
+               Zbigniew Wojna},
+  title     = {Rethinking the Inception Architecture for Computer Vision},
+  journal   = {CoRR},
+  volume    = {abs/1512.00567},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.00567},
+  archivePrefix = {arXiv},
+  eprint    = {1512.00567},
+  timestamp = {Mon, 13 Aug 2018 16:49:07 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/SzegedyVISW15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: gluon_inception_v3
+  Metadata:
+    FLOPs: 7352418880
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 95567055
+    Tasks:
+    - Image Classification
+    ID: gluon_inception_v3
+    Crop Pct: '0.875'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L464
+  In Collection: Gloun Inception v3
+Collections:
+- Name: Gloun Inception v3
+  Paper:
+    title: Rethinking the Inception Architecture for Computer Vision
+    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/gloun-inception-v3.md
+++ b/modelindex/.templates/models/gloun-inception-v3.md
@@ -65,7 +65,7 @@ Collections:
 - Name: Gloun Inception v3
   Paper:
     title: Rethinking the Inception Architecture for Computer Vision
-    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/gloun-inception-v3.md
+++ b/modelindex/.templates/models/gloun-inception-v3.md
@@ -33,12 +33,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun Inception v3
+  Paper:
+    Title: Rethinking the Inception Architecture for Computer Vision
+    URL: https://paperswithcode.com/paper/rethinking-the-inception-architecture-for
 Models:
 - Name: gluon_inception_v3
+  In Collection: Gloun Inception v3
   Metadata:
     FLOPs: 7352418880
-    Training Data:
-    - ImageNet
+    Parameters: 23830000
+    File Size: 95567055
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -52,20 +59,20 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 95567055
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_inception_v3
     Crop Pct: '0.875'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L464
-  In Collection: Gloun Inception v3
-Collections:
-- Name: Gloun Inception v3
-  Paper:
-    title: Rethinking the Inception Architecture for Computer Vision
-    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/gluon_inception_v3-9f746940.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.8%
+      Top 5 Accuracy: 94.38%
 -->

--- a/modelindex/.templates/models/gloun-resnet.md
+++ b/modelindex/.templates/models/gloun-resnet.md
@@ -32,12 +32,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun ResNet
+  Paper:
+    Title: Deep Residual Learning for Image Recognition
+    URL: https://paperswithcode.com/paper/deep-residual-learning-for-image-recognition
 Models:
 - Name: gluon_resnet101_v1b
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 10068547584
-    Training Data:
-    - ImageNet
+    Parameters: 44550000
+    File Size: 178723172
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -49,45 +56,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178723172
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet101_v1b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L89
-  In Collection: Gloun ResNet
-- Name: gluon_resnet101_v1s
-  Metadata:
-    FLOPs: 11805511680
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 179221777
-    Tasks:
-    - Image Classification
-    ID: gluon_resnet101_v1s
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L166
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet101_v1b-3b017079.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.3%
+      Top 5 Accuracy: 94.53%
 - Name: gluon_resnet101_v1c
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 10376567296
-    Training Data:
-    - ImageNet
+    Parameters: 44570000
+    File Size: 178802575
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -99,70 +89,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178802575
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet101_v1c
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L113
-  In Collection: Gloun ResNet
-- Name: gluon_resnet152_v1c
-  Metadata:
-    FLOPs: 15165680128
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 241613404
-    Tasks:
-    - Image Classification
-    ID: gluon_resnet152_v1c
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L121
-  In Collection: Gloun ResNet
-- Name: gluon_resnet152_v1b
-  Metadata:
-    FLOPs: 14857660416
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 241534001
-    Tasks:
-    - Image Classification
-    ID: gluon_resnet152_v1b
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L97
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet101_v1c-1f26822a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.53%
+      Top 5 Accuracy: 94.59%
 - Name: gluon_resnet101_v1d
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 10377018880
-    Training Data:
-    - ImageNet
+    Parameters: 44570000
+    File Size: 178802755
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -174,20 +122,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178802755
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet101_v1d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L138
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet101_v1d-0f9c8644.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.4%
+      Top 5 Accuracy: 95.02%
+- Name: gluon_resnet101_v1s
   In Collection: Gloun ResNet
-- Name: gluon_resnet152_v1d
   Metadata:
-    FLOPs: 15166131712
-    Training Data:
-    - ImageNet
+    FLOPs: 11805511680
+    Parameters: 44670000
+    File Size: 179221777
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -199,20 +155,127 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 241613584
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnet101_v1s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L166
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet101_v1s-60fe0cc1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.29%
+      Top 5 Accuracy: 95.16%
+- Name: gluon_resnet152_v1b
+  In Collection: Gloun ResNet
+  Metadata:
+    FLOPs: 14857660416
+    Parameters: 60190000
+    File Size: 241534001
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnet152_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L97
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet152_v1b-c1edb0dd.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.69%
+      Top 5 Accuracy: 94.73%
+- Name: gluon_resnet152_v1c
+  In Collection: Gloun ResNet
+  Metadata:
+    FLOPs: 15165680128
+    Parameters: 60210000
+    File Size: 241613404
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnet152_v1c
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L121
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet152_v1c-a3bb0b98.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.91%
+      Top 5 Accuracy: 94.85%
+- Name: gluon_resnet152_v1d
+  In Collection: Gloun ResNet
+  Metadata:
+    FLOPs: 15166131712
+    Parameters: 60210000
+    File Size: 241613584
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet152_v1d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L147
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet152_v1d-bd354e12.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.48%
+      Top 5 Accuracy: 95.2%
 - Name: gluon_resnet152_v1s
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 16594624512
-    Training Data:
-    - ImageNet
+    Parameters: 60320000
+    File Size: 242032606
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -224,45 +287,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 242032606
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet152_v1s
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L175
-  In Collection: Gloun ResNet
-- Name: gluon_resnet50_v1b
-  Metadata:
-    FLOPs: 5282531328
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 102493763
-    Tasks:
-    - Image Classification
-    ID: gluon_resnet50_v1b
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L81
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet152_v1s-dcc41b81.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.02%
+      Top 5 Accuracy: 95.42%
 - Name: gluon_resnet18_v1b
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 2337073152
-    Training Data:
-    - ImageNet
+    Parameters: 11690000
+    File Size: 46816736
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -274,20 +320,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 46816736
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet18_v1b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L65
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet18_v1b-0757602b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 70.84%
+      Top 5 Accuracy: 89.76%
 - Name: gluon_resnet34_v1b
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 4718469120
-    Training Data:
-    - ImageNet
+    Parameters: 21800000
+    File Size: 87295112
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -299,20 +353,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 87295112
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet34_v1b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L73
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet34_v1b-c6d82d59.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.59%
+      Top 5 Accuracy: 92.0%
+- Name: gluon_resnet50_v1b
   In Collection: Gloun ResNet
-- Name: gluon_resnet50_v1c
   Metadata:
-    FLOPs: 5590551040
-    Training Data:
-    - ImageNet
+    FLOPs: 5282531328
+    Parameters: 25560000
+    File Size: 102493763
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -324,20 +386,61 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102573166
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnet50_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L81
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet50_v1b-0ebe02e2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.58%
+      Top 5 Accuracy: 93.72%
+- Name: gluon_resnet50_v1c
+  In Collection: Gloun ResNet
+  Metadata:
+    FLOPs: 5590551040
+    Parameters: 25580000
+    File Size: 102573166
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet50_v1c
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L105
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet50_v1c-48092f55.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.01%
+      Top 5 Accuracy: 93.99%
 - Name: gluon_resnet50_v1d
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 5591002624
-    Training Data:
-    - ImageNet
+    Parameters: 25580000
+    File Size: 102573346
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -349,20 +452,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102573346
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet50_v1d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L129
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet50_v1d-818a1b1b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.06%
+      Top 5 Accuracy: 94.46%
 - Name: gluon_resnet50_v1s
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 7019495424
-    Training Data:
-    - ImageNet
+    Parameters: 25680000
+    File Size: 102992368
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -374,20 +485,20 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102992368
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet50_v1s
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L156
-  In Collection: Gloun ResNet
-Collections:
-- Name: Gloun ResNet
-  Paper:
-    title: Deep Residual Learning for Image Recognition
-    url: https://paperswithcode.com//paper/deep-residual-learning-for-image-recognition
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet50_v1s-1762acc0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.7%
+      Top 5 Accuracy: 94.25%
 -->

--- a/modelindex/.templates/models/gloun-resnet.md
+++ b/modelindex/.templates/models/gloun-resnet.md
@@ -1,0 +1,393 @@
+# Summary
+
+**Residual Networks**, or **ResNets**, learn residual functions with reference to the layer inputs, instead of learning unreferenced functions. Instead of hoping each few stacked layers directly fit a desired underlying mapping, residual nets let these layers fit a residual mapping. They stack [residual blocks](https://paperswithcode.com/method/residual-block) ontop of each other to form network: e.g. a ResNet-50 has fifty layers using these blocks. 
+
+The weights from this model were ported from Gluon.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/HeZRS15,
+  author    = {Kaiming He and
+               Xiangyu Zhang and
+               Shaoqing Ren and
+               Jian Sun},
+  title     = {Deep Residual Learning for Image Recognition},
+  journal   = {CoRR},
+  volume    = {abs/1512.03385},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.03385},
+  archivePrefix = {arXiv},
+  eprint    = {1512.03385},
+  timestamp = {Wed, 17 Apr 2019 17:23:45 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/HeZRS15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: gluon_resnet101_v1b
+  Metadata:
+    FLOPs: 10068547584
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178723172
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet101_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L89
+  In Collection: Gloun ResNet
+- Name: gluon_resnet101_v1s
+  Metadata:
+    FLOPs: 11805511680
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 179221777
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet101_v1s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L166
+  In Collection: Gloun ResNet
+- Name: gluon_resnet101_v1c
+  Metadata:
+    FLOPs: 10376567296
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178802575
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet101_v1c
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L113
+  In Collection: Gloun ResNet
+- Name: gluon_resnet152_v1c
+  Metadata:
+    FLOPs: 15165680128
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241613404
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet152_v1c
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L121
+  In Collection: Gloun ResNet
+- Name: gluon_resnet152_v1b
+  Metadata:
+    FLOPs: 14857660416
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241534001
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet152_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L97
+  In Collection: Gloun ResNet
+- Name: gluon_resnet101_v1d
+  Metadata:
+    FLOPs: 10377018880
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178802755
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet101_v1d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L138
+  In Collection: Gloun ResNet
+- Name: gluon_resnet152_v1d
+  Metadata:
+    FLOPs: 15166131712
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241613584
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet152_v1d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L147
+  In Collection: Gloun ResNet
+- Name: gluon_resnet152_v1s
+  Metadata:
+    FLOPs: 16594624512
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 242032606
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet152_v1s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L175
+  In Collection: Gloun ResNet
+- Name: gluon_resnet50_v1b
+  Metadata:
+    FLOPs: 5282531328
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102493763
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet50_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L81
+  In Collection: Gloun ResNet
+- Name: gluon_resnet18_v1b
+  Metadata:
+    FLOPs: 2337073152
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46816736
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet18_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L65
+  In Collection: Gloun ResNet
+- Name: gluon_resnet34_v1b
+  Metadata:
+    FLOPs: 4718469120
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 87295112
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet34_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L73
+  In Collection: Gloun ResNet
+- Name: gluon_resnet50_v1c
+  Metadata:
+    FLOPs: 5590551040
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102573166
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet50_v1c
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L105
+  In Collection: Gloun ResNet
+- Name: gluon_resnet50_v1d
+  Metadata:
+    FLOPs: 5591002624
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102573346
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet50_v1d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L129
+  In Collection: Gloun ResNet
+- Name: gluon_resnet50_v1s
+  Metadata:
+    FLOPs: 7019495424
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102992368
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet50_v1s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L156
+  In Collection: Gloun ResNet
+Collections:
+- Name: Gloun ResNet
+  Paper:
+    title: Deep Residual Learning for Image Recognition
+    url: https://papperswithcode.com//paper/deep-residual-learning-for-image-recognition
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/gloun-resnet.md
+++ b/modelindex/.templates/models/gloun-resnet.md
@@ -387,7 +387,7 @@ Collections:
 - Name: Gloun ResNet
   Paper:
     title: Deep Residual Learning for Image Recognition
-    url: https://papperswithcode.com//paper/deep-residual-learning-for-image-recognition
+    url: https://paperswithcode.com//paper/deep-residual-learning-for-image-recognition
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/gloun-resnext.md
+++ b/modelindex/.templates/models/gloun-resnext.md
@@ -33,37 +33,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun ResNeXt
+  Paper:
+    Title: Aggregated Residual Transformations for Deep Neural Networks
+    URL: https://paperswithcode.com/paper/aggregated-residual-transformations-for-deep
 Models:
-- Name: gluon_resnext50_32x4d
-  Metadata:
-    FLOPs: 5472648192
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 100441719
-    Tasks:
-    - Image Classification
-    ID: gluon_resnext50_32x4d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L185
-  In Collection: Gloun ResNeXt
 - Name: gluon_resnext101_32x4d
+  In Collection: Gloun ResNeXt
   Metadata:
     FLOPs: 10298145792
-    Training Data:
-    - ImageNet
+    Parameters: 44180000
+    File Size: 177367414
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -75,20 +57,28 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 177367414
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnext101_32x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L193
-  In Collection: Gloun ResNeXt
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnext101_32x4d-b253c8c4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.33%
+      Top 5 Accuracy: 94.91%
 - Name: gluon_resnext101_64x4d
+  In Collection: Gloun ResNeXt
   Metadata:
     FLOPs: 19954172928
-    Training Data:
-    - ImageNet
+    Parameters: 83460000
+    File Size: 334737852
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -100,20 +90,53 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 334737852
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnext101_64x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L201
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnext101_64x4d-f9a8e184.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.63%
+      Top 5 Accuracy: 95.0%
+- Name: gluon_resnext50_32x4d
   In Collection: Gloun ResNeXt
-Collections:
-- Name: Gloun ResNeXt
-  Paper:
-    title: Aggregated Residual Transformations for Deep Neural Networks
-    url: https://paperswithcode.com//paper/aggregated-residual-transformations-for-deep
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5472648192
+    Parameters: 25030000
+    File Size: 100441719
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L185
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnext50_32x4d-e6a097c1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.35%
+      Top 5 Accuracy: 94.42%
 -->

--- a/modelindex/.templates/models/gloun-resnext.md
+++ b/modelindex/.templates/models/gloun-resnext.md
@@ -113,7 +113,7 @@ Collections:
 - Name: Gloun ResNeXt
   Paper:
     title: Aggregated Residual Transformations for Deep Neural Networks
-    url: https://papperswithcode.com//paper/aggregated-residual-transformations-for-deep
+    url: https://paperswithcode.com//paper/aggregated-residual-transformations-for-deep
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/gloun-resnext.md
+++ b/modelindex/.templates/models/gloun-resnext.md
@@ -1,0 +1,119 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+The weights from this model were ported from Gluon.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/XieGDTH16,
+  author    = {Saining Xie and
+               Ross B. Girshick and
+               Piotr Doll{\'{a}}r and
+               Zhuowen Tu and
+               Kaiming He},
+  title     = {Aggregated Residual Transformations for Deep Neural Networks},
+  journal   = {CoRR},
+  volume    = {abs/1611.05431},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1611.05431},
+  archivePrefix = {arXiv},
+  eprint    = {1611.05431},
+  timestamp = {Mon, 13 Aug 2018 16:45:58 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/XieGDTH16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: gluon_resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100441719
+    Tasks:
+    - Image Classification
+    ID: gluon_resnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L185
+  In Collection: Gloun ResNeXt
+- Name: gluon_resnext101_32x4d
+  Metadata:
+    FLOPs: 10298145792
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 177367414
+    Tasks:
+    - Image Classification
+    ID: gluon_resnext101_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L193
+  In Collection: Gloun ResNeXt
+- Name: gluon_resnext101_64x4d
+  Metadata:
+    FLOPs: 19954172928
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 334737852
+    Tasks:
+    - Image Classification
+    ID: gluon_resnext101_64x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L201
+  In Collection: Gloun ResNeXt
+Collections:
+- Name: Gloun ResNeXt
+  Paper:
+    title: Aggregated Residual Transformations for Deep Neural Networks
+    url: https://papperswithcode.com//paper/aggregated-residual-transformations-for-deep
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/gloun-senet.md
+++ b/modelindex/.templates/models/gloun-senet.md
@@ -50,7 +50,7 @@ Collections:
 - Name: Gloun SENet
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/gloun-senet.md
+++ b/modelindex/.templates/models/gloun-senet.md
@@ -1,0 +1,56 @@
+# Summary
+
+A **SENet** is a convolutional neural network architecture that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+The weights from this model were ported from Gluon.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: gluon_senet154
+  Metadata:
+    FLOPs: 26681705136
+    Training Data:
+    - ImageNet
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 461546622
+    Tasks:
+    - Image Classification
+    ID: gluon_senet154
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L239
+  In Collection: Gloun SENet
+Collections:
+- Name: Gloun SENet
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/gloun-senet.md
+++ b/modelindex/.templates/models/gloun-senet.md
@@ -24,12 +24,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun SENet
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: gluon_senet154
+  In Collection: Gloun SENet
   Metadata:
     FLOPs: 26681705136
-    Training Data:
-    - ImageNet
+    Parameters: 115090000
+    File Size: 461546622
     Architecture:
     - Convolution
     - Dense Connections
@@ -37,20 +44,20 @@ Models:
     - Max Pooling
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 461546622
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_senet154
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L239
-  In Collection: Gloun SENet
-Collections:
-- Name: Gloun SENet
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_senet154-70a1a3c0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.23%
+      Top 5 Accuracy: 95.35%
 -->

--- a/modelindex/.templates/models/gloun-seresnext.md
+++ b/modelindex/.templates/models/gloun-seresnext.md
@@ -24,38 +24,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun SEResNeXt
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
-- Name: gluon_seresnext50_32x4d
-  Metadata:
-    FLOPs: 5475179184
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    - Squeeze-and-Excitation Block
-    File Size: 110578827
-    Tasks:
-    - Image Classification
-    ID: gluon_seresnext50_32x4d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L209
-  In Collection: Gloun SEResNeXt
 - Name: gluon_seresnext101_32x4d
+  In Collection: Gloun SEResNeXt
   Metadata:
     FLOPs: 10302923504
-    Training Data:
-    - ImageNet
+    Parameters: 48960000
+    File Size: 196505510
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -68,20 +49,28 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 196505510
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_seresnext101_32x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L219
-  In Collection: Gloun SEResNeXt
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_seresnext101_32x4d-cf52900d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.87%
+      Top 5 Accuracy: 95.29%
 - Name: gluon_seresnext101_64x4d
+  In Collection: Gloun SEResNeXt
   Metadata:
     FLOPs: 19958950640
-    Training Data:
-    - ImageNet
+    Parameters: 88230000
+    File Size: 353875948
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -94,20 +83,54 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 353875948
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_seresnext101_64x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L229
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_seresnext101_64x4d-f9926f93.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.88%
+      Top 5 Accuracy: 95.31%
+- Name: gluon_seresnext50_32x4d
   In Collection: Gloun SEResNeXt
-Collections:
-- Name: Gloun SEResNeXt
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5475179184
+    Parameters: 27560000
+    File Size: 110578827
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_seresnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L209
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_seresnext50_32x4d-90cf2d6e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.92%
+      Top 5 Accuracy: 94.82%
 -->

--- a/modelindex/.templates/models/gloun-seresnext.md
+++ b/modelindex/.templates/models/gloun-seresnext.md
@@ -107,7 +107,7 @@ Collections:
 - Name: Gloun SEResNeXt
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/gloun-seresnext.md
+++ b/modelindex/.templates/models/gloun-seresnext.md
@@ -1,0 +1,113 @@
+# Summary
+
+**SE ResNeXt** is a variant of a [ResNext](https://www.paperswithcode.com/method/resnext) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+The weights from this model were ported from Gluon.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: gluon_seresnext50_32x4d
+  Metadata:
+    FLOPs: 5475179184
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 110578827
+    Tasks:
+    - Image Classification
+    ID: gluon_seresnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L209
+  In Collection: Gloun SEResNeXt
+- Name: gluon_seresnext101_32x4d
+  Metadata:
+    FLOPs: 10302923504
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 196505510
+    Tasks:
+    - Image Classification
+    ID: gluon_seresnext101_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L219
+  In Collection: Gloun SEResNeXt
+- Name: gluon_seresnext101_64x4d
+  Metadata:
+    FLOPs: 19958950640
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 353875948
+    Tasks:
+    - Image Classification
+    ID: gluon_seresnext101_64x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L229
+  In Collection: Gloun SEResNeXt
+Collections:
+- Name: Gloun SEResNeXt
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/gloun-xception.md
+++ b/modelindex/.templates/models/gloun-xception.md
@@ -22,12 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun Xception
+  Paper:
+    Title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
+    URL: https://paperswithcode.com/paper/xception-deep-learning-with-depthwise
 Models:
 - Name: gluon_xception65
+  In Collection: Gloun Xception
   Metadata:
     FLOPs: 17594889728
-    Training Data:
-    - ImageNet
+    Parameters: 39920000
+    File Size: 160551306
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -38,20 +45,20 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 160551306
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_xception65
     Crop Pct: '0.903'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_xception.py#L241
-  In Collection: Gloun Xception
-Collections:
-- Name: Gloun Xception
-  Paper:
-    title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
-    url: https://paperswithcode.com//paper/xception-deep-learning-with-depthwise
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/gluon_xception-7015a15c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.7%
+      Top 5 Accuracy: 94.87%
 -->

--- a/modelindex/.templates/models/gloun-xception.md
+++ b/modelindex/.templates/models/gloun-xception.md
@@ -1,0 +1,57 @@
+# Summary
+
+**Xception** is a convolutional neural network architecture that relies solely on [depthwise separable convolution](https://paperswithcode.com/method/depthwise-separable-convolution) layers. The weights from this model were ported from Gluon.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{chollet2017xception,
+      title={Xception: Deep Learning with Depthwise Separable Convolutions}, 
+      author={François Chollet},
+      year={2017},
+      eprint={1610.02357},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: gluon_xception65
+  Metadata:
+    FLOPs: 17594889728
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 160551306
+    Tasks:
+    - Image Classification
+    ID: gluon_xception65
+    Crop Pct: '0.903'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_xception.py#L241
+  In Collection: Gloun Xception
+Collections:
+- Name: Gloun Xception
+  Paper:
+    title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
+    url: https://papperswithcode.com//paper/xception-deep-learning-with-depthwise
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/gloun-xception.md
+++ b/modelindex/.templates/models/gloun-xception.md
@@ -51,7 +51,7 @@ Collections:
 - Name: Gloun Xception
   Paper:
     title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
-    url: https://papperswithcode.com//paper/xception-deep-learning-with-depthwise
+    url: https://paperswithcode.com//paper/xception-deep-learning-with-depthwise
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/hrnet.md
+++ b/modelindex/.templates/models/hrnet.md
@@ -297,7 +297,7 @@ Collections:
 - Name: HRNet
   Paper:
     title: Deep High-Resolution Representation Learning for Visual Recognition
-    url: https://papperswithcode.com//paper/190807919
+    url: https://paperswithcode.com//paper/190807919
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/hrnet.md
+++ b/modelindex/.templates/models/hrnet.md
@@ -22,282 +22,337 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: HRNet
+  Paper:
+    Title: Deep High-Resolution Representation Learning for Visual Recognition
+    URL: https://paperswithcode.com/paper/190807919
 Models:
-- Name: hrnet_w18_small
-  Metadata:
-    FLOPs: 2071651488
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 52934302
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: hrnet_w18_small
-    Layers: 18
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L790
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w18_small_v2
-  Metadata:
-    FLOPs: 3360023160
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 62682879
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: hrnet_w18_small_v2
-    Layers: 18
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L795
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w32
-  Metadata:
-    FLOPs: 11524528320
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 165547812
-    Tasks:
-    - Image Classification
-    Training Time: 60 hours
-    ID: hrnet_w32
-    Layers: 32
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L810
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w40
-  Metadata:
-    FLOPs: 16381182192
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 230899236
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: hrnet_w40
-    Layers: 40
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L815
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w44
-  Metadata:
-    FLOPs: 19202520264
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 268957432
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: hrnet_w44
-    Layers: 44
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L820
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w48
-  Metadata:
-    FLOPs: 22285865760
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 310603710
-    Tasks:
-    - Image Classification
-    Training Time: 80 hours
-    ID: hrnet_w48
-    Layers: 48
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L825
-  Config: ''
-  In Collection: HRNet
 - Name: hrnet_w18
+  In Collection: HRNet
   Metadata:
     FLOPs: 5547205500
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 21300000
+    File Size: 85718883
     Architecture:
     - Batch Normalization
     - Convolution
     - ReLU
     - Residual Connection
-    File Size: 85718883
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: hrnet_w18
+    Epochs: 100
     Layers: 18
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L800
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w18-8cb57bb9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.76%
+      Top 5 Accuracy: 93.44%
+- Name: hrnet_w18_small
   In Collection: HRNet
-- Name: hrnet_w64
   Metadata:
-    FLOPs: 37239321984
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    FLOPs: 2071651488
+    Parameters: 13190000
+    File Size: 52934302
     Architecture:
     - Batch Normalization
     - Convolution
     - ReLU
     - Residual Connection
-    File Size: 513071818
     Tasks:
     - Image Classification
-    Training Time: ''
-    ID: hrnet_w64
-    Layers: 64
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w18_small
+    Epochs: 100
+    Layers: 18
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L830
-  Config: ''
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L790
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnet_w18_small_v1-f460c6bc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.34%
+      Top 5 Accuracy: 90.68%
+- Name: hrnet_w18_small_v2
   In Collection: HRNet
-- Name: hrnet_w30
   Metadata:
-    FLOPs: 10474119492
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    FLOPs: 3360023160
+    Parameters: 15600000
+    File Size: 62682879
     Architecture:
     - Batch Normalization
     - Convolution
     - ReLU
     - Residual Connection
-    File Size: 151452218
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w18_small_v2
+    Epochs: 100
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L795
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnet_w18_small_v2-4c50a8cb.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.11%
+      Top 5 Accuracy: 92.41%
+- Name: hrnet_w30
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 10474119492
+    Parameters: 37710000
+    File Size: 151452218
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: hrnet_w30
+    Epochs: 100
     Layers: 30
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L805
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w30-8d7f8dab.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.21%
+      Top 5 Accuracy: 94.22%
+- Name: hrnet_w32
   In Collection: HRNet
-Collections:
-- Name: HRNet
-  Paper:
-    title: Deep High-Resolution Representation Learning for Visual Recognition
-    url: https://paperswithcode.com//paper/190807919
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 11524528320
+    Parameters: 41230000
+    File Size: 165547812
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    Training Time: 60 hours
+    ID: hrnet_w32
+    Epochs: 100
+    Layers: 32
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L810
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w32-90d8c5fb.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.45%
+      Top 5 Accuracy: 94.19%
+- Name: hrnet_w40
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 16381182192
+    Parameters: 57560000
+    File Size: 230899236
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w40
+    Epochs: 100
+    Layers: 40
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L815
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w40-7cd397a4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.93%
+      Top 5 Accuracy: 94.48%
+- Name: hrnet_w44
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 19202520264
+    Parameters: 67060000
+    File Size: 268957432
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w44
+    Epochs: 100
+    Layers: 44
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L820
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w44-c9ac8c18.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.89%
+      Top 5 Accuracy: 94.37%
+- Name: hrnet_w48
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 22285865760
+    Parameters: 77470000
+    File Size: 310603710
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    Training Time: 80 hours
+    ID: hrnet_w48
+    Epochs: 100
+    Layers: 48
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L825
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w48-abd2e6ab.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.32%
+      Top 5 Accuracy: 94.51%
+- Name: hrnet_w64
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 37239321984
+    Parameters: 128060000
+    File Size: 513071818
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w64
+    Epochs: 100
+    Layers: 64
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L830
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w64-b47cc881.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.46%
+      Top 5 Accuracy: 94.65%
 -->

--- a/modelindex/.templates/models/hrnet.md
+++ b/modelindex/.templates/models/hrnet.md
@@ -1,0 +1,303 @@
+# Summary
+
+**HRNet**, or **High-Resolution Net**, is a general purpose convolutional neural network for tasks like semantic segmentation, object detection and image classification. It is able to maintain high resolution representations through the whole process. We start from a high-resolution convolution stream, gradually add high-to-low resolution convolution streams one by one, and connect the multi-resolution streams in parallel. The resulting network consists of several ($4$ in the paper) stages and the $n$th stage contains $n$ streams corresponding to $n$ resolutions. The authors conduct repeated multi-resolution fusions by exchanging the information across the parallel streams over and over.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{sun2019highresolution,
+      title={High-Resolution Representations for Labeling Pixels and Regions}, 
+      author={Ke Sun and Yang Zhao and Borui Jiang and Tianheng Cheng and Bin Xiao and Dong Liu and Yadong Mu and Xinggang Wang and Wenyu Liu and Jingdong Wang},
+      year={2019},
+      eprint={1904.04514},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: hrnet_w18_small
+  Metadata:
+    FLOPs: 2071651488
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 52934302
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w18_small
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L790
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w18_small_v2
+  Metadata:
+    FLOPs: 3360023160
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 62682879
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w18_small_v2
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L795
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w32
+  Metadata:
+    FLOPs: 11524528320
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 165547812
+    Tasks:
+    - Image Classification
+    Training Time: 60 hours
+    ID: hrnet_w32
+    Layers: 32
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L810
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w40
+  Metadata:
+    FLOPs: 16381182192
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 230899236
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w40
+    Layers: 40
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L815
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w44
+  Metadata:
+    FLOPs: 19202520264
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 268957432
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w44
+    Layers: 44
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L820
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w48
+  Metadata:
+    FLOPs: 22285865760
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 310603710
+    Tasks:
+    - Image Classification
+    Training Time: 80 hours
+    ID: hrnet_w48
+    Layers: 48
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L825
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w18
+  Metadata:
+    FLOPs: 5547205500
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 85718883
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w18
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L800
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w64
+  Metadata:
+    FLOPs: 37239321984
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 513071818
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w64
+    Layers: 64
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L830
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w30
+  Metadata:
+    FLOPs: 10474119492
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 151452218
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w30
+    Layers: 30
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L805
+  Config: ''
+  In Collection: HRNet
+Collections:
+- Name: HRNet
+  Paper:
+    title: Deep High-Resolution Representation Learning for Visual Recognition
+    url: https://papperswithcode.com//paper/190807919
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/ig-resnext.md
+++ b/modelindex/.templates/models/ig-resnext.md
@@ -172,7 +172,7 @@ Collections:
 - Name: IG ResNeXt
   Paper:
     title: Exploring the Limits of Weakly Supervised Pretraining
-    url: https://papperswithcode.com//paper/exploring-the-limits-of-weakly-supervised
+    url: https://paperswithcode.com//paper/exploring-the-limits-of-weakly-supervised
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/ig-resnext.md
+++ b/modelindex/.templates/models/ig-resnext.md
@@ -1,0 +1,178 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+This model was trained on billions of Instagram images using thousands of distinct hashtags as labels exhibit excellent transfer learning performance. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{mahajan2018exploring,
+      title={Exploring the Limits of Weakly Supervised Pretraining}, 
+      author={Dhruv Mahajan and Ross Girshick and Vignesh Ramanathan and Kaiming He and Manohar Paluri and Yixuan Li and Ashwin Bharambe and Laurens van der Maaten},
+      year={2018},
+      eprint={1805.00932},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: ig_resnext101_32x32d
+  Metadata:
+    FLOPs: 112225170432
+    Epochs: 100
+    Batch Size: 8064
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 336x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 1876573776
+    Tasks:
+    - Image Classification
+    ID: ig_resnext101_32x32d
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+    Minibatch Size: 8064
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L885
+  In Collection: IG ResNeXt
+- Name: ig_resnext101_32x16d
+  Metadata:
+    FLOPs: 46623691776
+    Epochs: 100
+    Batch Size: 8064
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 336x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 777518664
+    Tasks:
+    - Image Classification
+    ID: ig_resnext101_32x16d
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L874
+  In Collection: IG ResNeXt
+- Name: ig_resnext101_32x48d
+  Metadata:
+    FLOPs: 197446554624
+    Epochs: 100
+    Batch Size: 8064
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 336x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 3317136976
+    Tasks:
+    - Image Classification
+    ID: ig_resnext101_32x48d
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L896
+  In Collection: IG ResNeXt
+- Name: ig_resnext101_32x8d
+  Metadata:
+    FLOPs: 21180417024
+    Epochs: 100
+    Batch Size: 8064
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 336x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 356056638
+    Tasks:
+    - Image Classification
+    ID: ig_resnext101_32x8d
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L863
+  In Collection: IG ResNeXt
+Collections:
+- Name: IG ResNeXt
+  Paper:
+    title: Exploring the Limits of Weakly Supervised Pretraining
+    url: https://papperswithcode.com//paper/exploring-the-limits-of-weakly-supervised
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/ig-resnext.md
+++ b/modelindex/.templates/models/ig-resnext.md
@@ -26,19 +26,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: IG ResNeXt
+  Paper:
+    Title: Exploring the Limits of Weakly Supervised Pretraining
+    URL: https://paperswithcode.com/paper/exploring-the-limits-of-weakly-supervised
 Models:
-- Name: ig_resnext101_32x32d
+- Name: ig_resnext101_32x16d
+  In Collection: IG ResNeXt
   Metadata:
-    FLOPs: 112225170432
-    Epochs: 100
-    Batch Size: 8064
-    Training Data:
-    - IG-3.5B-17k
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 336x GPUs
+    FLOPs: 46623691776
+    Parameters: 194030000
+    File Size: 777518664
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -50,66 +50,82 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 1876573776
     Tasks:
     - Image Classification
-    ID: ig_resnext101_32x32d
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Resources: 336x GPUs
+    ID: ig_resnext101_32x16d
+    Epochs: 100
     Layers: 101
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8064
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L874
+  Weights: https://download.pytorch.org/models/ig_resnext101_32x16-c6f796b0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.16%
+      Top 5 Accuracy: 97.19%
+- Name: ig_resnext101_32x32d
+  In Collection: IG ResNeXt
+  Metadata:
+    FLOPs: 112225170432
+    Parameters: 468530000
+    File Size: 1876573776
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Resources: 336x GPUs
+    ID: ig_resnext101_32x32d
+    Epochs: 100
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 8064
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
     Minibatch Size: 8064
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L885
-  In Collection: IG ResNeXt
-- Name: ig_resnext101_32x16d
-  Metadata:
-    FLOPs: 46623691776
-    Epochs: 100
-    Batch Size: 8064
-    Training Data:
-    - IG-3.5B-17k
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 336x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 777518664
-    Tasks:
-    - Image Classification
-    ID: ig_resnext101_32x16d
-    Layers: 101
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L874
-  In Collection: IG ResNeXt
+  Weights: https://download.pytorch.org/models/ig_resnext101_32x32-e4b90b00.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.09%
+      Top 5 Accuracy: 97.44%
 - Name: ig_resnext101_32x48d
+  In Collection: IG ResNeXt
   Metadata:
     FLOPs: 197446554624
-    Epochs: 100
-    Batch Size: 8064
-    Training Data:
-    - IG-3.5B-17k
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 336x GPUs
+    Parameters: 828410000
+    File Size: 3317136976
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -121,30 +137,38 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 3317136976
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Resources: 336x GPUs
     ID: ig_resnext101_32x48d
+    Epochs: 100
     Layers: 101
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8064
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L896
-  In Collection: IG ResNeXt
+  Weights: https://download.pytorch.org/models/ig_resnext101_32x48-3e41cc8a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.42%
+      Top 5 Accuracy: 97.58%
 - Name: ig_resnext101_32x8d
+  In Collection: IG ResNeXt
   Metadata:
     FLOPs: 21180417024
-    Epochs: 100
-    Batch Size: 8064
-    Training Data:
-    - IG-3.5B-17k
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 336x GPUs
+    Parameters: 88790000
+    File Size: 356056638
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -156,23 +180,30 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 356056638
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Resources: 336x GPUs
     ID: ig_resnext101_32x8d
+    Epochs: 100
     Layers: 101
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8064
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L863
-  In Collection: IG ResNeXt
-Collections:
-- Name: IG ResNeXt
-  Paper:
-    title: Exploring the Limits of Weakly Supervised Pretraining
-    url: https://paperswithcode.com//paper/exploring-the-limits-of-weakly-supervised
-  type: model-index
-Type: model-index
+  Weights: https://download.pytorch.org/models/ig_resnext101_32x8-c38310e5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.7%
+      Top 5 Accuracy: 96.64%
 -->

--- a/modelindex/.templates/models/inception-resnet-v2.md
+++ b/modelindex/.templates/models/inception-resnet-v2.md
@@ -22,17 +22,20 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Inception ResNet v2
+  Paper:
+    Title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
+      Learning
+    URL: https://paperswithcode.com/paper/inception-v4-inception-resnet-and-the-impact
 Models:
 - Name: inception_resnet_v2
+  In Collection: Inception ResNet v2
   Metadata:
     FLOPs: 16959133120
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 20x NVIDIA Kepler GPUs
+    Parameters: 55850000
+    File Size: 223774238
     Architecture:
     - Average Pooling
     - Dropout
@@ -42,9 +45,15 @@ Models:
     - Inception-ResNet-v2-C
     - Reduction-A
     - Softmax
-    File Size: 223774238
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 20x NVIDIA Kepler GPUs
     ID: inception_resnet_v2
     LR: 0.045
     Dropout: 0.2
@@ -53,13 +62,11 @@ Models:
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_resnet_v2.py#L343
-  In Collection: Inception ResNet v2
-Collections:
-- Name: Inception ResNet v2
-  Paper:
-    title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
-      Learning
-    url: https://paperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/inception_resnet_v2-940b1cd6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 0.95%
+      Top 5 Accuracy: 17.29%
 -->

--- a/modelindex/.templates/models/inception-resnet-v2.md
+++ b/modelindex/.templates/models/inception-resnet-v2.md
@@ -59,7 +59,7 @@ Collections:
   Paper:
     title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
       Learning
-    url: https://papperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
+    url: https://paperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/inception-resnet-v2.md
+++ b/modelindex/.templates/models/inception-resnet-v2.md
@@ -1,0 +1,65 @@
+# Summary
+
+**Inception-ResNet-v2** is a convolutional neural architecture that builds on the Inception family of architectures but incorporates [residual connections](https://paperswithcode.com/method/residual-connection) (replacing the filter concatenation stage of the Inception architecture).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{szegedy2016inceptionv4,
+      title={Inception-v4, Inception-ResNet and the Impact of Residual Connections on Learning}, 
+      author={Christian Szegedy and Sergey Ioffe and Vincent Vanhoucke and Alex Alemi},
+      year={2016},
+      eprint={1602.07261},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: inception_resnet_v2
+  Metadata:
+    FLOPs: 16959133120
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 20x NVIDIA Kepler GPUs
+    Architecture:
+    - Average Pooling
+    - Dropout
+    - Inception-ResNet-v2 Reduction-B
+    - Inception-ResNet-v2-A
+    - Inception-ResNet-v2-B
+    - Inception-ResNet-v2-C
+    - Reduction-A
+    - Softmax
+    File Size: 223774238
+    Tasks:
+    - Image Classification
+    ID: inception_resnet_v2
+    LR: 0.045
+    Dropout: 0.2
+    Crop Pct: '0.897'
+    Momentum: 0.9
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_resnet_v2.py#L343
+  In Collection: Inception ResNet v2
+Collections:
+- Name: Inception ResNet v2
+  Paper:
+    title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
+      Learning
+    url: https://papperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/inception-v3.md
+++ b/modelindex/.templates/models/inception-v3.md
@@ -31,18 +31,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Inception v3
+  Paper:
+    Title: Rethinking the Inception Architecture for Computer Vision
+    URL: https://paperswithcode.com/paper/rethinking-the-inception-architecture-for
 Models:
 - Name: inception_v3
+  In Collection: Inception v3
   Metadata:
     FLOPs: 7352418880
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Gradient Clipping
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 50x NVIDIA Kepler GPUs
+    Parameters: 23830000
+    File Size: 108857766
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -56,9 +57,16 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 108857766
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Gradient Clipping
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 50x NVIDIA Kepler GPUs
     ID: inception_v3
     LR: 0.045
     Dropout: 0.2
@@ -67,12 +75,11 @@ Models:
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L442
-  In Collection: Inception v3
-Collections:
-- Name: Inception v3
-  Paper:
-    title: Rethinking the Inception Architecture for Computer Vision
-    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
-  type: model-index
-Type: model-index
+  Weights: https://download.pytorch.org/models/inception_v3_google-1a9a5a14.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.46%
+      Top 5 Accuracy: 93.48%
 -->

--- a/modelindex/.templates/models/inception-v3.md
+++ b/modelindex/.templates/models/inception-v3.md
@@ -1,0 +1,78 @@
+# Summary
+
+**Inception v3** is a convolutional neural network architecture from the Inception family that makes several improvements including using [Label Smoothing](https://paperswithcode.com/method/label-smoothing), Factorized 7 x 7 convolutions, and the use of an [auxiliary classifer](https://paperswithcode.com/method/auxiliary-classifier) to propagate label information lower down the network (along with the use of batch normalization for layers in the sidehead). The key building block is an [Inception Module](https://paperswithcode.com/method/inception-v3-module).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/SzegedyVISW15,
+  author    = {Christian Szegedy and
+               Vincent Vanhoucke and
+               Sergey Ioffe and
+               Jonathon Shlens and
+               Zbigniew Wojna},
+  title     = {Rethinking the Inception Architecture for Computer Vision},
+  journal   = {CoRR},
+  volume    = {abs/1512.00567},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.00567},
+  archivePrefix = {arXiv},
+  eprint    = {1512.00567},
+  timestamp = {Mon, 13 Aug 2018 16:49:07 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/SzegedyVISW15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: inception_v3
+  Metadata:
+    FLOPs: 7352418880
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Gradient Clipping
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 50x NVIDIA Kepler GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 108857766
+    Tasks:
+    - Image Classification
+    ID: inception_v3
+    LR: 0.045
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L442
+  In Collection: Inception v3
+Collections:
+- Name: Inception v3
+  Paper:
+    title: Rethinking the Inception Architecture for Computer Vision
+    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/inception-v3.md
+++ b/modelindex/.templates/models/inception-v3.md
@@ -72,7 +72,7 @@ Collections:
 - Name: Inception v3
   Paper:
     title: Rethinking the Inception Architecture for Computer Vision
-    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/inception-v4.md
+++ b/modelindex/.templates/models/inception-v4.md
@@ -21,17 +21,20 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Inception v4
+  Paper:
+    Title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
+      Learning
+    URL: https://paperswithcode.com/paper/inception-v4-inception-resnet-and-the-impact
 Models:
 - Name: inception_v4
+  In Collection: Inception v4
   Metadata:
     FLOPs: 15806527936
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 20x NVIDIA Kepler GPUs
+    Parameters: 42680000
+    File Size: 171082495
     Architecture:
     - Average Pooling
     - Dropout
@@ -41,9 +44,15 @@ Models:
     - Reduction-A
     - Reduction-B
     - Softmax
-    File Size: 171082495
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 20x NVIDIA Kepler GPUs
     ID: inception_v4
     LR: 0.045
     Dropout: 0.2
@@ -52,13 +61,11 @@ Models:
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v4.py#L313
-  In Collection: Inception v4
-Collections:
-- Name: Inception v4
-  Paper:
-    title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
-      Learning
-    url: https://paperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/inceptionv4-8e4777a0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 1.01%
+      Top 5 Accuracy: 16.85%
 -->

--- a/modelindex/.templates/models/inception-v4.md
+++ b/modelindex/.templates/models/inception-v4.md
@@ -1,0 +1,64 @@
+# Summary
+
+**Inception-v4** is a convolutional neural network architecture that builds on previous iterations of the Inception family by simplifying the architecture and using more inception modules than [Inception-v3](https://paperswithcode.com/method/inception-v3).
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{szegedy2016inceptionv4,
+      title={Inception-v4, Inception-ResNet and the Impact of Residual Connections on Learning}, 
+      author={Christian Szegedy and Sergey Ioffe and Vincent Vanhoucke and Alex Alemi},
+      year={2016},
+      eprint={1602.07261},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: inception_v4
+  Metadata:
+    FLOPs: 15806527936
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 20x NVIDIA Kepler GPUs
+    Architecture:
+    - Average Pooling
+    - Dropout
+    - Inception-A
+    - Inception-B
+    - Inception-C
+    - Reduction-A
+    - Reduction-B
+    - Softmax
+    File Size: 171082495
+    Tasks:
+    - Image Classification
+    ID: inception_v4
+    LR: 0.045
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v4.py#L313
+  In Collection: Inception v4
+Collections:
+- Name: Inception v4
+  Paper:
+    title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
+      Learning
+    url: https://papperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/inception-v4.md
+++ b/modelindex/.templates/models/inception-v4.md
@@ -58,7 +58,7 @@ Collections:
   Paper:
     title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
       Learning
-    url: https://papperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
+    url: https://paperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/legacy-se-resnet.md
+++ b/modelindex/.templates/models/legacy-se-resnet.md
@@ -212,7 +212,7 @@ Collections:
 - Name: Legacy SE ResNet
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/legacy-se-resnet.md
+++ b/modelindex/.templates/models/legacy-se-resnet.md
@@ -1,0 +1,218 @@
+# Summary
+
+**SE ResNet** is a variant of a [ResNet](https://www.paperswithcode.com/method/resnet) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: legacy_seresnet101
+  Metadata:
+    FLOPs: 9762614000
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 197822624
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet101
+    LR: 0.6
+    Layers: 101
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L426
+  In Collection: Legacy SE ResNet
+- Name: legacy_seresnet152
+  Metadata:
+    FLOPs: 14553578160
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 268033864
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet152
+    LR: 0.6
+    Layers: 152
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L433
+  In Collection: Legacy SE ResNet
+- Name: legacy_seresnet18
+  Metadata:
+    FLOPs: 2328876024
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 47175663
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet18
+    LR: 0.6
+    Layers: 18
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L405
+  In Collection: Legacy SE ResNet
+- Name: legacy_seresnet34
+  Metadata:
+    FLOPs: 4706201004
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 87958697
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet34
+    LR: 0.6
+    Layers: 34
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L412
+  In Collection: Legacy SE ResNet
+- Name: legacy_seresnet50
+  Metadata:
+    FLOPs: 4974351024
+    Epochs: 100
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 112611220
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet50
+    LR: 0.6
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+    Minibatch Size: 1024
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L419
+  In Collection: Legacy SE ResNet
+Collections:
+- Name: Legacy SE ResNet
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/legacy-se-resnet.md
+++ b/modelindex/.templates/models/legacy-se-resnet.md
@@ -22,19 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Legacy SE ResNet
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: legacy_seresnet101
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 9762614000
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 49330000
+    File Size: 197822624
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -47,31 +47,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 197822624
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet101
     LR: 0.6
+    Epochs: 100
     Layers: 101
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L426
-  In Collection: Legacy SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/se_resnet101-7e38fcc6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.38%
+      Top 5 Accuracy: 94.26%
 - Name: legacy_seresnet152
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 14553578160
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 66819999
+    File Size: 268033864
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -84,31 +92,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 268033864
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet152
     LR: 0.6
+    Epochs: 100
     Layers: 152
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L433
-  In Collection: Legacy SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/se_resnet152-d17c99b7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.67%
+      Top 5 Accuracy: 94.38%
 - Name: legacy_seresnet18
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 2328876024
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 11780000
+    File Size: 47175663
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -121,31 +137,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 47175663
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet18
     LR: 0.6
+    Epochs: 100
     Layers: 18
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L405
-  In Collection: Legacy SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnet18-4bb0ce65.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 71.74%
+      Top 5 Accuracy: 90.34%
 - Name: legacy_seresnet34
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 4706201004
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 21960000
+    File Size: 87958697
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -158,30 +182,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 87958697
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet34
     LR: 0.6
+    Epochs: 100
     Layers: 34
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L412
-  In Collection: Legacy SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnet34-a4004e63.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.79%
+      Top 5 Accuracy: 92.13%
 - Name: legacy_seresnet50
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 4974351024
-    Epochs: 100
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 28090000
+    File Size: 112611220
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -194,11 +227,18 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 112611220
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet50
     LR: 0.6
+    Epochs: 100
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
@@ -207,12 +247,11 @@ Models:
     Interpolation: bilinear
     Minibatch Size: 1024
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L419
-  In Collection: Legacy SE ResNet
-Collections:
-- Name: Legacy SE ResNet
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/se_resnet50-ce0d4300.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.64%
+      Top 5 Accuracy: 93.74%
 -->

--- a/modelindex/.templates/models/legacy-se-resnext.md
+++ b/modelindex/.templates/models/legacy-se-resnext.md
@@ -22,19 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Legacy SE ResNeXt
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: legacy_seresnext101_32x4d
+  In Collection: Legacy SE ResNeXt
   Metadata:
     FLOPs: 10287698672
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 48960000
+    File Size: 196466866
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -47,31 +47,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 196466866
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnext101_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 101
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L462
-  In Collection: Legacy SE ResNeXt
+  Weights: http://data.lip6.fr/cadene/pretrainedmodels/se_resnext101_32x4d-3b2fe3d8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.23%
+      Top 5 Accuracy: 95.02%
 - Name: legacy_seresnext26_32x4d
+  In Collection: Legacy SE ResNeXt
   Metadata:
     FLOPs: 3187342304
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 16790000
+    File Size: 67346327
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -84,31 +92,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 67346327
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnext26_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 26
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L448
-  In Collection: Legacy SE ResNeXt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnext26_32x4d-65ebdb501.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.11%
+      Top 5 Accuracy: 93.31%
 - Name: legacy_seresnext50_32x4d
+  In Collection: Legacy SE ResNeXt
   Metadata:
     FLOPs: 5459954352
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 27560000
+    File Size: 110559176
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -121,24 +137,31 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 110559176
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnext50_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L455
-  In Collection: Legacy SE ResNeXt
-Collections:
-- Name: Legacy SE ResNeXt
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: http://data.lip6.fr/cadene/pretrainedmodels/se_resnext50_32x4d-a260b3a4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.08%
+      Top 5 Accuracy: 94.43%
 -->

--- a/modelindex/.templates/models/legacy-se-resnext.md
+++ b/modelindex/.templates/models/legacy-se-resnext.md
@@ -138,7 +138,7 @@ Collections:
 - Name: Legacy SE ResNeXt
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/legacy-se-resnext.md
+++ b/modelindex/.templates/models/legacy-se-resnext.md
@@ -1,0 +1,144 @@
+# Summary
+
+**SE ResNeXt** is a variant of a [ResNeXt](https://www.paperswithcode.com/method/resnext) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: legacy_seresnext101_32x4d
+  Metadata:
+    FLOPs: 10287698672
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 196466866
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnext101_32x4d
+    LR: 0.6
+    Layers: 101
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L462
+  In Collection: Legacy SE ResNeXt
+- Name: legacy_seresnext26_32x4d
+  Metadata:
+    FLOPs: 3187342304
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 67346327
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnext26_32x4d
+    LR: 0.6
+    Layers: 26
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L448
+  In Collection: Legacy SE ResNeXt
+- Name: legacy_seresnext50_32x4d
+  Metadata:
+    FLOPs: 5459954352
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 110559176
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnext50_32x4d
+    LR: 0.6
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L455
+  In Collection: Legacy SE ResNeXt
+Collections:
+- Name: Legacy SE ResNeXt
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/legacy-senet.md
+++ b/modelindex/.templates/models/legacy-senet.md
@@ -24,19 +24,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Legacy SENet
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: legacy_senet154
+  In Collection: Legacy SENet
   Metadata:
     FLOPs: 26659556016
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 115090000
+    File Size: 461488402
     Architecture:
     - Convolution
     - Dense Connections
@@ -44,24 +44,31 @@ Models:
     - Max Pooling
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 461488402
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_senet154
     LR: 0.6
+    Epochs: 100
     Layers: 154
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L440
-  In Collection: Legacy SENet
-Collections:
-- Name: Legacy SENet
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: http://data.lip6.fr/cadene/pretrainedmodels/senet154-c7b49a05.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.33%
+      Top 5 Accuracy: 95.51%
 -->

--- a/modelindex/.templates/models/legacy-senet.md
+++ b/modelindex/.templates/models/legacy-senet.md
@@ -61,7 +61,7 @@ Collections:
 - Name: Legacy SENet
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/legacy-senet.md
+++ b/modelindex/.templates/models/legacy-senet.md
@@ -1,0 +1,67 @@
+# Summary
+
+A **SENet** is a convolutional neural network architecture that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+The weights from this model were ported from Gluon.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: legacy_senet154
+  Metadata:
+    FLOPs: 26659556016
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 461488402
+    Tasks:
+    - Image Classification
+    ID: legacy_senet154
+    LR: 0.6
+    Layers: 154
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L440
+  In Collection: Legacy SENet
+Collections:
+- Name: Legacy SENet
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/mixnet.md
+++ b/modelindex/.templates/models/mixnet.md
@@ -1,0 +1,133 @@
+# Summary
+
+**MixNet** is a type of convolutional neural network discovered via AutoML that utilises [MixConvs](https://paperswithcode.com/method/mixconv) instead of regular [depthwise convolutions](https://paperswithcode.com/method/depthwise-convolution).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2019mixconv,
+      title={MixConv: Mixed Depthwise Convolutional Kernels}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2019},
+      eprint={1907.09595},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: mixnet_xl
+  Metadata:
+    FLOPs: 1195880424
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 48001170
+    Tasks:
+    - Image Classification
+    ID: mixnet_xl
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1678
+  In Collection: MixNet
+- Name: mixnet_m
+  Metadata:
+    FLOPs: 454543374
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 20298347
+    Tasks:
+    - Image Classification
+    ID: mixnet_m
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1660
+  In Collection: MixNet
+- Name: mixnet_s
+  Metadata:
+    FLOPs: 321264910
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 16727982
+    Tasks:
+    - Image Classification
+    ID: mixnet_s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1651
+  In Collection: MixNet
+- Name: mixnet_l
+  Metadata:
+    FLOPs: 738671316
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 29608232
+    Tasks:
+    - Image Classification
+    ID: mixnet_l
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1669
+  In Collection: MixNet
+Collections:
+- Name: MixNet
+  Paper:
+    title: 'MixConv: Mixed Depthwise Convolutional Kernels'
+    url: https://papperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/mixnet.md
+++ b/modelindex/.templates/models/mixnet.md
@@ -127,7 +127,7 @@ Collections:
 - Name: MixNet
   Paper:
     title: 'MixConv: Mixed Depthwise Convolutional Kernels'
-    url: https://papperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
+    url: https://paperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/mixnet.md
+++ b/modelindex/.templates/models/mixnet.md
@@ -22,89 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: MixNet
+  Paper:
+    Title: 'MixConv: Mixed Depthwise Convolutional Kernels'
+    URL: https://paperswithcode.com/paper/mixnet-mixed-depthwise-convolutional-kernels
 Models:
-- Name: mixnet_xl
-  Metadata:
-    FLOPs: 1195880424
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
-    Architecture:
-    - Batch Normalization
-    - Dense Connections
-    - Dropout
-    - Global Average Pooling
-    - Grouped Convolution
-    - MixConv
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 48001170
-    Tasks:
-    - Image Classification
-    ID: mixnet_xl
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1678
-  In Collection: MixNet
-- Name: mixnet_m
-  Metadata:
-    FLOPs: 454543374
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
-    Architecture:
-    - Batch Normalization
-    - Dense Connections
-    - Dropout
-    - Global Average Pooling
-    - Grouped Convolution
-    - MixConv
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 20298347
-    Tasks:
-    - Image Classification
-    ID: mixnet_m
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1660
-  In Collection: MixNet
-- Name: mixnet_s
-  Metadata:
-    FLOPs: 321264910
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
-    Architecture:
-    - Batch Normalization
-    - Dense Connections
-    - Dropout
-    - Global Average Pooling
-    - Grouped Convolution
-    - MixConv
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 16727982
-    Tasks:
-    - Image Classification
-    ID: mixnet_s
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1651
-  In Collection: MixNet
 - Name: mixnet_l
+  In Collection: MixNet
   Metadata:
     FLOPs: 738671316
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
+    Parameters: 7330000
+    File Size: 29608232
     Architecture:
     - Batch Normalization
     - Dense Connections
@@ -114,20 +44,121 @@ Models:
     - MixConv
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 29608232
     Tasks:
     - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
     ID: mixnet_l
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1669
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mixnet_l-5a9a2ed8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.98%
+      Top 5 Accuracy: 94.18%
+- Name: mixnet_m
   In Collection: MixNet
-Collections:
-- Name: MixNet
-  Paper:
-    title: 'MixConv: Mixed Depthwise Convolutional Kernels'
-    url: https://paperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 454543374
+    Parameters: 5010000
+    File Size: 20298347
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
+    ID: mixnet_m
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1660
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mixnet_m-4647fc68.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.27%
+      Top 5 Accuracy: 93.42%
+- Name: mixnet_s
+  In Collection: MixNet
+  Metadata:
+    FLOPs: 321264910
+    Parameters: 4130000
+    File Size: 16727982
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
+    ID: mixnet_s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1651
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mixnet_s-a907afbc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.99%
+      Top 5 Accuracy: 92.79%
+- Name: mixnet_xl
+  In Collection: MixNet
+  Metadata:
+    FLOPs: 1195880424
+    Parameters: 11900000
+    File Size: 48001170
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
+    ID: mixnet_xl
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1678
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mixnet_xl_ra-aac3c00c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.47%
+      Top 5 Accuracy: 94.93%
 -->

--- a/modelindex/.templates/models/mnasnet.md
+++ b/modelindex/.templates/models/mnasnet.md
@@ -88,7 +88,7 @@ Collections:
 - Name: MNASNet
   Paper:
     title: 'MnasNet: Platform-Aware Neural Architecture Search for Mobile'
-    url: https://papperswithcode.com//paper/mnasnet-platform-aware-neural-architecture
+    url: https://paperswithcode.com//paper/mnasnet-platform-aware-neural-architecture
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/mnasnet.md
+++ b/modelindex/.templates/models/mnasnet.md
@@ -22,12 +22,61 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: MNASNet
+  Paper:
+    Title: 'MnasNet: Platform-Aware Neural Architecture Search for Mobile'
+    URL: https://paperswithcode.com/paper/mnasnet-platform-aware-neural-architecture
 Models:
-- Name: semnasnet_100
+- Name: mnasnet_100
+  In Collection: MNASNet
   Metadata:
-    FLOPs: 414570766
+    FLOPs: 416415488
+    Parameters: 4380000
+    File Size: 17731774
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
     Training Data:
     - ImageNet
+    ID: mnasnet_100
+    Layers: 100
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 4000
+    Image Size: '224'
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L894
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mnasnet_b1-74cb7081.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.67%
+      Top 5 Accuracy: 92.1%
+- Name: semnasnet_100
+  In Collection: MNASNet
+  Metadata:
+    FLOPs: 414570766
+    Parameters: 3890000
+    File Size: 15731489
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -41,54 +90,20 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 15731489
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: semnasnet_100
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L928
-  In Collection: MNASNet
-- Name: mnasnet_100
-  Metadata:
-    FLOPs: 416415488
-    Batch Size: 4000
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Depthwise Separable Convolution
-    - Dropout
-    - Global Average Pooling
-    - Inverted Residual Block
-    - Max Pooling
-    - ReLU
-    - Residual Connection
-    - Softmax
-    File Size: 17731774
-    Tasks:
-    - Image Classification
-    ID: mnasnet_100
-    Layers: 100
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L894
-  In Collection: MNASNet
-Collections:
-- Name: MNASNet
-  Paper:
-    title: 'MnasNet: Platform-Aware Neural Architecture Search for Mobile'
-    url: https://paperswithcode.com//paper/mnasnet-platform-aware-neural-architecture
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mnasnet_a1-d9418771.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.45%
+      Top 5 Accuracy: 92.61%
 -->

--- a/modelindex/.templates/models/mnasnet.md
+++ b/modelindex/.templates/models/mnasnet.md
@@ -1,0 +1,94 @@
+# Summary
+
+**MnasNet** is a type of convolutional neural network optimized for mobile devices that is discovered through mobile neural architecture search, which explicitly incorporates model latency into the main objective so that the search can identify a model that achieves a good trade-off between accuracy and latency. The main building block is an [inverted residual block](https://paperswithcode.com/method/inverted-residual-block) (from [MobileNetV2](https://paperswithcode.com/method/mobilenetv2)).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2019mnasnet,
+      title={MnasNet: Platform-Aware Neural Architecture Search for Mobile}, 
+      author={Mingxing Tan and Bo Chen and Ruoming Pang and Vijay Vasudevan and Mark Sandler and Andrew Howard and Quoc V. Le},
+      year={2019},
+      eprint={1807.11626},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: semnasnet_100
+  Metadata:
+    FLOPs: 414570766
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 15731489
+    Tasks:
+    - Image Classification
+    ID: semnasnet_100
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L928
+  In Collection: MNASNet
+- Name: mnasnet_100
+  Metadata:
+    FLOPs: 416415488
+    Batch Size: 4000
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 17731774
+    Tasks:
+    - Image Classification
+    ID: mnasnet_100
+    Layers: 100
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L894
+  In Collection: MNASNet
+Collections:
+- Name: MNASNet
+  Paper:
+    title: 'MnasNet: Platform-Aware Neural Architecture Search for Mobile'
+    url: https://papperswithcode.com//paper/mnasnet-platform-aware-neural-architecture
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/mobilenet-v2.md
+++ b/modelindex/.templates/models/mobilenet-v2.md
@@ -1,0 +1,179 @@
+# Summary
+
+**MobileNetV2** is a convolutional neural network architecture that seeks to perform well on mobile devices. It is based on an [inverted residual structure](https://paperswithcode.com/method/inverted-residual-block) where the residual connections are between the bottleneck layers.  The intermediate expansion layer uses lightweight depthwise convolutions to filter features as a source of non-linearity. As a whole, the architecture of MobileNetV2 contains the initial fully convolution layer with 32 filters, followed by 19 residual bottleneck layers.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1801-04381,
+  author    = {Mark Sandler and
+               Andrew G. Howard and
+               Menglong Zhu and
+               Andrey Zhmoginov and
+               Liang{-}Chieh Chen},
+  title     = {Inverted Residuals and Linear Bottlenecks: Mobile Networks for Classification,
+               Detection and Segmentation},
+  journal   = {CoRR},
+  volume    = {abs/1801.04381},
+  year      = {2018},
+  url       = {http://arxiv.org/abs/1801.04381},
+  archivePrefix = {arXiv},
+  eprint    = {1801.04381},
+  timestamp = {Tue, 12 Jan 2021 15:30:06 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1801-04381.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: mobilenetv2_100
+  Metadata:
+    FLOPs: 401920448
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU6
+    - Residual Connection
+    - Softmax
+    File Size: 14202571
+    Tasks:
+    - Image Classification
+    ID: mobilenetv2_100
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L955
+  In Collection: MobileNet V2
+- Name: mobilenetv2_110d
+  Metadata:
+    FLOPs: 573958832
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU6
+    - Residual Connection
+    - Softmax
+    File Size: 18316431
+    Tasks:
+    - Image Classification
+    ID: mobilenetv2_110d
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L969
+  In Collection: MobileNet V2
+- Name: mobilenetv2_120d
+  Metadata:
+    FLOPs: 888510048
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU6
+    - Residual Connection
+    - Softmax
+    File Size: 23651121
+    Tasks:
+    - Image Classification
+    ID: mobilenetv2_120d
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L977
+  In Collection: MobileNet V2
+- Name: mobilenetv2_140
+  Metadata:
+    FLOPs: 770196784
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU6
+    - Residual Connection
+    - Softmax
+    File Size: 24673555
+    Tasks:
+    - Image Classification
+    ID: mobilenetv2_140
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L962
+  In Collection: MobileNet V2
+Collections:
+- Name: MobileNet V2
+  Paper:
+    title: 'MobileNetV2: Inverted Residuals and Linear Bottlenecks'
+    url: https://papperswithcode.com//paper/mobilenetv2-inverted-residuals-and-linear
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/mobilenet-v2.md
+++ b/modelindex/.templates/models/mobilenet-v2.md
@@ -173,7 +173,7 @@ Collections:
 - Name: MobileNet V2
   Paper:
     title: 'MobileNetV2: Inverted Residuals and Linear Bottlenecks'
-    url: https://papperswithcode.com//paper/mobilenetv2-inverted-residuals-and-linear
+    url: https://paperswithcode.com//paper/mobilenetv2-inverted-residuals-and-linear
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/mobilenet-v2.md
+++ b/modelindex/.templates/models/mobilenet-v2.md
@@ -32,17 +32,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: MobileNet V2
+  Paper:
+    Title: 'MobileNetV2: Inverted Residuals and Linear Bottlenecks'
+    URL: https://paperswithcode.com/paper/mobilenetv2-inverted-residuals-and-linear
 Models:
 - Name: mobilenetv2_100
+  In Collection: MobileNet V2
   Metadata:
     FLOPs: 401920448
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 3500000
+    File Size: 14202571
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -54,29 +56,37 @@ Models:
     - ReLU6
     - Residual Connection
     - Softmax
-    File Size: 14202571
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: mobilenetv2_100
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L955
-  In Collection: MobileNet V2
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv2_100_ra-b33bc2c4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.95%
+      Top 5 Accuracy: 91.0%
 - Name: mobilenetv2_110d
+  In Collection: MobileNet V2
   Metadata:
     FLOPs: 573958832
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 4520000
+    File Size: 18316431
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -88,29 +98,37 @@ Models:
     - ReLU6
     - Residual Connection
     - Softmax
-    File Size: 18316431
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: mobilenetv2_110d
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L969
-  In Collection: MobileNet V2
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv2_110d_ra-77090ade.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.05%
+      Top 5 Accuracy: 92.19%
 - Name: mobilenetv2_120d
+  In Collection: MobileNet V2
   Metadata:
     FLOPs: 888510048
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 5830000
+    File Size: 23651121
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -122,29 +140,37 @@ Models:
     - ReLU6
     - Residual Connection
     - Softmax
-    File Size: 23651121
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: mobilenetv2_120d
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L977
-  In Collection: MobileNet V2
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv2_120d_ra-5987e2ed.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.28%
+      Top 5 Accuracy: 93.51%
 - Name: mobilenetv2_140
+  In Collection: MobileNet V2
   Metadata:
     FLOPs: 770196784
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 6110000
+    File Size: 24673555
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -156,24 +182,29 @@ Models:
     - ReLU6
     - Residual Connection
     - Softmax
-    File Size: 24673555
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: mobilenetv2_140
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L962
-  In Collection: MobileNet V2
-Collections:
-- Name: MobileNet V2
-  Paper:
-    title: 'MobileNetV2: Inverted Residuals and Linear Bottlenecks'
-    url: https://paperswithcode.com//paper/mobilenetv2-inverted-residuals-and-linear
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv2_140_ra-21a4e913.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.51%
+      Top 5 Accuracy: 93.0%
 -->

--- a/modelindex/.templates/models/mobilenet-v3.md
+++ b/modelindex/.templates/models/mobilenet-v3.md
@@ -117,7 +117,7 @@ Collections:
 - Name: MobileNet V3
   Paper:
     title: Searching for MobileNetV3
-    url: https://papperswithcode.com//paper/searching-for-mobilenetv3
+    url: https://paperswithcode.com//paper/searching-for-mobilenetv3
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/mobilenet-v3.md
+++ b/modelindex/.templates/models/mobilenet-v3.md
@@ -1,0 +1,123 @@
+# Summary
+
+**MobileNetV3** is a convolutional neural network that is designed for mobile phone CPUs. The network design includes the use of a [hard swish activation](https://paperswithcode.com/method/hard-swish) and [squeeze-and-excitation](https://paperswithcode.com/method/squeeze-and-excitation-block) modules in the [MBConv blocks](https://paperswithcode.com/method/inverted-residual-block).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-02244,
+  author    = {Andrew Howard and
+               Mark Sandler and
+               Grace Chu and
+               Liang{-}Chieh Chen and
+               Bo Chen and
+               Mingxing Tan and
+               Weijun Wang and
+               Yukun Zhu and
+               Ruoming Pang and
+               Vijay Vasudevan and
+               Quoc V. Le and
+               Hartwig Adam},
+  title     = {Searching for MobileNetV3},
+  journal   = {CoRR},
+  volume    = {abs/1905.02244},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.02244},
+  archivePrefix = {arXiv},
+  eprint    = {1905.02244},
+  timestamp = {Tue, 12 Jan 2021 15:30:06 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-02244.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: mobilenetv3_rw
+  Metadata:
+    FLOPs: 287190638
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 22064048
+    Tasks:
+    - Image Classification
+    ID: mobilenetv3_rw
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L384
+  In Collection: MobileNet V3
+- Name: mobilenetv3_large_100
+  Metadata:
+    FLOPs: 287193752
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 22076443
+    Tasks:
+    - Image Classification
+    ID: mobilenetv3_large_100
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L363
+  In Collection: MobileNet V3
+Collections:
+- Name: MobileNet V3
+  Paper:
+    title: Searching for MobileNetV3
+    url: https://papperswithcode.com//paper/searching-for-mobilenetv3
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/mobilenet-v3.md
+++ b/modelindex/.templates/models/mobilenet-v3.md
@@ -38,54 +38,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: MobileNet V3
+  Paper:
+    Title: Searching for MobileNetV3
+    URL: https://paperswithcode.com/paper/searching-for-mobilenetv3
 Models:
-- Name: mobilenetv3_rw
-  Metadata:
-    FLOPs: 287190638
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Depthwise Separable Convolution
-    - Dropout
-    - Global Average Pooling
-    - Hard Swish
-    - Inverted Residual Block
-    - ReLU
-    - Residual Connection
-    - Softmax
-    - Squeeze-and-Excitation Block
-    File Size: 22064048
-    Tasks:
-    - Image Classification
-    ID: mobilenetv3_rw
-    LR: 0.1
-    Dropout: 0.8
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L384
-  In Collection: MobileNet V3
 - Name: mobilenetv3_large_100
+  In Collection: MobileNet V3
   Metadata:
     FLOPs: 287193752
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
+    Parameters: 5480000
+    File Size: 22076443
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -100,24 +65,74 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 22076443
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
     ID: mobilenetv3_large_100
     LR: 0.1
     Dropout: 0.8
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L363
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv3_large_100_ra-f55367f5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.77%
+      Top 5 Accuracy: 92.54%
+- Name: mobilenetv3_rw
   In Collection: MobileNet V3
-Collections:
-- Name: MobileNet V3
-  Paper:
-    title: Searching for MobileNetV3
-    url: https://paperswithcode.com//paper/searching-for-mobilenetv3
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 287190638
+    Parameters: 5480000
+    File Size: 22064048
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
+    ID: mobilenetv3_rw
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 4096
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L384
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv3_100-35495452.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.62%
+      Top 5 Accuracy: 92.71%
 -->

--- a/modelindex/.templates/models/nasnet.md
+++ b/modelindex/.templates/models/nasnet.md
@@ -59,7 +59,7 @@ Collections:
 - Name: NASNet
   Paper:
     title: Learning Transferable Architectures for Scalable Image Recognition
-    url: https://papperswithcode.com//paper/learning-transferable-architectures-for
+    url: https://paperswithcode.com//paper/learning-transferable-architectures-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/nasnet.md
+++ b/modelindex/.templates/models/nasnet.md
@@ -1,0 +1,65 @@
+# Summary
+
+**NASNet** is a type of convolutional neural network discovered through neural architecture search. The building blocks consist of normal and reduction cells.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{zoph2018learning,
+      title={Learning Transferable Architectures for Scalable Image Recognition}, 
+      author={Barret Zoph and Vijay Vasudevan and Jonathon Shlens and Quoc V. Le},
+      year={2018},
+      eprint={1707.07012},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: nasnetalarge
+  Metadata:
+    FLOPs: 30242402862
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 50x Tesla K40 GPUs
+    Architecture:
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - ReLU
+    File Size: 356056626
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: nasnetalarge
+    Dropout: 0.5
+    Crop Pct: '0.911'
+    Momentum: 0.9
+    Image Size: '331'
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+    RMSProp $\epsilon$: 1.0
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/nasnet.py#L562
+  Config: ''
+  In Collection: NASNet
+Collections:
+- Name: NASNet
+  Paper:
+    title: Learning Transferable Architectures for Scalable Image Recognition
+    url: https://papperswithcode.com//paper/learning-transferable-architectures-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/nasnet.md
+++ b/modelindex/.templates/models/nasnet.md
@@ -22,17 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: NASNet
+  Paper:
+    Title: Learning Transferable Architectures for Scalable Image Recognition
+    URL: https://paperswithcode.com/paper/learning-transferable-architectures-for
 Models:
 - Name: nasnetalarge
+  In Collection: NASNet
   Metadata:
     FLOPs: 30242402862
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 50x Tesla K40 GPUs
+    Parameters: 88750000
+    File Size: 356056626
     Architecture:
     - Average Pooling
     - Batch Normalization
@@ -40,10 +42,15 @@ Models:
     - Depthwise Separable Convolution
     - Dropout
     - ReLU
-    File Size: 356056626
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 50x Tesla K40 GPUs
     ID: nasnetalarge
     Dropout: 0.5
     Crop Pct: '0.911'
@@ -53,13 +60,11 @@ Models:
     Label Smoothing: 0.1
     RMSProp $\epsilon$: 1.0
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/nasnet.py#L562
-  Config: ''
-  In Collection: NASNet
-Collections:
-- Name: NASNet
-  Paper:
-    title: Learning Transferable Architectures for Scalable Image Recognition
-    url: https://paperswithcode.com//paper/learning-transferable-architectures-for
-  type: model-index
-Type: model-index
+  Weights: http://data.lip6.fr/cadene/pretrainedmodels/nasnetalarge-a1897284.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.63%
+      Top 5 Accuracy: 96.05%
 -->

--- a/modelindex/.templates/models/noisy-student.md
+++ b/modelindex/.templates/models/noisy-student.md
@@ -31,162 +31,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Noisy Student
+  Paper:
+    Title: Self-training with Noisy Student improves ImageNet classification
+    URL: https://paperswithcode.com/paper/self-training-with-noisy-student-improves
 Models:
-- Name: tf_efficientnet_b3_ns
-  Metadata:
-    FLOPs: 2275247568
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49385734
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b3_ns
-    LR: 0.128
-    Dropout: 0.5
-    Crop Pct: '0.904'
-    Momentum: 0.9
-    Image Size: '300'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-    Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1457
-  Config: ''
-  In Collection: Noisy Student
-- Name: tf_efficientnet_b1_ns
-  Metadata:
-    FLOPs: 883633200
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 31516408
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b1_ns
-    LR: 0.128
-    Dropout: 0.5
-    Crop Pct: '0.882'
-    Momentum: 0.9
-    Image Size: '240'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-    Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1437
-  Config: ''
-  In Collection: Noisy Student
-- Name: tf_efficientnet_l2_ns
-  Metadata:
-    FLOPs: 611646113804
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 1925950424
-    Tasks:
-    - Image Classification
-    Training Time: 6 days
-    ID: tf_efficientnet_l2_ns
-    LR: 0.128
-    Dropout: 0.5
-    Crop Pct: '0.96'
-    Momentum: 0.9
-    Image Size: '800'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-    Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1520
-  Config: ''
-  In Collection: Noisy Student
 - Name: tf_efficientnet_b0_ns
+  In Collection: Noisy Student
   Metadata:
     FLOPs: 488688572
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    Parameters: 5290000
+    File Size: 21386709
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -197,15 +54,27 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 21386709
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
     ID: tf_efficientnet_b0_ns
     LR: 0.128
+    Epochs: 700
     Dropout: 0.5
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -214,25 +83,19 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1427
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b0_ns-c0e6a31c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.66%
+      Top 5 Accuracy: 94.37%
+- Name: tf_efficientnet_b1_ns
   In Collection: Noisy Student
-- Name: tf_efficientnet_b2_ns
   Metadata:
-    FLOPs: 1234321170
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    FLOPs: 883633200
+    Parameters: 7790000
+    File Size: 31516408
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -243,15 +106,79 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 36801803
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
+    ID: tf_efficientnet_b1_ns
+    LR: 0.128
+    Epochs: 700
+    Dropout: 0.5
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1437
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b1_ns-99dd0c41.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.39%
+      Top 5 Accuracy: 95.74%
+- Name: tf_efficientnet_b2_ns
+  In Collection: Noisy Student
+  Metadata:
+    FLOPs: 1234321170
+    Parameters: 9110000
+    File Size: 36801803
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
     ID: tf_efficientnet_b2_ns
     LR: 0.128
+    Epochs: 700
     Dropout: 0.5
     Crop Pct: '0.89'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '260'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -260,25 +187,19 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1447
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b2_ns-00306e48.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.39%
+      Top 5 Accuracy: 96.24%
+- Name: tf_efficientnet_b3_ns
   In Collection: Noisy Student
-- Name: tf_efficientnet_b5_ns
   Metadata:
-    FLOPs: 13176501888
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    FLOPs: 2275247568
+    Parameters: 12230000
+    File Size: 49385734
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -289,33 +210,8 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 122404944
     Tasks:
     - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b5_ns
-    LR: 0.128
-    Dropout: 0.5
-    Crop Pct: '0.934'
-    Momentum: 0.9
-    Image Size: '456'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-    Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1477
-  Config: ''
-  In Collection: Noisy Student
-- Name: tf_efficientnet_b6_ns
-  Metadata:
-    FLOPs: 24180518488
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
     Training Techniques:
     - AutoAugment
     - FixRes
@@ -324,53 +220,38 @@ Models:
     - RMSProp
     - RandAugment
     - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
     Training Resources: Cloud TPU v3 Pod
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 173239537
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b6_ns
+    ID: tf_efficientnet_b3_ns
     LR: 0.128
+    Epochs: 700
     Dropout: 0.5
-    Crop Pct: '0.942'
+    Crop Pct: '0.904'
     Momentum: 0.9
-    Image Size: '528'
+    Batch Size: 2048
+    Image Size: '300'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1487
-  Config: ''
-  In Collection: Noisy Student
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1457
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b3_ns-9d44bf68.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.04%
+      Top 5 Accuracy: 96.91%
 - Name: tf_efficientnet_b4_ns
+  In Collection: Noisy Student
   Metadata:
     FLOPs: 5749638672
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    Parameters: 19340000
+    File Size: 77995057
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -381,15 +262,27 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 77995057
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
     ID: tf_efficientnet_b4_ns
     LR: 0.128
+    Epochs: 700
     Dropout: 0.5
     Crop Pct: '0.922'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '380'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -398,25 +291,19 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1467
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b4_ns-d6313a46.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.15%
+      Top 5 Accuracy: 97.47%
+- Name: tf_efficientnet_b5_ns
   In Collection: Noisy Student
-- Name: tf_efficientnet_b7_ns
   Metadata:
-    FLOPs: 48205304880
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    FLOPs: 13176501888
+    Parameters: 30390000
+    File Size: 122404944
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -427,15 +314,131 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 266853140
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
+    ID: tf_efficientnet_b5_ns
+    LR: 0.128
+    Epochs: 350
+    Dropout: 0.5
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1477
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_ns-6f26d0cf.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 86.08%
+      Top 5 Accuracy: 97.75%
+- Name: tf_efficientnet_b6_ns
+  In Collection: Noisy Student
+  Metadata:
+    FLOPs: 24180518488
+    Parameters: 43040000
+    File Size: 173239537
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
+    ID: tf_efficientnet_b6_ns
+    LR: 0.128
+    Epochs: 350
+    Dropout: 0.5
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1487
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b6_ns-51548356.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 86.45%
+      Top 5 Accuracy: 97.88%
+- Name: tf_efficientnet_b7_ns
+  In Collection: Noisy Student
+  Metadata:
+    FLOPs: 48205304880
+    Parameters: 66349999
+    File Size: 266853140
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
     ID: tf_efficientnet_b7_ns
     LR: 0.128
+    Epochs: 350
     Dropout: 0.5
     Crop Pct: '0.949'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '600'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -444,13 +447,64 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1498
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b7_ns-1dbc32de.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 86.83%
+      Top 5 Accuracy: 98.08%
+- Name: tf_efficientnet_l2_ns
   In Collection: Noisy Student
-Collections:
-- Name: Noisy Student
-  Paper:
-    title: Self-training with Noisy Student improves ImageNet classification
-    url: https://paperswithcode.com//paper/self-training-with-noisy-student-improves
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 611646113804
+    Parameters: 480310000
+    File Size: 1925950424
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
+    Training Time: 6 days
+    ID: tf_efficientnet_l2_ns
+    LR: 0.128
+    Epochs: 350
+    Dropout: 0.5
+    Crop Pct: '0.96'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '800'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1520
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_l2_ns-df73bb44.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 88.35%
+      Top 5 Accuracy: 98.66%
 -->

--- a/modelindex/.templates/models/noisy-student.md
+++ b/modelindex/.templates/models/noisy-student.md
@@ -1,0 +1,456 @@
+# Summary
+
+**Noisy Student Training** is a semi-supervised learning approach. It extends the idea of self-training
+and distillation with the use of equal-or-larger student models and noise added to the student during learning. It has three main steps: 
+
+1. train a teacher model on labeled images
+2. use the teacher to generate pseudo labels on unlabeled images
+3. train a student model on the combination of labeled images and pseudo labeled images. 
+
+The algorithm is iterated a few times by treating the student as a teacher to relabel the unlabeled data and training a new student.
+
+Noisy Student Training seeks to improve on self-training and distillation in two ways. First, it makes the student larger than, or at least equal to, the teacher so the student can better learn from a larger dataset. Second, it adds noise to the student so the noised student is forced to learn harder from the pseudo labels. To noise the student, it uses input noise such as RandAugment data augmentation, and model noise such as dropout and stochastic depth during training.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{xie2020selftraining,
+      title={Self-training with Noisy Student improves ImageNet classification}, 
+      author={Qizhe Xie and Minh-Thang Luong and Eduard Hovy and Quoc V. Le},
+      year={2020},
+      eprint={1911.04252},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_b3_ns
+  Metadata:
+    FLOPs: 2275247568
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49385734
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b3_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1457
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b1_ns
+  Metadata:
+    FLOPs: 883633200
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 31516408
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b1_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1437
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_l2_ns
+  Metadata:
+    FLOPs: 611646113804
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 1925950424
+    Tasks:
+    - Image Classification
+    Training Time: 6 days
+    ID: tf_efficientnet_l2_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.96'
+    Momentum: 0.9
+    Image Size: '800'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1520
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b0_ns
+  Metadata:
+    FLOPs: 488688572
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 21386709
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b0_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1427
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b2_ns
+  Metadata:
+    FLOPs: 1234321170
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 36801803
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b2_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1447
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b5_ns
+  Metadata:
+    FLOPs: 13176501888
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 122404944
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b5_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1477
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b6_ns
+  Metadata:
+    FLOPs: 24180518488
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 173239537
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b6_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1487
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b4_ns
+  Metadata:
+    FLOPs: 5749638672
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 77995057
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b4_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1467
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b7_ns
+  Metadata:
+    FLOPs: 48205304880
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 266853140
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b7_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.949'
+    Momentum: 0.9
+    Image Size: '600'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1498
+  Config: ''
+  In Collection: Noisy Student
+Collections:
+- Name: Noisy Student
+  Paper:
+    title: Self-training with Noisy Student improves ImageNet classification
+    url: https://papperswithcode.com//paper/self-training-with-noisy-student-improves
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/noisy-student.md
+++ b/modelindex/.templates/models/noisy-student.md
@@ -450,7 +450,7 @@ Collections:
 - Name: Noisy Student
   Paper:
     title: Self-training with Noisy Student improves ImageNet classification
-    url: https://papperswithcode.com//paper/self-training-with-noisy-student-improves
+    url: https://paperswithcode.com//paper/self-training-with-noisy-student-improves
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/pnasnet.md
+++ b/modelindex/.templates/models/pnasnet.md
@@ -1,0 +1,64 @@
+# Summary
+
+**Progressive Neural Architecture Search**, or **PNAS**, is a method for learning the structure of convolutional neural networks (CNNs). It uses a sequential model-based optimization (SMBO) strategy, where we search the space of cell structures, starting with simple (shallow) models and progressing to complex ones, pruning out unpromising structures as we go. 
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{liu2018progressive,
+      title={Progressive Neural Architecture Search}, 
+      author={Chenxi Liu and Barret Zoph and Maxim Neumann and Jonathon Shlens and Wei Hua and Li-Jia Li and Li Fei-Fei and Alan Yuille and Jonathan Huang and Kevin Murphy},
+      year={2018},
+      eprint={1712.00559},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: pnasnet5large
+  Metadata:
+    FLOPs: 31458865950
+    Batch Size: 1600
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 100x NVIDIA P100 GPUs
+    Architecture:
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - ReLU
+    File Size: 345153926
+    Tasks:
+    - Image Classification
+    ID: pnasnet5large
+    LR: 0.015
+    Dropout: 0.5
+    Crop Pct: '0.911'
+    Momentum: 0.9
+    Image Size: '331'
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/pnasnet.py#L343
+  In Collection: PNASNet
+Collections:
+- Name: PNASNet
+  Paper:
+    title: Progressive Neural Architecture Search
+    url: https://papperswithcode.com//paper/progressive-neural-architecture-search
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/pnasnet.md
+++ b/modelindex/.templates/models/pnasnet.md
@@ -58,7 +58,7 @@ Collections:
 - Name: PNASNet
   Paper:
     title: Progressive Neural Architecture Search
-    url: https://papperswithcode.com//paper/progressive-neural-architecture-search
+    url: https://paperswithcode.com//paper/progressive-neural-architecture-search
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/pnasnet.md
+++ b/modelindex/.templates/models/pnasnet.md
@@ -22,18 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: PNASNet
+  Paper:
+    Title: Progressive Neural Architecture Search
+    URL: https://paperswithcode.com/paper/progressive-neural-architecture-search
 Models:
 - Name: pnasnet5large
+  In Collection: PNASNet
   Metadata:
     FLOPs: 31458865950
-    Batch Size: 1600
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 100x NVIDIA P100 GPUs
+    Parameters: 86060000
+    File Size: 345153926
     Architecture:
     - Average Pooling
     - Batch Normalization
@@ -41,24 +42,30 @@ Models:
     - Depthwise Separable Convolution
     - Dropout
     - ReLU
-    File Size: 345153926
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 100x NVIDIA P100 GPUs
     ID: pnasnet5large
     LR: 0.015
     Dropout: 0.5
     Crop Pct: '0.911'
     Momentum: 0.9
+    Batch Size: 1600
     Image Size: '331'
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/pnasnet.py#L343
-  In Collection: PNASNet
-Collections:
-- Name: PNASNet
-  Paper:
-    title: Progressive Neural Architecture Search
-    url: https://paperswithcode.com//paper/progressive-neural-architecture-search
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/pnasnet5large-bf079911.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 0.98%
+      Top 5 Accuracy: 18.58%
 -->

--- a/modelindex/.templates/models/regnetx.md
+++ b/modelindex/.templates/models/regnetx.md
@@ -26,108 +26,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: RegNetX
+  Paper:
+    Title: Designing Network Design Spaces
+    URL: https://paperswithcode.com/paper/designing-network-design-spaces
 Models:
-- Name: regnetx_040
-  Metadata:
-    FLOPs: 5095167744
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    File Size: 88844824
-    Tasks:
-    - Image Classification
-    ID: regnetx_040
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L373
-  In Collection: RegNetX
-- Name: regnetx_004
-  Metadata:
-    FLOPs: 510619136
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    File Size: 20841309
-    Tasks:
-    - Image Classification
-    ID: regnetx_004
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L343
-  In Collection: RegNetX
-- Name: regnetx_006
-  Metadata:
-    FLOPs: 771659136
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    File Size: 24965172
-    Tasks:
-    - Image Classification
-    ID: regnetx_006
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L349
-  In Collection: RegNetX
 - Name: regnetx_002
+  In Collection: RegNetX
   Metadata:
     FLOPs: 255276032
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 2680000
+    File Size: 10862199
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -136,28 +47,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 10862199
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_002
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L337
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_002-e7e85e5c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 68.75%
+      Top 5 Accuracy: 88.56%
+- Name: regnetx_004
   In Collection: RegNetX
-- Name: regnetx_008
   Metadata:
-    FLOPs: 1027038208
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    FLOPs: 510619136
+    Parameters: 5160000
+    File Size: 20841309
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -166,28 +85,112 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 29235944
     Tasks:
     - Image Classification
-    ID: regnetx_008
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_004
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L343
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_004-7d0e9424.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.39%
+      Top 5 Accuracy: 90.82%
+- Name: regnetx_006
+  In Collection: RegNetX
+  Metadata:
+    FLOPs: 771659136
+    Parameters: 6200000
+    File Size: 24965172
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_006
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 1024
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L349
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_006-85ec1baa.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.84%
+      Top 5 Accuracy: 91.68%
+- Name: regnetx_008
+  In Collection: RegNetX
+  Metadata:
+    FLOPs: 1027038208
+    Parameters: 7260000
+    File Size: 29235944
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_008
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L355
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_008-d8b470eb.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.05%
+      Top 5 Accuracy: 92.34%
 - Name: regnetx_016
+  In Collection: RegNetX
   Metadata:
     FLOPs: 2059337856
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 9190000
+    File Size: 36988158
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -196,28 +199,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 36988158
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_016
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L361
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_016-65ca972a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.95%
+      Top 5 Accuracy: 93.43%
 - Name: regnetx_032
+  In Collection: RegNetX
   Metadata:
     FLOPs: 4082555904
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 15300000
+    File Size: 61509573
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -226,28 +237,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 61509573
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_032
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L367
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_032-ed0c7f7e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.15%
+      Top 5 Accuracy: 94.09%
+- Name: regnetx_040
   In Collection: RegNetX
-- Name: regnetx_064
   Metadata:
-    FLOPs: 8303405824
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    FLOPs: 5095167744
+    Parameters: 22120000
+    File Size: 88844824
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -256,28 +275,74 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 105184854
     Tasks:
     - Image Classification
-    ID: regnetx_064
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_040
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L373
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_040-73c2a654.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.48%
+      Top 5 Accuracy: 94.25%
+- Name: regnetx_064
+  In Collection: RegNetX
+  Metadata:
+    FLOPs: 8303405824
+    Parameters: 26210000
+    File Size: 105184854
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_064
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L379
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_064-29278baa.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.06%
+      Top 5 Accuracy: 94.47%
 - Name: regnetx_080
+  In Collection: RegNetX
   Metadata:
     FLOPs: 10276726784
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 39570000
+    File Size: 158720042
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -286,28 +351,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 158720042
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_080
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L385
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_080-7c7fcab1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.21%
+      Top 5 Accuracy: 94.55%
 - Name: regnetx_120
+  In Collection: RegNetX
   Metadata:
     FLOPs: 15536378368
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 46110000
+    File Size: 184866342
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -316,28 +389,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 184866342
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_120
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L391
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_120-65d5521e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.61%
+      Top 5 Accuracy: 94.73%
 - Name: regnetx_160
+  In Collection: RegNetX
   Metadata:
     FLOPs: 20491740672
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 54280000
+    File Size: 217623862
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -346,28 +427,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 217623862
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_160
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L397
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_160-c98c4112.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.84%
+      Top 5 Accuracy: 94.82%
 - Name: regnetx_320
+  In Collection: RegNetX
   Metadata:
     FLOPs: 40798958592
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 107810000
+    File Size: 431962133
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -376,22 +465,28 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 431962133
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_320
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L403
-  In Collection: RegNetX
-Collections:
-- Name: RegNetX
-  Paper:
-    title: Designing Network Design Spaces
-    url: https://paperswithcode.com//paper/designing-network-design-spaces
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_320-8ea38b93.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.25%
+      Top 5 Accuracy: 95.03%
 -->

--- a/modelindex/.templates/models/regnetx.md
+++ b/modelindex/.templates/models/regnetx.md
@@ -1,0 +1,397 @@
+# Summary
+
+**RegNetX** is a convolutional network design space with simple, regular models with parameters: depth $d$, initial width $w\_{0} > 0$, and slope $w\_{a} > 0$, and generates a different block width $u\_{j}$ for each block $j < d$. The key restriction for the RegNet types of model is that there is a linear parameterisation of block widths (the design space only contains models with this linear structure):
+
+$$ u\_{j} = w\_{0} + w\_{a}\cdot{j} $$
+
+For **RegNetX** we have additional restrictions: we set $b = 1$ (the bottleneck ratio), $12 \leq d \leq 28$, and $w\_{m} \geq 2$ (the width multiplier).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{radosavovic2020designing,
+      title={Designing Network Design Spaces}, 
+      author={Ilija Radosavovic and Raj Prateek Kosaraju and Ross Girshick and Kaiming He and Piotr Dollár},
+      year={2020},
+      eprint={2003.13678},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: regnetx_040
+  Metadata:
+    FLOPs: 5095167744
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 88844824
+    Tasks:
+    - Image Classification
+    ID: regnetx_040
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L373
+  In Collection: RegNetX
+- Name: regnetx_004
+  Metadata:
+    FLOPs: 510619136
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 20841309
+    Tasks:
+    - Image Classification
+    ID: regnetx_004
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L343
+  In Collection: RegNetX
+- Name: regnetx_006
+  Metadata:
+    FLOPs: 771659136
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 24965172
+    Tasks:
+    - Image Classification
+    ID: regnetx_006
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L349
+  In Collection: RegNetX
+- Name: regnetx_002
+  Metadata:
+    FLOPs: 255276032
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 10862199
+    Tasks:
+    - Image Classification
+    ID: regnetx_002
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L337
+  In Collection: RegNetX
+- Name: regnetx_008
+  Metadata:
+    FLOPs: 1027038208
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 29235944
+    Tasks:
+    - Image Classification
+    ID: regnetx_008
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L355
+  In Collection: RegNetX
+- Name: regnetx_016
+  Metadata:
+    FLOPs: 2059337856
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 36988158
+    Tasks:
+    - Image Classification
+    ID: regnetx_016
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L361
+  In Collection: RegNetX
+- Name: regnetx_032
+  Metadata:
+    FLOPs: 4082555904
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 61509573
+    Tasks:
+    - Image Classification
+    ID: regnetx_032
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L367
+  In Collection: RegNetX
+- Name: regnetx_064
+  Metadata:
+    FLOPs: 8303405824
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 105184854
+    Tasks:
+    - Image Classification
+    ID: regnetx_064
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L379
+  In Collection: RegNetX
+- Name: regnetx_080
+  Metadata:
+    FLOPs: 10276726784
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 158720042
+    Tasks:
+    - Image Classification
+    ID: regnetx_080
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L385
+  In Collection: RegNetX
+- Name: regnetx_120
+  Metadata:
+    FLOPs: 15536378368
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 184866342
+    Tasks:
+    - Image Classification
+    ID: regnetx_120
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L391
+  In Collection: RegNetX
+- Name: regnetx_160
+  Metadata:
+    FLOPs: 20491740672
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 217623862
+    Tasks:
+    - Image Classification
+    ID: regnetx_160
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L397
+  In Collection: RegNetX
+- Name: regnetx_320
+  Metadata:
+    FLOPs: 40798958592
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 431962133
+    Tasks:
+    - Image Classification
+    ID: regnetx_320
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L403
+  In Collection: RegNetX
+Collections:
+- Name: RegNetX
+  Paper:
+    title: Designing Network Design Spaces
+    url: https://papperswithcode.com//paper/designing-network-design-spaces
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/regnetx.md
+++ b/modelindex/.templates/models/regnetx.md
@@ -391,7 +391,7 @@ Collections:
 - Name: RegNetX
   Paper:
     title: Designing Network Design Spaces
-    url: https://papperswithcode.com//paper/designing-network-design-spaces
+    url: https://paperswithcode.com//paper/designing-network-design-spaces
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/regnety.md
+++ b/modelindex/.templates/models/regnety.md
@@ -1,0 +1,411 @@
+# Summary
+
+**RegNetY** is a convolutional network design space with simple, regular models with parameters: depth $d$, initial width $w\_{0} > 0$, and slope $w\_{a} > 0$, and generates a different block width $u\_{j}$ for each block $j < d$. The key restriction for the RegNet types of model is that there is a linear parameterisation of block widths (the design space only contains models with this linear structure):
+
+$$ u\_{j} = w\_{0} + w\_{a}\cdot{j} $$
+
+For **RegNetX** authors have additional restrictions: we set $b = 1$ (the bottleneck ratio), $12 \leq d \leq 28$, and $w\_{m} \geq 2$ (the width multiplier).
+
+For **RegNetY** authors make one change, which is to include [Squeeze-and-Excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{radosavovic2020designing,
+      title={Designing Network Design Spaces}, 
+      author={Ilija Radosavovic and Raj Prateek Kosaraju and Ross Girshick and Kaiming He and Piotr Dollár},
+      year={2020},
+      eprint={2003.13678},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: regnety_002
+  Metadata:
+    FLOPs: 255754236
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 12782926
+    Tasks:
+    - Image Classification
+    ID: regnety_002
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L409
+  In Collection: RegNetY
+- Name: regnety_016
+  Metadata:
+    FLOPs: 2070895094
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 45115589
+    Tasks:
+    - Image Classification
+    ID: regnety_016
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L433
+  In Collection: RegNetY
+- Name: regnety_004
+  Metadata:
+    FLOPs: 515664568
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 17542753
+    Tasks:
+    - Image Classification
+    ID: regnety_004
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L415
+  In Collection: RegNetY
+- Name: regnety_006
+  Metadata:
+    FLOPs: 771746928
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 24394127
+    Tasks:
+    - Image Classification
+    ID: regnety_006
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L421
+  In Collection: RegNetY
+- Name: regnety_008
+  Metadata:
+    FLOPs: 1023448952
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 25223268
+    Tasks:
+    - Image Classification
+    ID: regnety_008
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L427
+  In Collection: RegNetY
+- Name: regnety_032
+  Metadata:
+    FLOPs: 4081118714
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 78084523
+    Tasks:
+    - Image Classification
+    ID: regnety_032
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L439
+  In Collection: RegNetY
+- Name: regnety_080
+  Metadata:
+    FLOPs: 10233621420
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 157124671
+    Tasks:
+    - Image Classification
+    ID: regnety_080
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L457
+  In Collection: RegNetY
+- Name: regnety_040
+  Metadata:
+    FLOPs: 5105933432
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 82913909
+    Tasks:
+    - Image Classification
+    ID: regnety_040
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L445
+  In Collection: RegNetY
+- Name: regnety_064
+  Metadata:
+    FLOPs: 8167730444
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 122751416
+    Tasks:
+    - Image Classification
+    ID: regnety_064
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L451
+  In Collection: RegNetY
+- Name: regnety_120
+  Metadata:
+    FLOPs: 15542094856
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 207743949
+    Tasks:
+    - Image Classification
+    ID: regnety_120
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L463
+  In Collection: RegNetY
+- Name: regnety_160
+  Metadata:
+    FLOPs: 20450196852
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 334916722
+    Tasks:
+    - Image Classification
+    ID: regnety_160
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L469
+  In Collection: RegNetY
+- Name: regnety_320
+  Metadata:
+    FLOPs: 41492618394
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 580891965
+    Tasks:
+    - Image Classification
+    ID: regnety_320
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L475
+  In Collection: RegNetY
+Collections:
+- Name: RegNetY
+  Paper:
+    title: Designing Network Design Spaces
+    url: https://papperswithcode.com//paper/designing-network-design-spaces
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/regnety.md
+++ b/modelindex/.templates/models/regnety.md
@@ -405,7 +405,7 @@ Collections:
 - Name: RegNetY
   Paper:
     title: Designing Network Design Spaces
-    url: https://papperswithcode.com//paper/designing-network-design-spaces
+    url: https://paperswithcode.com//paper/designing-network-design-spaces
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/regnety.md
+++ b/modelindex/.templates/models/regnety.md
@@ -28,18 +28,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: RegNetY
+  Paper:
+    Title: Designing Network Design Spaces
+    URL: https://paperswithcode.com/paper/designing-network-design-spaces
 Models:
 - Name: regnety_002
+  In Collection: RegNetY
   Metadata:
     FLOPs: 255754236
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 3160000
+    File Size: 12782926
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -49,59 +50,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 12782926
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_002
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L409
-  In Collection: RegNetY
-- Name: regnety_016
-  Metadata:
-    FLOPs: 2070895094
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    - Squeeze-and-Excitation Block
-    File Size: 45115589
-    Tasks:
-    - Image Classification
-    ID: regnety_016
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L433
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_002-e68ca334.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 70.28%
+      Top 5 Accuracy: 89.55%
 - Name: regnety_004
+  In Collection: RegNetY
   Metadata:
     FLOPs: 515664568
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 4340000
+    File Size: 17542753
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -111,28 +89,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 17542753
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_004
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L415
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_004-0db870e6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.02%
+      Top 5 Accuracy: 91.76%
 - Name: regnety_006
+  In Collection: RegNetY
   Metadata:
     FLOPs: 771746928
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 6060000
+    File Size: 24394127
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -142,28 +128,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 24394127
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_006
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L421
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_006-c67e57ec.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.27%
+      Top 5 Accuracy: 92.53%
 - Name: regnety_008
+  In Collection: RegNetY
   Metadata:
     FLOPs: 1023448952
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 6260000
+    File Size: 25223268
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -173,28 +167,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 25223268
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_008
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L427
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_008-dc900dbe.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.32%
+      Top 5 Accuracy: 93.07%
+- Name: regnety_016
   In Collection: RegNetY
-- Name: regnety_032
   Metadata:
-    FLOPs: 4081118714
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    FLOPs: 2070895094
+    Parameters: 11200000
+    File Size: 45115589
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -204,59 +206,75 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 78084523
     Tasks:
     - Image Classification
-    ID: regnety_032
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnety_016
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L433
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_016-54367f74.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.87%
+      Top 5 Accuracy: 93.73%
+- Name: regnety_032
+  In Collection: RegNetY
+  Metadata:
+    FLOPs: 4081118714
+    Parameters: 19440000
+    File Size: 78084523
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnety_032
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L439
-  In Collection: RegNetY
-- Name: regnety_080
-  Metadata:
-    FLOPs: 10233621420
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    - Squeeze-and-Excitation Block
-    File Size: 157124671
-    Tasks:
-    - Image Classification
-    ID: regnety_080
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L457
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/regnety_032_ra-7f2439f9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.01%
+      Top 5 Accuracy: 95.91%
 - Name: regnety_040
+  In Collection: RegNetY
   Metadata:
     FLOPs: 5105933432
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 20650000
+    File Size: 82913909
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -266,28 +284,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 82913909
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_040
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L445
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_040-f0d569f9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.23%
+      Top 5 Accuracy: 94.64%
 - Name: regnety_064
+  In Collection: RegNetY
   Metadata:
     FLOPs: 8167730444
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 30580000
+    File Size: 122751416
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -297,28 +323,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 122751416
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_064
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L451
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_064-0a48325c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.73%
+      Top 5 Accuracy: 94.76%
+- Name: regnety_080
   In Collection: RegNetY
-- Name: regnety_120
   Metadata:
-    FLOPs: 15542094856
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    FLOPs: 10233621420
+    Parameters: 39180000
+    File Size: 157124671
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -328,28 +362,75 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 207743949
     Tasks:
     - Image Classification
-    ID: regnety_120
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnety_080
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L457
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_080-e7f3eb93.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.87%
+      Top 5 Accuracy: 94.83%
+- Name: regnety_120
+  In Collection: RegNetY
+  Metadata:
+    FLOPs: 15542094856
+    Parameters: 51820000
+    File Size: 207743949
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnety_120
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L463
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_120-721ba79a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.38%
+      Top 5 Accuracy: 95.12%
 - Name: regnety_160
+  In Collection: RegNetY
   Metadata:
     FLOPs: 20450196852
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 83590000
+    File Size: 334916722
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -359,28 +440,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 334916722
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_160
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L469
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_160-d64013cd.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.28%
+      Top 5 Accuracy: 94.97%
 - Name: regnety_320
+  In Collection: RegNetY
   Metadata:
     FLOPs: 41492618394
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 145050000
+    File Size: 580891965
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -390,22 +479,28 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 580891965
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_320
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L475
-  In Collection: RegNetY
-Collections:
-- Name: RegNetY
-  Paper:
-    title: Designing Network Design Spaces
-    url: https://paperswithcode.com//paper/designing-network-design-spaces
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_320-ba464b29.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.8%
+      Top 5 Accuracy: 95.25%
 -->

--- a/modelindex/.templates/models/res2net.md
+++ b/modelindex/.templates/models/res2net.md
@@ -28,186 +28,233 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Res2Net
+  Paper:
+    Title: 'Res2Net: A New Multi-scale Backbone Architecture'
+    URL: https://paperswithcode.com/paper/res2net-a-new-multi-scale-backbone
 Models:
 - Name: res2net101_26w_4s
+  In Collection: Res2Net
   Metadata:
     FLOPs: 10415881200
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    Parameters: 45210000
+    File Size: 181456059
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2Net Block
-    File Size: 181456059
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
     ID: res2net101_26w_4s
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L152
-  In Collection: Res2Net
-- Name: res2net50_26w_6s
-  Metadata:
-    FLOPs: 8130156528
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - ReLU
-    - Res2Net Block
-    File Size: 148603239
-    Tasks:
-    - Image Classification
-    ID: res2net50_26w_6s
-    LR: 0.1
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L163
-  In Collection: Res2Net
-- Name: res2net50_26w_8s
-  Metadata:
-    FLOPs: 10760338992
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - ReLU
-    - Res2Net Block
-    File Size: 194085165
-    Tasks:
-    - Image Classification
-    ID: res2net50_26w_8s
-    LR: 0.1
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L174
-  In Collection: Res2Net
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net101_26w_4s-02a759a1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.19%
+      Top 5 Accuracy: 94.43%
 - Name: res2net50_14w_8s
+  In Collection: Res2Net
   Metadata:
     FLOPs: 5403546768
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    Parameters: 25060000
+    File Size: 100638543
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2Net Block
-    File Size: 100638543
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
     ID: res2net50_14w_8s
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L196
-  In Collection: Res2Net
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_14w_8s-6527dddc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.14%
+      Top 5 Accuracy: 93.86%
 - Name: res2net50_26w_4s
+  In Collection: Res2Net
   Metadata:
     FLOPs: 5499974064
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    Parameters: 25700000
+    File Size: 103110087
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2Net Block
-    File Size: 103110087
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
     ID: res2net50_26w_4s
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L141
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_26w_4s-06e79181.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.99%
+      Top 5 Accuracy: 93.85%
+- Name: res2net50_26w_6s
   In Collection: Res2Net
-- Name: res2net50_48w_2s
   Metadata:
-    FLOPs: 5375291520
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    FLOPs: 8130156528
+    Parameters: 37050000
+    File Size: 148603239
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2Net Block
-    File Size: 101421406
     Tasks:
     - Image Classification
-    ID: res2net50_48w_2s
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
+    ID: res2net50_26w_6s
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L163
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_26w_6s-19041792.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.57%
+      Top 5 Accuracy: 94.12%
+- Name: res2net50_26w_8s
+  In Collection: Res2Net
+  Metadata:
+    FLOPs: 10760338992
+    Parameters: 48400000
+    File Size: 194085165
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
+    ID: res2net50_26w_8s
+    LR: 0.1
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L174
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_26w_8s-2c7c9f12.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.19%
+      Top 5 Accuracy: 94.37%
+- Name: res2net50_48w_2s
+  In Collection: Res2Net
+  Metadata:
+    FLOPs: 5375291520
+    Parameters: 25290000
+    File Size: 101421406
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
+    ID: res2net50_48w_2s
+    LR: 0.1
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L185
-  In Collection: Res2Net
-Collections:
-- Name: Res2Net
-  Paper:
-    title: 'Res2Net: A New Multi-scale Backbone Architecture'
-    url: https://paperswithcode.com//paper/res2net-a-new-multi-scale-backbone
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_48w_2s-afed724a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.53%
+      Top 5 Accuracy: 93.56%
 -->

--- a/modelindex/.templates/models/res2net.md
+++ b/modelindex/.templates/models/res2net.md
@@ -1,0 +1,213 @@
+# Summary
+
+**Res2Net** is an image model that employs a variation on bottleneck residual blocks, [Res2Net Blocks](https://paperswithcode.com/method/res2net-block). The motivation is to be able to represent features at multiple scales. This is achieved through a novel building block for CNNs that constructs hierarchical residual-like connections within one single residual block. This represents multi-scale features at a granular level and increases the range of receptive fields for each network layer.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{Gao_2021,
+   title={Res2Net: A New Multi-Scale Backbone Architecture},
+   volume={43},
+   ISSN={1939-3539},
+   url={http://dx.doi.org/10.1109/TPAMI.2019.2938758},
+   DOI={10.1109/tpami.2019.2938758},
+   number={2},
+   journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
+   publisher={Institute of Electrical and Electronics Engineers (IEEE)},
+   author={Gao, Shang-Hua and Cheng, Ming-Ming and Zhao, Kai and Zhang, Xin-Yu and Yang, Ming-Hsuan and Torr, Philip},
+   year={2021},
+   month={Feb},
+   pages={652–662}
+}
+```
+
+<!--
+Models:
+- Name: res2net101_26w_4s
+  Metadata:
+    FLOPs: 10415881200
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 181456059
+    Tasks:
+    - Image Classification
+    ID: res2net101_26w_4s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L152
+  In Collection: Res2Net
+- Name: res2net50_26w_6s
+  Metadata:
+    FLOPs: 8130156528
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 148603239
+    Tasks:
+    - Image Classification
+    ID: res2net50_26w_6s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L163
+  In Collection: Res2Net
+- Name: res2net50_26w_8s
+  Metadata:
+    FLOPs: 10760338992
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 194085165
+    Tasks:
+    - Image Classification
+    ID: res2net50_26w_8s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L174
+  In Collection: Res2Net
+- Name: res2net50_14w_8s
+  Metadata:
+    FLOPs: 5403546768
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 100638543
+    Tasks:
+    - Image Classification
+    ID: res2net50_14w_8s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L196
+  In Collection: Res2Net
+- Name: res2net50_26w_4s
+  Metadata:
+    FLOPs: 5499974064
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 103110087
+    Tasks:
+    - Image Classification
+    ID: res2net50_26w_4s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L141
+  In Collection: Res2Net
+- Name: res2net50_48w_2s
+  Metadata:
+    FLOPs: 5375291520
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 101421406
+    Tasks:
+    - Image Classification
+    ID: res2net50_48w_2s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L185
+  In Collection: Res2Net
+Collections:
+- Name: Res2Net
+  Paper:
+    title: 'Res2Net: A New Multi-scale Backbone Architecture'
+    url: https://papperswithcode.com//paper/res2net-a-new-multi-scale-backbone
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/res2net.md
+++ b/modelindex/.templates/models/res2net.md
@@ -207,7 +207,7 @@ Collections:
 - Name: Res2Net
   Paper:
     title: 'Res2Net: A New Multi-scale Backbone Architecture'
-    url: https://papperswithcode.com//paper/res2net-a-new-multi-scale-backbone
+    url: https://paperswithcode.com//paper/res2net-a-new-multi-scale-backbone
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/res2next.md
+++ b/modelindex/.templates/models/res2next.md
@@ -62,7 +62,7 @@ Collections:
 - Name: Res2NeXt
   Paper:
     title: 'Res2Net: A New Multi-scale Backbone Architecture'
-    url: https://papperswithcode.com//paper/res2net-a-new-multi-scale-backbone
+    url: https://paperswithcode.com//paper/res2net-a-new-multi-scale-backbone
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/res2next.md
+++ b/modelindex/.templates/models/res2next.md
@@ -28,41 +28,48 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Res2NeXt
+  Paper:
+    Title: 'Res2Net: A New Multi-scale Backbone Architecture'
+    URL: https://paperswithcode.com/paper/res2net-a-new-multi-scale-backbone
 Models:
 - Name: res2next50
+  In Collection: Res2NeXt
   Metadata:
     FLOPs: 5396798208
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    Parameters: 24670000
+    File Size: 99019592
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2NeXt Block
-    File Size: 99019592
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
     ID: res2next50
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L207
-  In Collection: Res2NeXt
-Collections:
-- Name: Res2NeXt
-  Paper:
-    title: 'Res2Net: A New Multi-scale Backbone Architecture'
-    url: https://paperswithcode.com//paper/res2net-a-new-multi-scale-backbone
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2next50_4s-6ef7e7bf.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.24%
+      Top 5 Accuracy: 93.91%
 -->

--- a/modelindex/.templates/models/res2next.md
+++ b/modelindex/.templates/models/res2next.md
@@ -1,0 +1,68 @@
+# Summary
+
+**Res2Net** is an image model that employs a variation on [ResNeXt](https://paperswithcode.com/method/resnext) bottleneck residual blocks. The motivation is to be able to represent features at multiple scales. This is achieved through a novel building block for CNNs that constructs hierarchical residual-like connections within one single residual block. This represents multi-scale features at a granular level and increases the range of receptive fields for each network layer.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{Gao_2021,
+   title={Res2Net: A New Multi-Scale Backbone Architecture},
+   volume={43},
+   ISSN={1939-3539},
+   url={http://dx.doi.org/10.1109/TPAMI.2019.2938758},
+   DOI={10.1109/tpami.2019.2938758},
+   number={2},
+   journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
+   publisher={Institute of Electrical and Electronics Engineers (IEEE)},
+   author={Gao, Shang-Hua and Cheng, Ming-Ming and Zhao, Kai and Zhang, Xin-Yu and Yang, Ming-Hsuan and Torr, Philip},
+   year={2021},
+   month={Feb},
+   pages={652–662}
+}
+```
+
+<!--
+Models:
+- Name: res2next50
+  Metadata:
+    FLOPs: 5396798208
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2NeXt Block
+    File Size: 99019592
+    Tasks:
+    - Image Classification
+    ID: res2next50
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L207
+  In Collection: Res2NeXt
+Collections:
+- Name: Res2NeXt
+  Paper:
+    title: 'Res2Net: A New Multi-scale Backbone Architecture'
+    url: https://papperswithcode.com//paper/res2net-a-new-multi-scale-backbone
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/resnest.md
+++ b/modelindex/.templates/models/resnest.md
@@ -22,145 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ResNeSt
+  Paper:
+    Title: 'ResNeSt: Split-Attention Networks'
+    URL: https://paperswithcode.com/paper/resnest-split-attention-networks
 Models:
-- Name: resnest50d_4s2x40d
-  Metadata:
-    FLOPs: 5657064720
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Connection
-    - Softmax
-    - Split Attention
-    File Size: 122133282
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnest50d_4s2x40d
-    LR: 0.1
-    Layers: 50
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L218
-  Config: ''
-  In Collection: ResNeSt
-- Name: resnest200e
-  Metadata:
-    FLOPs: 45954387872
-    Epochs: 270
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Connection
-    - Softmax
-    - Split Attention
-    File Size: 193782911
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnest200e
-    LR: 0.1
-    Layers: 200
-    Dropout: 0.2
-    Crop Pct: '0.909'
-    Momentum: 0.9
-    Image Size: '320'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L194
-  Config: ''
-  In Collection: ResNeSt
-- Name: resnest14d
-  Metadata:
-    FLOPs: 3548594464
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Connection
-    - Softmax
-    - Split Attention
-    File Size: 42562639
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnest14d
-    LR: 0.1
-    Layers: 14
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L148
-  Config: ''
-  In Collection: ResNeSt
 - Name: resnest101e
+  In Collection: ResNeSt
   Metadata:
     FLOPs: 17423183648
-    Epochs: 270
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    Parameters: 48280000
+    File Size: 193782911
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -171,37 +45,43 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 193782911
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest101e
     LR: 0.1
+    Epochs: 270
     Layers: 101
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '256'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L182
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest101-22405ba7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.88%
+      Top 5 Accuracy: 96.31%
+- Name: resnest14d
   In Collection: ResNeSt
-- Name: resnest269e
   Metadata:
-    FLOPs: 100830307104
-    Epochs: 270
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    FLOPs: 3548594464
+    Parameters: 10610000
+    File Size: 42562639
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -212,37 +92,137 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 445402691
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
+    ID: resnest14d
+    LR: 0.1
+    Epochs: 270
+    Layers: 14
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 8192
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L148
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/gluon_resnest14-9c8fe254.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.51%
+      Top 5 Accuracy: 92.52%
+- Name: resnest200e
+  In Collection: ResNeSt
+  Metadata:
+    FLOPs: 45954387872
+    Parameters: 70200000
+    File Size: 193782911
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
+    ID: resnest200e
+    LR: 0.1
+    Epochs: 270
+    Layers: 200
+    Dropout: 0.2
+    Crop Pct: '0.909'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '320'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L194
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest101-22405ba7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.85%
+      Top 5 Accuracy: 96.89%
+- Name: resnest269e
+  In Collection: ResNeSt
+  Metadata:
+    FLOPs: 100830307104
+    Parameters: 110930000
+    File Size: 445402691
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest269e
     LR: 0.1
+    Epochs: 270
     Layers: 269
     Dropout: 0.2
     Crop Pct: '0.928'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '416'
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L206
-  Config: ''
-  In Collection: ResNeSt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest269-0cc87c48.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.53%
+      Top 5 Accuracy: 96.99%
 - Name: resnest26d
+  In Collection: ResNeSt
   Metadata:
     FLOPs: 4678918720
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    Parameters: 17070000
+    File Size: 68470242
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -253,37 +233,43 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 68470242
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest26d
     LR: 0.1
+    Epochs: 270
     Layers: 26
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8192
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L159
-  Config: ''
-  In Collection: ResNeSt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/gluon_resnest26-50eb607c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.48%
+      Top 5 Accuracy: 94.3%
 - Name: resnest50d
+  In Collection: ResNeSt
   Metadata:
     FLOPs: 6937106336
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    Parameters: 27480000
+    File Size: 110273258
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -294,37 +280,43 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 110273258
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest50d
     LR: 0.1
+    Epochs: 270
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8192
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L170
-  Config: ''
-  In Collection: ResNeSt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest50-528c19ca.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.96%
+      Top 5 Accuracy: 95.38%
 - Name: resnest50d_1s4x24d
+  In Collection: ResNeSt
   Metadata:
     FLOPs: 5686764544
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    Parameters: 25680000
+    File Size: 103045531
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -335,25 +327,82 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 103045531
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest50d_1s4x24d
     LR: 0.1
+    Epochs: 270
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8192
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L229
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest50_fast_1s4x24d-d4a4f76f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.0%
+      Top 5 Accuracy: 95.33%
+- Name: resnest50d_4s2x40d
   In Collection: ResNeSt
-Collections:
-- Name: ResNeSt
-  Paper:
-    title: 'ResNeSt: Split-Attention Networks'
-    url: https://paperswithcode.com//paper/resnest-split-attention-networks
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5657064720
+    Parameters: 30420000
+    File Size: 122133282
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
+    ID: resnest50d_4s2x40d
+    LR: 0.1
+    Epochs: 270
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 8192
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L218
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest50_fast_4s2x40d-41d14ed0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.11%
+      Top 5 Accuracy: 95.55%
 -->

--- a/modelindex/.templates/models/resnest.md
+++ b/modelindex/.templates/models/resnest.md
@@ -1,0 +1,359 @@
+# Summary
+
+A **ResNest** is a variant on a [ResNet](https://paperswithcode.com/method/resnet), which instead stacks [Split-Attention blocks](https://paperswithcode.com/method/split-attention). The cardinal group representations are then concatenated along the channel dimension: $V = \text{Concat}${$V^{1},V^{2},\cdots{V}^{K}$}. As in standard residual blocks, the final output $Y$ of otheur Split-Attention block is produced using a shortcut connection: $Y=V+X$, if the input and output feature-map share the same shape.  For blocks with a stride, an appropriate transformation $\mathcal{T}$ is applied to the shortcut connection to align the output shapes:  $Y=V+\mathcal{T}(X)$. For example, $\mathcal{T}$ can be strided convolution or combined convolution-with-pooling.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{zhang2020resnest,
+      title={ResNeSt: Split-Attention Networks}, 
+      author={Hang Zhang and Chongruo Wu and Zhongyue Zhang and Yi Zhu and Haibin Lin and Zhi Zhang and Yue Sun and Tong He and Jonas Mueller and R. Manmatha and Mu Li and Alexander Smola},
+      year={2020},
+      eprint={2004.08955},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: resnest50d_4s2x40d
+  Metadata:
+    FLOPs: 5657064720
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 122133282
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest50d_4s2x40d
+    LR: 0.1
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L218
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest200e
+  Metadata:
+    FLOPs: 45954387872
+    Epochs: 270
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 193782911
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest200e
+    LR: 0.1
+    Layers: 200
+    Dropout: 0.2
+    Crop Pct: '0.909'
+    Momentum: 0.9
+    Image Size: '320'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L194
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest14d
+  Metadata:
+    FLOPs: 3548594464
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 42562639
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest14d
+    LR: 0.1
+    Layers: 14
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L148
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest101e
+  Metadata:
+    FLOPs: 17423183648
+    Epochs: 270
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 193782911
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest101e
+    LR: 0.1
+    Layers: 101
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '256'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L182
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest269e
+  Metadata:
+    FLOPs: 100830307104
+    Epochs: 270
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 445402691
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest269e
+    LR: 0.1
+    Layers: 269
+    Dropout: 0.2
+    Crop Pct: '0.928'
+    Momentum: 0.9
+    Image Size: '416'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L206
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest26d
+  Metadata:
+    FLOPs: 4678918720
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 68470242
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest26d
+    LR: 0.1
+    Layers: 26
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L159
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest50d
+  Metadata:
+    FLOPs: 6937106336
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 110273258
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest50d
+    LR: 0.1
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L170
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest50d_1s4x24d
+  Metadata:
+    FLOPs: 5686764544
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 103045531
+    Tasks:
+    - Image Classification
+    ID: resnest50d_1s4x24d
+    LR: 0.1
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L229
+  In Collection: ResNeSt
+Collections:
+- Name: ResNeSt
+  Paper:
+    title: 'ResNeSt: Split-Attention Networks'
+    url: https://papperswithcode.com//paper/resnest-split-attention-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/resnest.md
+++ b/modelindex/.templates/models/resnest.md
@@ -353,7 +353,7 @@ Collections:
 - Name: ResNeSt
   Paper:
     title: 'ResNeSt: Split-Attention Networks'
-    url: https://papperswithcode.com//paper/resnest-split-attention-networks
+    url: https://paperswithcode.com//paper/resnest-split-attention-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/resnet-d.md
+++ b/modelindex/.templates/models/resnet-d.md
@@ -1,0 +1,208 @@
+# Summary
+
+**ResNet-D** is a modification on the [ResNet](https://paperswithcode.com/method/resnet) architecture that utilises an [average pooling](https://paperswithcode.com/method/average-pooling) tweak for downsampling. The motivation is that in the unmodified ResNet, the [1×1 convolution](https://paperswithcode.com/method/1x1-convolution) for the downsampling block ignores 3/4 of input feature maps, so this is modified so no information will be ignored
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{he2018bag,
+      title={Bag of Tricks for Image Classification with Convolutional Neural Networks}, 
+      author={Tong He and Zhi Zhang and Hang Zhang and Zhongyue Zhang and Junyuan Xie and Mu Li},
+      year={2018},
+      eprint={1812.01187},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: resnet50d
+  Metadata:
+    FLOPs: 5591002624
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102567109
+    Tasks:
+    - Image Classification
+    ID: resnet50d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L699
+  In Collection: ResNet-D
+- Name: resnet26d
+  Metadata:
+    FLOPs: 3335276032
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 64209122
+    Tasks:
+    - Image Classification
+    ID: resnet26d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L683
+  In Collection: ResNet-D
+- Name: resnet18d
+  Metadata:
+    FLOPs: 2645205760
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46893231
+    Tasks:
+    - Image Classification
+    ID: resnet18d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L649
+  In Collection: ResNet-D
+- Name: resnet34d
+  Metadata:
+    FLOPs: 5026601728
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 87369807
+    Tasks:
+    - Image Classification
+    ID: resnet34d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L666
+  In Collection: ResNet-D
+- Name: resnet200d
+  Metadata:
+    FLOPs: 26034378752
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 259662933
+    Tasks:
+    - Image Classification
+    ID: resnet200d
+    Crop Pct: '0.94'
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L749
+  In Collection: ResNet-D
+- Name: resnet101d
+  Metadata:
+    FLOPs: 13805639680
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178791263
+    Tasks:
+    - Image Classification
+    ID: resnet101d
+    Crop Pct: '0.94'
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L716
+  In Collection: ResNet-D
+- Name: resnet152d
+  Metadata:
+    FLOPs: 20155275264
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241596837
+    Tasks:
+    - Image Classification
+    ID: resnet152d
+    Crop Pct: '0.94'
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L724
+  In Collection: ResNet-D
+Collections:
+- Name: ResNet-D
+  Paper:
+    title: Bag of Tricks for Image Classification with Convolutional Neural Networks
+    url: https://papperswithcode.com//paper/bag-of-tricks-for-image-classification-with
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/resnet-d.md
+++ b/modelindex/.templates/models/resnet-d.md
@@ -202,7 +202,7 @@ Collections:
 - Name: ResNet-D
   Paper:
     title: Bag of Tricks for Image Classification with Convolutional Neural Networks
-    url: https://papperswithcode.com//paper/bag-of-tricks-for-image-classification-with
+    url: https://paperswithcode.com//paper/bag-of-tricks-for-image-classification-with
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/resnet-d.md
+++ b/modelindex/.templates/models/resnet-d.md
@@ -22,137 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ResNet-D
+  Paper:
+    Title: Bag of Tricks for Image Classification with Convolutional Neural Networks
+    URL: https://paperswithcode.com/paper/bag-of-tricks-for-image-classification-with
 Models:
-- Name: resnet50d
-  Metadata:
-    FLOPs: 5591002624
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 102567109
-    Tasks:
-    - Image Classification
-    ID: resnet50d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L699
-  In Collection: ResNet-D
-- Name: resnet26d
-  Metadata:
-    FLOPs: 3335276032
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 64209122
-    Tasks:
-    - Image Classification
-    ID: resnet26d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L683
-  In Collection: ResNet-D
-- Name: resnet18d
-  Metadata:
-    FLOPs: 2645205760
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 46893231
-    Tasks:
-    - Image Classification
-    ID: resnet18d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L649
-  In Collection: ResNet-D
-- Name: resnet34d
-  Metadata:
-    FLOPs: 5026601728
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 87369807
-    Tasks:
-    - Image Classification
-    ID: resnet34d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L666
-  In Collection: ResNet-D
-- Name: resnet200d
-  Metadata:
-    FLOPs: 26034378752
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 259662933
-    Tasks:
-    - Image Classification
-    ID: resnet200d
-    Crop Pct: '0.94'
-    Image Size: '256'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L749
-  In Collection: ResNet-D
 - Name: resnet101d
+  In Collection: ResNet-D
   Metadata:
     FLOPs: 13805639680
-    Training Data:
-    - ImageNet
+    Parameters: 44570000
+    File Size: 178791263
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -164,20 +46,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178791263
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnet101d
     Crop Pct: '0.94'
     Image Size: '256'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L716
-  In Collection: ResNet-D
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet101d_ra2-2803ffab.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.31%
+      Top 5 Accuracy: 96.06%
 - Name: resnet152d
+  In Collection: ResNet-D
   Metadata:
     FLOPs: 20155275264
-    Training Data:
-    - ImageNet
+    Parameters: 60210000
+    File Size: 241596837
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -189,20 +79,185 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 241596837
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnet152d
     Crop Pct: '0.94'
     Image Size: '256'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L724
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet152d_ra2-5cac0439.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.13%
+      Top 5 Accuracy: 96.35%
+- Name: resnet18d
   In Collection: ResNet-D
-Collections:
-- Name: ResNet-D
-  Paper:
-    title: Bag of Tricks for Image Classification with Convolutional Neural Networks
-    url: https://paperswithcode.com//paper/bag-of-tricks-for-image-classification-with
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 2645205760
+    Parameters: 11710000
+    File Size: 46893231
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet18d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L649
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet18d_ra2-48a79e06.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.27%
+      Top 5 Accuracy: 90.69%
+- Name: resnet200d
+  In Collection: ResNet-D
+  Metadata:
+    FLOPs: 26034378752
+    Parameters: 64690000
+    File Size: 259662933
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet200d
+    Crop Pct: '0.94'
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L749
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet200d_ra2-bdba9bf9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.24%
+      Top 5 Accuracy: 96.49%
+- Name: resnet26d
+  In Collection: ResNet-D
+  Metadata:
+    FLOPs: 3335276032
+    Parameters: 16010000
+    File Size: 64209122
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet26d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L683
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet26d-69e92c46.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.69%
+      Top 5 Accuracy: 93.15%
+- Name: resnet34d
+  In Collection: ResNet-D
+  Metadata:
+    FLOPs: 5026601728
+    Parameters: 21820000
+    File Size: 87369807
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet34d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L666
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet34d_ra2-f8dcfcaf.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.11%
+      Top 5 Accuracy: 93.38%
+- Name: resnet50d
+  In Collection: ResNet-D
+  Metadata:
+    FLOPs: 5591002624
+    Parameters: 25580000
+    File Size: 102567109
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet50d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L699
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet50d_ra2-464e36ba.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.55%
+      Top 5 Accuracy: 95.16%
 -->

--- a/modelindex/.templates/models/resnet.md
+++ b/modelindex/.templates/models/resnet.md
@@ -30,72 +30,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ResNet
+  Paper:
+    Title: Deep Residual Learning for Image Recognition
+    URL: https://paperswithcode.com/paper/deep-residual-learning-for-image-recognition
 Models:
-- Name: resnet26
-  Metadata:
-    FLOPs: 3026804736
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 64129972
-    Tasks:
-    - Image Classification
-    ID: resnet26
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L675
-  In Collection: ResNet
-- Name: tv_resnet152
-  Metadata:
-    FLOPs: 14857660416
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 241530880
-    Tasks:
-    - Image Classification
-    ID: tv_resnet152
-    LR: 0.1
-    Crop Pct: '0.875'
-    LR Gamma: 0.1
-    Momentum: 0.9
-    Image Size: '224'
-    LR Step Size: 30
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L769
-  In Collection: ResNet
 - Name: resnet18
+  In Collection: ResNet
   Metadata:
     FLOPs: 2337073152
-    Training Data:
-    - ImageNet
+    Parameters: 11690000
+    File Size: 46827520
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -107,20 +54,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 46827520
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnet18
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L641
+  Weights: https://download.pytorch.org/models/resnet18-5c106cde.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 69.74%
+      Top 5 Accuracy: 89.09%
+- Name: resnet26
   In Collection: ResNet
-- Name: resnet50
   Metadata:
-    FLOPs: 5282531328
-    Training Data:
-    - ImageNet
+    FLOPs: 3026804736
+    Parameters: 16000000
+    File Size: 64129972
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -132,20 +87,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102488165
     Tasks:
     - Image Classification
-    ID: resnet50
+    Training Data:
+    - ImageNet
+    ID: resnet26
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L691
-  In Collection: ResNet
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L675
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet26-9aa10e23.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.29%
+      Top 5 Accuracy: 92.57%
 - Name: resnet34
+  In Collection: ResNet
   Metadata:
     FLOPs: 4718469120
-    Training Data:
-    - ImageNet
+    Parameters: 21800000
+    File Size: 87290831
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -157,20 +120,61 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 87290831
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnet34
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L658
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet34-43635321.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.11%
+      Top 5 Accuracy: 92.28%
+- Name: resnet50
   In Collection: ResNet
-- Name: resnetblur50
   Metadata:
-    FLOPs: 6621606912
+    FLOPs: 5282531328
+    Parameters: 25560000
+    File Size: 102488165
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
     Training Data:
     - ImageNet
+    ID: resnet50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L691
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet50_ram-a26f946b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.04%
+      Top 5 Accuracy: 94.39%
+- Name: resnetblur50
+  In Collection: ResNet
+  Metadata:
+    FLOPs: 6621606912
+    Parameters: 25560000
+    File Size: 102488165
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -183,60 +187,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102488165
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnetblur50
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L1160
-  In Collection: ResNet
-- Name: tv_resnet34
-  Metadata:
-    FLOPs: 4718469120
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 87306240
-    Tasks:
-    - Image Classification
-    ID: tv_resnet34
-    LR: 0.1
-    Crop Pct: '0.875'
-    LR Gamma: 0.1
-    Momentum: 0.9
-    Image Size: '224'
-    LR Step Size: 30
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L745
-  In Collection: ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnetblur50-84f4748f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.29%
+      Top 5 Accuracy: 94.64%
 - Name: tv_resnet101
+  In Collection: ResNet
   Metadata:
     FLOPs: 10068547584
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    Parameters: 44550000
+    File Size: 178728960
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -248,30 +220,38 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178728960
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tv_resnet101
     LR: 0.1
+    Epochs: 90
     Crop Pct: '0.875'
     LR Gamma: 0.1
     Momentum: 0.9
+    Batch Size: 32
     Image Size: '224'
     LR Step Size: 30
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L761
+  Weights: https://download.pytorch.org/models/resnet101-5d3b4d8f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.37%
+      Top 5 Accuracy: 93.56%
+- Name: tv_resnet152
   In Collection: ResNet
-- Name: tv_resnet50
   Metadata:
-    FLOPs: 5282531328
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    FLOPs: 14857660416
+    Parameters: 60190000
+    File Size: 241530880
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -283,25 +263,116 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102502400
     Tasks:
     - Image Classification
-    ID: tv_resnet50
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tv_resnet152
     LR: 0.1
+    Epochs: 90
     Crop Pct: '0.875'
     LR Gamma: 0.1
     Momentum: 0.9
+    Batch Size: 32
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L769
+  Weights: https://download.pytorch.org/models/resnet152-b121ed2d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.32%
+      Top 5 Accuracy: 94.05%
+- Name: tv_resnet34
+  In Collection: ResNet
+  Metadata:
+    FLOPs: 4718469120
+    Parameters: 21800000
+    File Size: 87306240
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tv_resnet34
+    LR: 0.1
+    Epochs: 90
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Batch Size: 32
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L745
+  Weights: https://download.pytorch.org/models/resnet34-333f7ec4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.3%
+      Top 5 Accuracy: 91.42%
+- Name: tv_resnet50
+  In Collection: ResNet
+  Metadata:
+    FLOPs: 5282531328
+    Parameters: 25560000
+    File Size: 102502400
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tv_resnet50
+    LR: 0.1
+    Epochs: 90
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Batch Size: 32
     Image Size: '224'
     LR Step Size: 30
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L753
-  In Collection: ResNet
-Collections:
-- Name: ResNet
-  Paper:
-    title: Deep Residual Learning for Image Recognition
-    url: https://paperswithcode.com//paper/deep-residual-learning-for-image-recognition
-  type: model-index
-Type: model-index
+  Weights: https://download.pytorch.org/models/resnet50-19c8e357.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.16%
+      Top 5 Accuracy: 92.88%
 -->

--- a/modelindex/.templates/models/resnet.md
+++ b/modelindex/.templates/models/resnet.md
@@ -301,7 +301,7 @@ Collections:
 - Name: ResNet
   Paper:
     title: Deep Residual Learning for Image Recognition
-    url: https://papperswithcode.com//paper/deep-residual-learning-for-image-recognition
+    url: https://paperswithcode.com//paper/deep-residual-learning-for-image-recognition
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/resnet.md
+++ b/modelindex/.templates/models/resnet.md
@@ -1,0 +1,307 @@
+# Summary
+
+**Residual Networks**, or **ResNets**, learn residual functions with reference to the layer inputs, instead of learning unreferenced functions. Instead of hoping each few stacked layers directly fit a desired underlying mapping, residual nets let these layers fit a residual mapping. They stack [residual blocks](https://paperswithcode.com/method/residual-block) ontop of each other to form network: e.g. a ResNet-50 has fifty layers using these blocks. 
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/HeZRS15,
+  author    = {Kaiming He and
+               Xiangyu Zhang and
+               Shaoqing Ren and
+               Jian Sun},
+  title     = {Deep Residual Learning for Image Recognition},
+  journal   = {CoRR},
+  volume    = {abs/1512.03385},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.03385},
+  archivePrefix = {arXiv},
+  eprint    = {1512.03385},
+  timestamp = {Wed, 17 Apr 2019 17:23:45 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/HeZRS15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: resnet26
+  Metadata:
+    FLOPs: 3026804736
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 64129972
+    Tasks:
+    - Image Classification
+    ID: resnet26
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L675
+  In Collection: ResNet
+- Name: tv_resnet152
+  Metadata:
+    FLOPs: 14857660416
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241530880
+    Tasks:
+    - Image Classification
+    ID: tv_resnet152
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L769
+  In Collection: ResNet
+- Name: resnet18
+  Metadata:
+    FLOPs: 2337073152
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46827520
+    Tasks:
+    - Image Classification
+    ID: resnet18
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L641
+  In Collection: ResNet
+- Name: resnet50
+  Metadata:
+    FLOPs: 5282531328
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102488165
+    Tasks:
+    - Image Classification
+    ID: resnet50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L691
+  In Collection: ResNet
+- Name: resnet34
+  Metadata:
+    FLOPs: 4718469120
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 87290831
+    Tasks:
+    - Image Classification
+    ID: resnet34
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L658
+  In Collection: ResNet
+- Name: resnetblur50
+  Metadata:
+    FLOPs: 6621606912
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Blur Pooling
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102488165
+    Tasks:
+    - Image Classification
+    ID: resnetblur50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L1160
+  In Collection: ResNet
+- Name: tv_resnet34
+  Metadata:
+    FLOPs: 4718469120
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 87306240
+    Tasks:
+    - Image Classification
+    ID: tv_resnet34
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L745
+  In Collection: ResNet
+- Name: tv_resnet101
+  Metadata:
+    FLOPs: 10068547584
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178728960
+    Tasks:
+    - Image Classification
+    ID: tv_resnet101
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L761
+  In Collection: ResNet
+- Name: tv_resnet50
+  Metadata:
+    FLOPs: 5282531328
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102502400
+    Tasks:
+    - Image Classification
+    ID: tv_resnet50
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L753
+  In Collection: ResNet
+Collections:
+- Name: ResNet
+  Paper:
+    title: Deep Residual Learning for Image Recognition
+    url: https://papperswithcode.com//paper/deep-residual-learning-for-image-recognition
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/resnext.md
+++ b/modelindex/.templates/models/resnext.md
@@ -31,12 +31,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ResNeXt
+  Paper:
+    Title: Aggregated Residual Transformations for Deep Neural Networks
+    URL: https://paperswithcode.com/paper/aggregated-residual-transformations-for-deep
 Models:
 - Name: resnext101_32x8d
+  In Collection: ResNeXt
   Metadata:
     FLOPs: 21180417024
-    Training Data:
-    - ImageNet
+    Parameters: 88790000
+    File Size: 356082095
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -48,20 +55,28 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 356082095
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnext101_32x8d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L877
-  In Collection: ResNeXt
+  Weights: https://download.pytorch.org/models/resnext101_32x8d-8ba56ff5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.3%
+      Top 5 Accuracy: 94.53%
 - Name: resnext50_32x4d
+  In Collection: ResNeXt
   Metadata:
     FLOPs: 5472648192
-    Training Data:
-    - ImageNet
+    Parameters: 25030000
+    File Size: 100435887
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -73,55 +88,28 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 100435887
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnext50_32x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L851
-  In Collection: ResNeXt
-- Name: tv_resnext50_32x4d
-  Metadata:
-    FLOPs: 5472648192
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 100441675
-    Tasks:
-    - Image Classification
-    ID: tv_resnext50_32x4d
-    LR: 0.1
-    Crop Pct: '0.875'
-    LR Gamma: 0.1
-    Momentum: 0.9
-    Image Size: '224'
-    LR Step Size: 30
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L842
-  In Collection: ResNeXt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnext50_32x4d_ra-d733960d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.79%
+      Top 5 Accuracy: 94.61%
 - Name: resnext50d_32x4d
+  In Collection: ResNeXt
   Metadata:
     FLOPs: 5781119488
-    Training Data:
-    - ImageNet
+    Parameters: 25050000
+    File Size: 100515304
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -133,20 +121,63 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 100515304
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnext50d_32x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L869
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnext50d_32x4d-103e99f8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.67%
+      Top 5 Accuracy: 94.87%
+- Name: tv_resnext50_32x4d
   In Collection: ResNeXt
-Collections:
-- Name: ResNeXt
-  Paper:
-    title: Aggregated Residual Transformations for Deep Neural Networks
-    url: https://paperswithcode.com//paper/aggregated-residual-transformations-for-deep
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5472648192
+    Parameters: 25030000
+    File Size: 100441675
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tv_resnext50_32x4d
+    LR: 0.1
+    Epochs: 90
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Batch Size: 32
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L842
+  Weights: https://download.pytorch.org/models/resnext50_32x4d-7cdf4587.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.61%
+      Top 5 Accuracy: 93.68%
 -->

--- a/modelindex/.templates/models/resnext.md
+++ b/modelindex/.templates/models/resnext.md
@@ -146,7 +146,7 @@ Collections:
 - Name: ResNeXt
   Paper:
     title: Aggregated Residual Transformations for Deep Neural Networks
-    url: https://papperswithcode.com//paper/aggregated-residual-transformations-for-deep
+    url: https://paperswithcode.com//paper/aggregated-residual-transformations-for-deep
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/resnext.md
+++ b/modelindex/.templates/models/resnext.md
@@ -1,0 +1,152 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/XieGDTH16,
+  author    = {Saining Xie and
+               Ross B. Girshick and
+               Piotr Doll{\'{a}}r and
+               Zhuowen Tu and
+               Kaiming He},
+  title     = {Aggregated Residual Transformations for Deep Neural Networks},
+  journal   = {CoRR},
+  volume    = {abs/1611.05431},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1611.05431},
+  archivePrefix = {arXiv},
+  eprint    = {1611.05431},
+  timestamp = {Mon, 13 Aug 2018 16:45:58 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/XieGDTH16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: resnext101_32x8d
+  Metadata:
+    FLOPs: 21180417024
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 356082095
+    Tasks:
+    - Image Classification
+    ID: resnext101_32x8d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L877
+  In Collection: ResNeXt
+- Name: resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100435887
+    Tasks:
+    - Image Classification
+    ID: resnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L851
+  In Collection: ResNeXt
+- Name: tv_resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100441675
+    Tasks:
+    - Image Classification
+    ID: tv_resnext50_32x4d
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L842
+  In Collection: ResNeXt
+- Name: resnext50d_32x4d
+  Metadata:
+    FLOPs: 5781119488
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100515304
+    Tasks:
+    - Image Classification
+    ID: resnext50d_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L869
+  In Collection: ResNeXt
+Collections:
+- Name: ResNeXt
+  Paper:
+    title: Aggregated Residual Transformations for Deep Neural Networks
+    url: https://papperswithcode.com//paper/aggregated-residual-transformations-for-deep
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/rexnet.md
+++ b/modelindex/.templates/models/rexnet.md
@@ -168,7 +168,7 @@ Collections:
   Paper:
     title: 'ReXNet: Diminishing Representational Bottleneck on Convolutional Neural
       Network'
-    url: https://papperswithcode.com//paper/rexnet-diminishing-representational
+    url: https://paperswithcode.com//paper/rexnet-diminishing-representational
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/rexnet.md
+++ b/modelindex/.templates/models/rexnet.md
@@ -22,153 +22,176 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: RexNet
+  Paper:
+    Title: 'ReXNet: Diminishing Representational Bottleneck on Convolutional Neural
+      Network'
+    URL: https://paperswithcode.com/paper/rexnet-diminishing-representational
 Models:
 - Name: rexnet_100
+  In Collection: RexNet
   Metadata:
     FLOPs: 509989377
-    Epochs: 400
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Linear Warmup With Cosine Annealing
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 4800000
+    File Size: 19417552
     Architecture:
     - Batch Normalization
     - Convolution
     - Dropout
     - ReLU6
     - Residual Connection
-    File Size: 19417552
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: rexnet_100
     LR: 0.5
+    Epochs: 400
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L212
-  Config: ''
-  In Collection: RexNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-rexnet/rexnetv1_100-1b4dddf4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.86%
+      Top 5 Accuracy: 93.88%
 - Name: rexnet_130
+  In Collection: RexNet
   Metadata:
     FLOPs: 848364461
-    Epochs: 400
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Linear Warmup With Cosine Annealing
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 7560000
+    File Size: 30508197
     Architecture:
     - Batch Normalization
     - Convolution
     - Dropout
     - ReLU6
     - Residual Connection
-    File Size: 30508197
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: rexnet_130
     LR: 0.5
+    Epochs: 400
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L218
-  Config: ''
-  In Collection: RexNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-rexnet/rexnetv1_130-590d768e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.49%
+      Top 5 Accuracy: 94.67%
 - Name: rexnet_150
+  In Collection: RexNet
   Metadata:
     FLOPs: 1122374469
-    Epochs: 400
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Linear Warmup With Cosine Annealing
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 9730000
+    File Size: 39227315
     Architecture:
     - Batch Normalization
     - Convolution
     - Dropout
     - ReLU6
     - Residual Connection
-    File Size: 39227315
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: rexnet_150
     LR: 0.5
+    Epochs: 400
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L224
-  Config: ''
-  In Collection: RexNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-rexnet/rexnetv1_150-bd1a6aa8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.31%
+      Top 5 Accuracy: 95.16%
 - Name: rexnet_200
+  In Collection: RexNet
   Metadata:
     FLOPs: 1960224938
-    Epochs: 400
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Linear Warmup With Cosine Annealing
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 16370000
+    File Size: 65862221
     Architecture:
     - Batch Normalization
     - Convolution
     - Dropout
     - ReLU6
     - Residual Connection
-    File Size: 65862221
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: rexnet_200
     LR: 0.5
+    Epochs: 400
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L230
-  Config: ''
-  In Collection: RexNet
-Collections:
-- Name: RexNet
-  Paper:
-    title: 'ReXNet: Diminishing Representational Bottleneck on Convolutional Neural
-      Network'
-    url: https://paperswithcode.com//paper/rexnet-diminishing-representational
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-rexnet/rexnetv1_200-8c0b7f2d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.63%
+      Top 5 Accuracy: 95.67%
 -->

--- a/modelindex/.templates/models/rexnet.md
+++ b/modelindex/.templates/models/rexnet.md
@@ -1,0 +1,174 @@
+# Summary
+
+**Rank Expansion Networks** (ReXNets) follow a set of new design principles for designing bottlenecks in image classification models. Authors refine each layer by 1) expanding the input channel size of the convolution layer and 2) replacing the [ReLU6s](https://www.paperswithcode.com/method/relu6).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{han2020rexnet,
+      title={ReXNet: Diminishing Representational Bottleneck on Convolutional Neural Network}, 
+      author={Dongyoon Han and Sangdoo Yun and Byeongho Heo and YoungJoon Yoo},
+      year={2020},
+      eprint={2007.00992},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: rexnet_100
+  Metadata:
+    FLOPs: 509989377
+    Epochs: 400
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dropout
+    - ReLU6
+    - Residual Connection
+    File Size: 19417552
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: rexnet_100
+    LR: 0.5
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L212
+  Config: ''
+  In Collection: RexNet
+- Name: rexnet_130
+  Metadata:
+    FLOPs: 848364461
+    Epochs: 400
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dropout
+    - ReLU6
+    - Residual Connection
+    File Size: 30508197
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: rexnet_130
+    LR: 0.5
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L218
+  Config: ''
+  In Collection: RexNet
+- Name: rexnet_150
+  Metadata:
+    FLOPs: 1122374469
+    Epochs: 400
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dropout
+    - ReLU6
+    - Residual Connection
+    File Size: 39227315
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: rexnet_150
+    LR: 0.5
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L224
+  Config: ''
+  In Collection: RexNet
+- Name: rexnet_200
+  Metadata:
+    FLOPs: 1960224938
+    Epochs: 400
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dropout
+    - ReLU6
+    - Residual Connection
+    File Size: 65862221
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: rexnet_200
+    LR: 0.5
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L230
+  Config: ''
+  In Collection: RexNet
+Collections:
+- Name: RexNet
+  Paper:
+    title: 'ReXNet: Diminishing Representational Bottleneck on Convolutional Neural
+      Network'
+    url: https://papperswithcode.com//paper/rexnet-diminishing-representational
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/se-resnet.md
+++ b/modelindex/.templates/models/se-resnet.md
@@ -101,7 +101,7 @@ Collections:
 - Name: SE ResNet
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/se-resnet.md
+++ b/modelindex/.templates/models/se-resnet.md
@@ -22,19 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SE ResNet
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: seresnet152d
+  In Collection: SE ResNet
   Metadata:
     FLOPs: 20161904304
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 66840000
+    File Size: 268144497
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -47,31 +47,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 268144497
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnet152d
     LR: 0.6
+    Epochs: 100
     Layers: 152
     Dropout: 0.2
     Crop Pct: '0.94'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '256'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1206
-  In Collection: SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnet152d_ra2-04464dd2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.74%
+      Top 5 Accuracy: 96.77%
 - Name: seresnet50
+  In Collection: SE ResNet
   Metadata:
     FLOPs: 5285062320
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 28090000
+    File Size: 112621903
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -84,24 +92,31 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 112621903
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnet50
     LR: 0.6
+    Epochs: 100
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1180
-  In Collection: SE ResNet
-Collections:
-- Name: SE ResNet
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnet50_ra_224-8efdb4bb.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.26%
+      Top 5 Accuracy: 95.07%
 -->

--- a/modelindex/.templates/models/se-resnet.md
+++ b/modelindex/.templates/models/se-resnet.md
@@ -1,0 +1,107 @@
+# Summary
+
+**SE ResNet** is a variant of a [ResNet](https://www.paperswithcode.com/method/resnet) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: seresnet152d
+  Metadata:
+    FLOPs: 20161904304
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 268144497
+    Tasks:
+    - Image Classification
+    ID: seresnet152d
+    LR: 0.6
+    Layers: 152
+    Dropout: 0.2
+    Crop Pct: '0.94'
+    Momentum: 0.9
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1206
+  In Collection: SE ResNet
+- Name: seresnet50
+  Metadata:
+    FLOPs: 5285062320
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 112621903
+    Tasks:
+    - Image Classification
+    ID: seresnet50
+    LR: 0.6
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1180
+  In Collection: SE ResNet
+Collections:
+- Name: SE ResNet
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/selecsls.md
+++ b/modelindex/.templates/models/selecsls.md
@@ -1,0 +1,113 @@
+# Summary
+
+**SelecSLS** uses novel selective long and short range skip connections to improve the information flow allowing for a drastically faster network without compromising accuracy.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{Mehta_2020,
+   title={XNect},
+   volume={39},
+   ISSN={1557-7368},
+   url={http://dx.doi.org/10.1145/3386569.3392410},
+   DOI={10.1145/3386569.3392410},
+   number={4},
+   journal={ACM Transactions on Graphics},
+   publisher={Association for Computing Machinery (ACM)},
+   author={Mehta, Dushyant and Sotnychenko, Oleksandr and Mueller, Franziska and Xu, Weipeng and Elgharib, Mohamed and Fua, Pascal and Seidel, Hans-Peter and Rhodin, Helge and Pons-Moll, Gerard and Theobalt, Christian},
+   year={2020},
+   month={Jul}
+}
+```
+
+<!--
+Models:
+- Name: selecsls42b
+  Metadata:
+    FLOPs: 3824022528
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - ReLU
+    - SelecSLS Block
+    File Size: 129948954
+    Tasks:
+    - Image Classification
+    ID: selecsls42b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L335
+  In Collection: SelecSLS
+- Name: selecsls60
+  Metadata:
+    FLOPs: 4610472600
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - ReLU
+    - SelecSLS Block
+    File Size: 122839714
+    Tasks:
+    - Image Classification
+    ID: selecsls60
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L342
+  In Collection: SelecSLS
+- Name: selecsls60b
+  Metadata:
+    FLOPs: 4657653144
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - ReLU
+    - SelecSLS Block
+    File Size: 131252898
+    Tasks:
+    - Image Classification
+    ID: selecsls60b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L349
+  In Collection: SelecSLS
+Collections:
+- Name: SelecSLS
+  Paper:
+    title: 'XNect: Real-time Multi-Person 3D Motion Capture with a Single RGB Camera'
+    url: https://papperswithcode.com//paper/xnect-real-time-multi-person-3d-human-pose
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/selecsls.md
+++ b/modelindex/.templates/models/selecsls.md
@@ -27,15 +27,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SelecSLS
+  Paper:
+    Title: 'XNect: Real-time Multi-Person 3D Motion Capture with a Single RGB Camera'
+    URL: https://paperswithcode.com/paper/xnect-real-time-multi-person-3d-human-pose
 Models:
 - Name: selecsls42b
+  In Collection: SelecSLS
   Metadata:
     FLOPs: 3824022528
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Cosine Annealing
-    - Random Erasing
+    Parameters: 32460000
+    File Size: 129948954
     Architecture:
     - Batch Normalization
     - Convolution
@@ -44,23 +48,31 @@ Models:
     - Global Average Pooling
     - ReLU
     - SelecSLS Block
-    File Size: 129948954
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Training Data:
+    - ImageNet
     ID: selecsls42b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L335
-  In Collection: SelecSLS
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-selecsls/selecsls42b-8af30141.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.18%
+      Top 5 Accuracy: 93.39%
 - Name: selecsls60
+  In Collection: SelecSLS
   Metadata:
     FLOPs: 4610472600
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Cosine Annealing
-    - Random Erasing
+    Parameters: 30670000
+    File Size: 122839714
     Architecture:
     - Batch Normalization
     - Convolution
@@ -69,23 +81,31 @@ Models:
     - Global Average Pooling
     - ReLU
     - SelecSLS Block
-    File Size: 122839714
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Training Data:
+    - ImageNet
     ID: selecsls60
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L342
-  In Collection: SelecSLS
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-selecsls/selecsls60-bbf87526.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.99%
+      Top 5 Accuracy: 93.83%
 - Name: selecsls60b
+  In Collection: SelecSLS
   Metadata:
     FLOPs: 4657653144
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Cosine Annealing
-    - Random Erasing
+    Parameters: 32770000
+    File Size: 131252898
     Architecture:
     - Batch Normalization
     - Convolution
@@ -94,20 +114,23 @@ Models:
     - Global Average Pooling
     - ReLU
     - SelecSLS Block
-    File Size: 131252898
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Training Data:
+    - ImageNet
     ID: selecsls60b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L349
-  In Collection: SelecSLS
-Collections:
-- Name: SelecSLS
-  Paper:
-    title: 'XNect: Real-time Multi-Person 3D Motion Capture with a Single RGB Camera'
-    url: https://paperswithcode.com//paper/xnect-real-time-multi-person-3d-human-pose
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-selecsls/selecsls60b-94e619b5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.41%
+      Top 5 Accuracy: 94.18%
 -->

--- a/modelindex/.templates/models/selecsls.md
+++ b/modelindex/.templates/models/selecsls.md
@@ -107,7 +107,7 @@ Collections:
 - Name: SelecSLS
   Paper:
     title: 'XNect: Real-time Multi-Person 3D Motion Capture with a Single RGB Camera'
-    url: https://papperswithcode.com//paper/xnect-real-time-multi-person-3d-human-pose
+    url: https://paperswithcode.com//paper/xnect-real-time-multi-person-3d-human-pose
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/seresnext.md
+++ b/modelindex/.templates/models/seresnext.md
@@ -1,0 +1,144 @@
+# Summary
+
+**SE ResNeXt** is a variant of a [ResNext](https://www.paperswithcode.com/method/resneXt) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: seresnext26d_32x4d
+  Metadata:
+    FLOPs: 3507053024
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 67425193
+    Tasks:
+    - Image Classification
+    ID: seresnext26d_32x4d
+    LR: 0.6
+    Layers: 26
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1234
+  In Collection: SEResNeXt
+- Name: seresnext26t_32x4d
+  Metadata:
+    FLOPs: 3466436448
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 67414838
+    Tasks:
+    - Image Classification
+    ID: seresnext26t_32x4d
+    LR: 0.6
+    Layers: 26
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1246
+  In Collection: SEResNeXt
+- Name: seresnext50_32x4d
+  Metadata:
+    FLOPs: 5475179184
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 110569859
+    Tasks:
+    - Image Classification
+    ID: seresnext50_32x4d
+    LR: 0.6
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1267
+  In Collection: SEResNeXt
+Collections:
+- Name: SEResNeXt
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/seresnext.md
+++ b/modelindex/.templates/models/seresnext.md
@@ -22,19 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SEResNeXt
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: seresnext26d_32x4d
+  In Collection: SEResNeXt
   Metadata:
     FLOPs: 3507053024
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 16810000
+    File Size: 67425193
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -47,31 +47,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 67425193
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnext26d_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 26
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1234
-  In Collection: SEResNeXt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnext26d_32x4d-80fa48a3.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.59%
+      Top 5 Accuracy: 93.61%
 - Name: seresnext26t_32x4d
+  In Collection: SEResNeXt
   Metadata:
     FLOPs: 3466436448
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 16820000
+    File Size: 67414838
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -84,31 +92,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 67414838
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnext26t_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 26
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1246
-  In Collection: SEResNeXt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnext26tn_32x4d-569cb627.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.99%
+      Top 5 Accuracy: 93.73%
 - Name: seresnext50_32x4d
+  In Collection: SEResNeXt
   Metadata:
     FLOPs: 5475179184
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 27560000
+    File Size: 110569859
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -121,24 +137,31 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 110569859
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnext50_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1267
-  In Collection: SEResNeXt
-Collections:
-- Name: SEResNeXt
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnext50_32x4d_racm-a304a460.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.27%
+      Top 5 Accuracy: 95.62%
 -->

--- a/modelindex/.templates/models/seresnext.md
+++ b/modelindex/.templates/models/seresnext.md
@@ -138,7 +138,7 @@ Collections:
 - Name: SEResNeXt
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/skresnet.md
+++ b/modelindex/.templates/models/skresnet.md
@@ -1,0 +1,97 @@
+# Summary
+
+**SK ResNet** is a variant of a [ResNet](https://www.paperswithcode.com/method/resnet) that employs a [Selective Kernel](https://paperswithcode.com/method/selective-kernel) unit. In general, all the large kernel convolutions in the original bottleneck blocks in ResNet are replaced by the proposed [SK convolutions](https://paperswithcode.com/method/selective-kernel-convolution), enabling the network to choose appropriate receptive field sizes in an adaptive manner.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{li2019selective,
+      title={Selective Kernel Networks}, 
+      author={Xiang Li and Wenhai Wang and Xiaolin Hu and Jian Yang},
+      year={2019},
+      eprint={1903.06586},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: skresnet18
+  Metadata:
+    FLOPs: 2333467136
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Residual Connection
+    - Selective Kernel
+    - Softmax
+    File Size: 47923238
+    Tasks:
+    - Image Classification
+    ID: skresnet18
+    LR: 0.1
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L148
+  In Collection: SKResNet
+- Name: skresnet34
+  Metadata:
+    FLOPs: 4711849952
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Residual Connection
+    - Selective Kernel
+    - Softmax
+    File Size: 89299314
+    Tasks:
+    - Image Classification
+    ID: skresnet34
+    LR: 0.1
+    Layers: 34
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L165
+  In Collection: SKResNet
+Collections:
+- Name: SKResNet
+  Paper:
+    title: Selective Kernel Networks
+    url: https://papperswithcode.com//paper/selective-kernel-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/skresnet.md
+++ b/modelindex/.templates/models/skresnet.md
@@ -22,18 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SKResNet
+  Paper:
+    Title: Selective Kernel Networks
+    URL: https://paperswithcode.com/paper/selective-kernel-networks
 Models:
 - Name: skresnet18
+  In Collection: SKResNet
   Metadata:
     FLOPs: 2333467136
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 11960000
+    File Size: 47923238
     Architecture:
     - Convolution
     - Dense Connections
@@ -42,30 +43,38 @@ Models:
     - Residual Connection
     - Selective Kernel
     - Softmax
-    File Size: 47923238
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: skresnet18
     LR: 0.1
+    Epochs: 100
     Layers: 18
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L148
-  In Collection: SKResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/skresnet18_ra-4eec2804.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.03%
+      Top 5 Accuracy: 91.17%
 - Name: skresnet34
+  In Collection: SKResNet
   Metadata:
     FLOPs: 4711849952
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 22280000
+    File Size: 89299314
     Architecture:
     - Convolution
     - Dense Connections
@@ -74,24 +83,30 @@ Models:
     - Residual Connection
     - Selective Kernel
     - Softmax
-    File Size: 89299314
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: skresnet34
     LR: 0.1
+    Epochs: 100
     Layers: 34
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L165
-  In Collection: SKResNet
-Collections:
-- Name: SKResNet
-  Paper:
-    title: Selective Kernel Networks
-    url: https://paperswithcode.com//paper/selective-kernel-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/skresnet34_ra-bdc0ccde.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.93%
+      Top 5 Accuracy: 93.32%
 -->

--- a/modelindex/.templates/models/skresnet.md
+++ b/modelindex/.templates/models/skresnet.md
@@ -91,7 +91,7 @@ Collections:
 - Name: SKResNet
   Paper:
     title: Selective Kernel Networks
-    url: https://papperswithcode.com//paper/selective-kernel-networks
+    url: https://paperswithcode.com//paper/selective-kernel-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/skresnext.md
+++ b/modelindex/.templates/models/skresnext.md
@@ -57,7 +57,7 @@ Collections:
 - Name: SKResNeXt
   Paper:
     title: Selective Kernel Networks
-    url: https://papperswithcode.com//paper/selective-kernel-networks
+    url: https://paperswithcode.com//paper/selective-kernel-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/skresnext.md
+++ b/modelindex/.templates/models/skresnext.md
@@ -1,0 +1,63 @@
+# Summary
+
+**SK ResNeXt** is a variant of a [ResNeXt](https://www.paperswithcode.com/method/resnext) that employs a [Selective Kernel](https://paperswithcode.com/method/selective-kernel) unit. In general, all the large kernel convolutions in the original bottleneck blocks in ResNext are replaced by the proposed [SK convolutions](https://paperswithcode.com/method/selective-kernel-convolution), enabling the network to choose appropriate receptive field sizes in an adaptive manner.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{li2019selective,
+      title={Selective Kernel Networks}, 
+      author={Xiang Li and Wenhai Wang and Xiaolin Hu and Jian Yang},
+      year={2019},
+      eprint={1903.06586},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: skresnext50_32x4d
+  Metadata:
+    FLOPs: 5739845824
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - Residual Connection
+    - Selective Kernel
+    - Softmax
+    File Size: 110340975
+    Tasks:
+    - Image Classification
+    ID: skresnext50_32x4d
+    LR: 0.1
+    Layers: 50
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L210
+  In Collection: SKResNeXt
+Collections:
+- Name: SKResNeXt
+  Paper:
+    title: Selective Kernel Networks
+    url: https://papperswithcode.com//paper/selective-kernel-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/skresnext.md
+++ b/modelindex/.templates/models/skresnext.md
@@ -22,15 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SKResNeXt
+  Paper:
+    Title: Selective Kernel Networks
+    URL: https://paperswithcode.com/paper/selective-kernel-networks
 Models:
 - Name: skresnext50_32x4d
+  In Collection: SKResNeXt
   Metadata:
     FLOPs: 5739845824
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Resources: 8x GPUs
+    Parameters: 27480000
+    File Size: 110340975
     Architecture:
     - Convolution
     - Dense Connections
@@ -40,24 +44,27 @@ Models:
     - Residual Connection
     - Selective Kernel
     - Softmax
-    File Size: 110340975
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: skresnext50_32x4d
     LR: 0.1
+    Epochs: 100
     Layers: 50
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L210
-  In Collection: SKResNeXt
-Collections:
-- Name: SKResNeXt
-  Paper:
-    title: Selective Kernel Networks
-    url: https://paperswithcode.com//paper/selective-kernel-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/skresnext50_ra-f40e40bf.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.15%
+      Top 5 Accuracy: 94.64%
 -->

--- a/modelindex/.templates/models/spnasnet.md
+++ b/modelindex/.templates/models/spnasnet.md
@@ -1,0 +1,55 @@
+# Summary
+
+**Single-Path NAS** is a novel differentiable NAS method for designing hardware-efficient ConvNets in less than 4 hours.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{stamoulis2019singlepath,
+      title={Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4 Hours}, 
+      author={Dimitrios Stamoulis and Ruizhou Ding and Di Wang and Dimitrios Lymberopoulos and Bodhi Priyantha and Jie Liu and Diana Marculescu},
+      year={2019},
+      eprint={1904.02877},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: spnasnet_100
+  Metadata:
+    FLOPs: 442385600
+    Training Data:
+    - ImageNet
+    Architecture:
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - ReLU
+    File Size: 17902337
+    Tasks:
+    - Image Classification
+    ID: spnasnet_100
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L995
+  In Collection: SPNASNet
+Collections:
+- Name: SPNASNet
+  Paper:
+    title: 'Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4
+      Hours'
+    url: https://papperswithcode.com//paper/single-path-nas-designing-hardware-efficient
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/spnasnet.md
+++ b/modelindex/.templates/models/spnasnet.md
@@ -22,12 +22,20 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SPNASNet
+  Paper:
+    Title: 'Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4
+      Hours'
+    URL: https://paperswithcode.com/paper/single-path-nas-designing-hardware-efficient
 Models:
 - Name: spnasnet_100
+  In Collection: SPNASNet
   Metadata:
     FLOPs: 442385600
-    Training Data:
-    - ImageNet
+    Parameters: 4420000
+    File Size: 17902337
     Architecture:
     - Average Pooling
     - Batch Normalization
@@ -35,21 +43,20 @@ Models:
     - Depthwise Separable Convolution
     - Dropout
     - ReLU
-    File Size: 17902337
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: spnasnet_100
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L995
-  In Collection: SPNASNet
-Collections:
-- Name: SPNASNet
-  Paper:
-    title: 'Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4
-      Hours'
-    url: https://paperswithcode.com//paper/single-path-nas-designing-hardware-efficient
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/spnasnet_100-048bc3f4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.08%
+      Top 5 Accuracy: 91.82%
 -->

--- a/modelindex/.templates/models/spnasnet.md
+++ b/modelindex/.templates/models/spnasnet.md
@@ -49,7 +49,7 @@ Collections:
   Paper:
     title: 'Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4
       Hours'
-    url: https://papperswithcode.com//paper/single-path-nas-designing-hardware-efficient
+    url: https://paperswithcode.com//paper/single-path-nas-designing-hardware-efficient
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/ssl-resnet.md
+++ b/modelindex/.templates/models/ssl-resnet.md
@@ -35,54 +35,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SSL ResNet
+  Paper:
+    Title: Billion-scale semi-supervised learning for image classification
+    URL: https://paperswithcode.com/paper/billion-scale-semi-supervised-learning-for
 Models:
-- Name: ssl_resnet50
-  Metadata:
-    FLOPs: 5282531328
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 102480594
-    Tasks:
-    - Image Classification
-    ID: ssl_resnet50
-    LR: 0.0015
-    Layers: 50
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L904
-  In Collection: SSL ResNet
 - Name: ssl_resnet18
+  In Collection: SSL ResNet
   Metadata:
     FLOPs: 2337073152
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 11690000
+    File Size: 46811375
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -94,23 +59,73 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 46811375
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
     ID: ssl_resnet18
     LR: 0.0015
+    Epochs: 30
     Layers: 18
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L894
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnet18-d92f0530.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.62%
+      Top 5 Accuracy: 91.42%
+- Name: ssl_resnet50
   In Collection: SSL ResNet
-Collections:
-- Name: SSL ResNet
-  Paper:
-    title: Billion-scale semi-supervised learning for image classification
-    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5282531328
+    Parameters: 25560000
+    File Size: 102480594
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
+    ID: ssl_resnet50
+    LR: 0.0015
+    Epochs: 30
+    Layers: 50
+    Crop Pct: '0.875'
+    Batch Size: 1536
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L904
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnet50-08389792.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.24%
+      Top 5 Accuracy: 94.83%
 -->

--- a/modelindex/.templates/models/ssl-resnet.md
+++ b/modelindex/.templates/models/ssl-resnet.md
@@ -110,7 +110,7 @@ Collections:
 - Name: SSL ResNet
   Paper:
     title: Billion-scale semi-supervised learning for image classification
-    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/ssl-resnet.md
+++ b/modelindex/.templates/models/ssl-resnet.md
@@ -1,0 +1,116 @@
+# Summary
+
+**Residual Networks**, or **ResNets**, learn residual functions with reference to the layer inputs, instead of learning unreferenced functions. Instead of hoping each few stacked layers directly fit a desired underlying mapping, residual nets let these layers fit a residual mapping. They stack [residual blocks](https://paperswithcode.com/method/residual-block) ontop of each other to form network: e.g. a ResNet-50 has fifty layers using these blocks. 
+
+The model in this collection utilises semi-supervised learning to improve the performance of the model. The approach brings important gains to standard architectures for image, video and fine-grained classification. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-00546,
+  author    = {I. Zeki Yalniz and
+               Herv{\'{e}} J{\'{e}}gou and
+               Kan Chen and
+               Manohar Paluri and
+               Dhruv Mahajan},
+  title     = {Billion-scale semi-supervised learning for image classification},
+  journal   = {CoRR},
+  volume    = {abs/1905.00546},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.00546},
+  archivePrefix = {arXiv},
+  eprint    = {1905.00546},
+  timestamp = {Mon, 28 Sep 2020 08:19:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-00546.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: ssl_resnet50
+  Metadata:
+    FLOPs: 5282531328
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102480594
+    Tasks:
+    - Image Classification
+    ID: ssl_resnet50
+    LR: 0.0015
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L904
+  In Collection: SSL ResNet
+- Name: ssl_resnet18
+  Metadata:
+    FLOPs: 2337073152
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46811375
+    Tasks:
+    - Image Classification
+    ID: ssl_resnet18
+    LR: 0.0015
+    Layers: 18
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L894
+  In Collection: SSL ResNet
+Collections:
+- Name: SSL ResNet
+  Paper:
+    title: Billion-scale semi-supervised learning for image classification
+    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/ssl-resnext.md
+++ b/modelindex/.templates/models/ssl-resnext.md
@@ -180,7 +180,7 @@ Collections:
 - Name: SSL ResNext
   Paper:
     title: Billion-scale semi-supervised learning for image classification
-    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/ssl-resnext.md
+++ b/modelindex/.templates/models/ssl-resnext.md
@@ -1,0 +1,186 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+The model in this collection utilises semi-supervised learning to improve the performance of the model. The approach brings important gains to standard architectures for image, video and fine-grained classification. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-00546,
+  author    = {I. Zeki Yalniz and
+               Herv{\'{e}} J{\'{e}}gou and
+               Kan Chen and
+               Manohar Paluri and
+               Dhruv Mahajan},
+  title     = {Billion-scale semi-supervised learning for image classification},
+  journal   = {CoRR},
+  volume    = {abs/1905.00546},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.00546},
+  archivePrefix = {arXiv},
+  eprint    = {1905.00546},
+  timestamp = {Mon, 28 Sep 2020 08:19:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-00546.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: ssl_resnext101_32x16d
+  Metadata:
+    FLOPs: 46623691776
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 777518664
+    Tasks:
+    - Image Classification
+    ID: ssl_resnext101_32x16d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L944
+  In Collection: SSL ResNext
+- Name: ssl_resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100428550
+    Tasks:
+    - Image Classification
+    ID: ssl_resnext50_32x4d
+    LR: 0.0015
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L914
+  In Collection: SSL ResNext
+- Name: ssl_resnext101_32x4d
+  Metadata:
+    FLOPs: 10298145792
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 177341913
+    Tasks:
+    - Image Classification
+    ID: ssl_resnext101_32x4d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L924
+  In Collection: SSL ResNext
+- Name: ssl_resnext101_32x8d
+  Metadata:
+    FLOPs: 21180417024
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 356056638
+    Tasks:
+    - Image Classification
+    ID: ssl_resnext101_32x8d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L934
+  In Collection: SSL ResNext
+Collections:
+- Name: SSL ResNext
+  Paper:
+    title: Billion-scale semi-supervised learning for image classification
+    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/ssl-resnext.md
+++ b/modelindex/.templates/models/ssl-resnext.md
@@ -35,19 +35,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SSL ResNext
+  Paper:
+    Title: Billion-scale semi-supervised learning for image classification
+    URL: https://paperswithcode.com/paper/billion-scale-semi-supervised-learning-for
 Models:
 - Name: ssl_resnext101_32x16d
+  In Collection: SSL ResNext
   Metadata:
     FLOPs: 46623691776
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 194030000
+    File Size: 777518664
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -59,65 +59,38 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 777518664
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
     ID: ssl_resnext101_32x16d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L944
-  In Collection: SSL ResNext
-- Name: ssl_resnext50_32x4d
-  Metadata:
-    FLOPs: 5472648192
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 100428550
-    Tasks:
-    - Image Classification
-    ID: ssl_resnext50_32x4d
-    LR: 0.0015
-    Layers: 50
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L914
-  In Collection: SSL ResNext
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnext101_32x16-15fffa57.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.84%
+      Top 5 Accuracy: 96.09%
 - Name: ssl_resnext101_32x4d
+  In Collection: SSL ResNext
   Metadata:
     FLOPs: 10298145792
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 44180000
+    File Size: 177341913
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -129,30 +102,38 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 177341913
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
     ID: ssl_resnext101_32x4d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L924
-  In Collection: SSL ResNext
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnext101_32x4-dc43570a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.91%
+      Top 5 Accuracy: 95.73%
 - Name: ssl_resnext101_32x8d
+  In Collection: SSL ResNext
   Metadata:
     FLOPs: 21180417024
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 88790000
+    File Size: 356056638
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -164,23 +145,73 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 356056638
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
     ID: ssl_resnext101_32x8d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L934
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnext101_32x8-2cfe2f8b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.61%
+      Top 5 Accuracy: 96.04%
+- Name: ssl_resnext50_32x4d
   In Collection: SSL ResNext
-Collections:
-- Name: SSL ResNext
-  Paper:
-    title: Billion-scale semi-supervised learning for image classification
-    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5472648192
+    Parameters: 25030000
+    File Size: 100428550
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
+    ID: ssl_resnext50_32x4d
+    LR: 0.0015
+    Epochs: 30
+    Layers: 50
+    Crop Pct: '0.875'
+    Batch Size: 1536
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L914
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnext50_32x4-ddb3e555.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.3%
+      Top 5 Accuracy: 95.41%
 -->

--- a/modelindex/.templates/models/swsl-resnet.md
+++ b/modelindex/.templates/models/swsl-resnet.md
@@ -35,19 +35,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SWSL ResNet
+  Paper:
+    Title: Billion-scale semi-supervised learning for image classification
+    URL: https://paperswithcode.com/paper/billion-scale-semi-supervised-learning-for
 Models:
 - Name: swsl_resnet18
+  In Collection: SWSL ResNet
   Metadata:
     FLOPs: 2337073152
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 11690000
+    File Size: 46811375
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -59,30 +59,38 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 46811375
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
     ID: swsl_resnet18
     LR: 0.0015
+    Epochs: 30
     Layers: 18
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L954
-  In Collection: SWSL ResNet
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnet18-118f1556.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.28%
+      Top 5 Accuracy: 91.76%
 - Name: swsl_resnet50
+  In Collection: SWSL ResNet
   Metadata:
     FLOPs: 5282531328
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 25560000
+    File Size: 102480594
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -94,23 +102,30 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102480594
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
     ID: swsl_resnet50
     LR: 0.0015
+    Epochs: 30
     Layers: 50
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L965
-  In Collection: SWSL ResNet
-Collections:
-- Name: SWSL ResNet
-  Paper:
-    title: Billion-scale semi-supervised learning for image classification
-    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
-  type: model-index
-Type: model-index
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnet50-16a12f1b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.14%
+      Top 5 Accuracy: 95.97%
 -->

--- a/modelindex/.templates/models/swsl-resnet.md
+++ b/modelindex/.templates/models/swsl-resnet.md
@@ -1,0 +1,116 @@
+# Summary
+
+**Residual Networks**, or **ResNets**, learn residual functions with reference to the layer inputs, instead of learning unreferenced functions. Instead of hoping each few stacked layers directly fit a desired underlying mapping, residual nets let these layers fit a residual mapping. They stack [residual blocks](https://paperswithcode.com/method/residual-block) ontop of each other to form network: e.g. a ResNet-50 has fifty layers using these blocks. 
+
+The models in this collection utilise semi-weakly supervised learning to improve the performance of the model. The approach brings important gains to standard architectures for image, video and fine-grained classification. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-00546,
+  author    = {I. Zeki Yalniz and
+               Herv{\'{e}} J{\'{e}}gou and
+               Kan Chen and
+               Manohar Paluri and
+               Dhruv Mahajan},
+  title     = {Billion-scale semi-supervised learning for image classification},
+  journal   = {CoRR},
+  volume    = {abs/1905.00546},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.00546},
+  archivePrefix = {arXiv},
+  eprint    = {1905.00546},
+  timestamp = {Mon, 28 Sep 2020 08:19:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-00546.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: swsl_resnet18
+  Metadata:
+    FLOPs: 2337073152
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46811375
+    Tasks:
+    - Image Classification
+    ID: swsl_resnet18
+    LR: 0.0015
+    Layers: 18
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L954
+  In Collection: SWSL ResNet
+- Name: swsl_resnet50
+  Metadata:
+    FLOPs: 5282531328
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102480594
+    Tasks:
+    - Image Classification
+    ID: swsl_resnet50
+    LR: 0.0015
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L965
+  In Collection: SWSL ResNet
+Collections:
+- Name: SWSL ResNet
+  Paper:
+    title: Billion-scale semi-supervised learning for image classification
+    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/swsl-resnet.md
+++ b/modelindex/.templates/models/swsl-resnet.md
@@ -110,7 +110,7 @@ Collections:
 - Name: SWSL ResNet
   Paper:
     title: Billion-scale semi-supervised learning for image classification
-    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/swsl-resnext.md
+++ b/modelindex/.templates/models/swsl-resnext.md
@@ -180,7 +180,7 @@ Collections:
 - Name: SWSL ResNext
   Paper:
     title: Billion-scale semi-supervised learning for image classification
-    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/swsl-resnext.md
+++ b/modelindex/.templates/models/swsl-resnext.md
@@ -35,89 +35,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SWSL ResNext
+  Paper:
+    Title: Billion-scale semi-supervised learning for image classification
+    URL: https://paperswithcode.com/paper/billion-scale-semi-supervised-learning-for
 Models:
-- Name: swsl_resnext101_32x4d
-  Metadata:
-    FLOPs: 10298145792
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 177341913
-    Tasks:
-    - Image Classification
-    ID: swsl_resnext101_32x4d
-    LR: 0.0015
-    Layers: 101
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L987
-  In Collection: SWSL ResNext
-- Name: swsl_resnext50_32x4d
-  Metadata:
-    FLOPs: 5472648192
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 100428550
-    Tasks:
-    - Image Classification
-    ID: swsl_resnext50_32x4d
-    LR: 0.0015
-    Layers: 50
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L976
-  In Collection: SWSL ResNext
 - Name: swsl_resnext101_32x16d
+  In Collection: SWSL ResNext
   Metadata:
     FLOPs: 46623691776
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 194030000
+    File Size: 777518664
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -129,30 +59,38 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 777518664
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
     ID: swsl_resnext101_32x16d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L1009
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnext101_32x16-f3559a9c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.34%
+      Top 5 Accuracy: 96.84%
+- Name: swsl_resnext101_32x4d
   In Collection: SWSL ResNext
-- Name: swsl_resnext101_32x8d
   Metadata:
-    FLOPs: 21180417024
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    FLOPs: 10298145792
+    Parameters: 44180000
+    File Size: 177341913
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -164,23 +102,116 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 356056638
     Tasks:
     - Image Classification
-    ID: swsl_resnext101_32x8d
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
+    ID: swsl_resnext101_32x4d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L987
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnext101_32x4-3f87e46b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.22%
+      Top 5 Accuracy: 96.77%
+- Name: swsl_resnext101_32x8d
+  In Collection: SWSL ResNext
+  Metadata:
+    FLOPs: 21180417024
+    Parameters: 88790000
+    File Size: 356056638
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
+    ID: swsl_resnext101_32x8d
+    LR: 0.0015
+    Epochs: 30
+    Layers: 101
+    Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L998
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnext101_32x8-b4712904.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.27%
+      Top 5 Accuracy: 97.17%
+- Name: swsl_resnext50_32x4d
   In Collection: SWSL ResNext
-Collections:
-- Name: SWSL ResNext
-  Paper:
-    title: Billion-scale semi-supervised learning for image classification
-    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5472648192
+    Parameters: 25030000
+    File Size: 100428550
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
+    ID: swsl_resnext50_32x4d
+    LR: 0.0015
+    Epochs: 30
+    Layers: 50
+    Crop Pct: '0.875'
+    Batch Size: 1536
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L976
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnext50_32x4-72679e44.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.17%
+      Top 5 Accuracy: 96.23%
 -->

--- a/modelindex/.templates/models/swsl-resnext.md
+++ b/modelindex/.templates/models/swsl-resnext.md
@@ -1,0 +1,186 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+The models in this collection utilise semi-weakly supervised learning to improve the performance of the model. The approach brings important gains to standard architectures for image, video and fine-grained classification. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-00546,
+  author    = {I. Zeki Yalniz and
+               Herv{\'{e}} J{\'{e}}gou and
+               Kan Chen and
+               Manohar Paluri and
+               Dhruv Mahajan},
+  title     = {Billion-scale semi-supervised learning for image classification},
+  journal   = {CoRR},
+  volume    = {abs/1905.00546},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.00546},
+  archivePrefix = {arXiv},
+  eprint    = {1905.00546},
+  timestamp = {Mon, 28 Sep 2020 08:19:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-00546.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: swsl_resnext101_32x4d
+  Metadata:
+    FLOPs: 10298145792
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 177341913
+    Tasks:
+    - Image Classification
+    ID: swsl_resnext101_32x4d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L987
+  In Collection: SWSL ResNext
+- Name: swsl_resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100428550
+    Tasks:
+    - Image Classification
+    ID: swsl_resnext50_32x4d
+    LR: 0.0015
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L976
+  In Collection: SWSL ResNext
+- Name: swsl_resnext101_32x16d
+  Metadata:
+    FLOPs: 46623691776
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 777518664
+    Tasks:
+    - Image Classification
+    ID: swsl_resnext101_32x16d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L1009
+  In Collection: SWSL ResNext
+- Name: swsl_resnext101_32x8d
+  Metadata:
+    FLOPs: 21180417024
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 356056638
+    Tasks:
+    - Image Classification
+    ID: swsl_resnext101_32x8d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L998
+  In Collection: SWSL ResNext
+Collections:
+- Name: SWSL ResNext
+  Paper:
+    title: Billion-scale semi-supervised learning for image classification
+    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/tf-efficientnet-condconv.md
+++ b/modelindex/.templates/models/tf-efficientnet-condconv.md
@@ -1,0 +1,164 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2), in addition to squeeze-and-excitation blocks.
+
+This collection of models amends EfficientNet by adding [CondConv](https://paperswithcode.com/method/condconv) convolutions.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1904-04971,
+  author    = {Brandon Yang and
+               Gabriel Bender and
+               Quoc V. Le and
+               Jiquan Ngiam},
+  title     = {Soft Conditional Computation},
+  journal   = {CoRR},
+  volume    = {abs/1904.04971},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1904.04971},
+  archivePrefix = {arXiv},
+  eprint    = {1904.04971},
+  timestamp = {Thu, 25 Apr 2019 13:55:01 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1904-04971.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_cc_b1_8e
+  Metadata:
+    FLOPs: 370427824
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - CondConv
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 159206198
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_cc_b1_8e
+    LR: 0.256
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1584
+  In Collection: TF EfficientNet CondConv
+- Name: tf_efficientnet_cc_b0_4e
+  Metadata:
+    FLOPs: 224153788
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - CondConv
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 53490940
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_cc_b0_4e
+    LR: 0.256
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1561
+  In Collection: TF EfficientNet CondConv
+- Name: tf_efficientnet_cc_b0_8e
+  Metadata:
+    FLOPs: 224158524
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - CondConv
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 96287616
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_cc_b0_8e
+    LR: 0.256
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1572
+  In Collection: TF EfficientNet CondConv
+Collections:
+- Name: TF EfficientNet CondConv
+  Paper:
+    title: 'CondConv: Conditionally Parameterized Convolutions for Efficient Inference'
+    url: https://papperswithcode.com//paper/soft-conditional-computation
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/tf-efficientnet-condconv.md
+++ b/modelindex/.templates/models/tf-efficientnet-condconv.md
@@ -36,59 +36,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF EfficientNet CondConv
+  Paper:
+    Title: 'CondConv: Conditionally Parameterized Convolutions for Efficient Inference'
+    URL: https://paperswithcode.com/paper/soft-conditional-computation
 Models:
-- Name: tf_efficientnet_cc_b1_8e
-  Metadata:
-    FLOPs: 370427824
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - CondConv
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 159206198
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_cc_b1_8e
-    LR: 0.256
-    Crop Pct: '0.882'
-    Momentum: 0.9
-    Image Size: '240'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1584
-  In Collection: TF EfficientNet CondConv
 - Name: tf_efficientnet_cc_b0_4e
+  In Collection: TF EfficientNet CondConv
   Metadata:
     FLOPs: 224153788
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 13310000
+    File Size: 53490940
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -100,13 +60,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 53490940
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_cc_b0_4e
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -114,20 +83,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1561
-  In Collection: TF EfficientNet CondConv
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_cc_b0_4e-4362b6b2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.32%
+      Top 5 Accuracy: 93.32%
 - Name: tf_efficientnet_cc_b0_8e
+  In Collection: TF EfficientNet CondConv
   Metadata:
     FLOPs: 224158524
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 24010000
+    File Size: 96287616
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -139,13 +107,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 96287616
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_cc_b0_8e
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -153,12 +130,58 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1572
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_cc_b0_8e-66184a25.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.91%
+      Top 5 Accuracy: 93.65%
+- Name: tf_efficientnet_cc_b1_8e
   In Collection: TF EfficientNet CondConv
-Collections:
-- Name: TF EfficientNet CondConv
-  Paper:
-    title: 'CondConv: Conditionally Parameterized Convolutions for Efficient Inference'
-    url: https://paperswithcode.com//paper/soft-conditional-computation
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 370427824
+    Parameters: 39720000
+    File Size: 159206198
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - CondConv
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_cc_b1_8e
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1584
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_cc_b1_8e-f7c79ae1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.33%
+      Top 5 Accuracy: 94.37%
 -->

--- a/modelindex/.templates/models/tf-efficientnet-condconv.md
+++ b/modelindex/.templates/models/tf-efficientnet-condconv.md
@@ -158,7 +158,7 @@ Collections:
 - Name: TF EfficientNet CondConv
   Paper:
     title: 'CondConv: Conditionally Parameterized Convolutions for Efficient Inference'
-    url: https://papperswithcode.com//paper/soft-conditional-computation
+    url: https://paperswithcode.com//paper/soft-conditional-computation
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/tf-efficientnet-lite.md
+++ b/modelindex/.templates/models/tf-efficientnet-lite.md
@@ -1,0 +1,154 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2).
+
+EfficientNet-Lite makes EfficientNet more suitable for mobile devices by introducing [ReLU6](https://paperswithcode.com/method/relu6) activation functions and removing [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2020efficientnet,
+      title={EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2020},
+      eprint={1905.11946},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_lite3
+  Metadata:
+    FLOPs: 2011534304
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 33161413
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite3
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1629
+  In Collection: TF EfficientNet Lite
+- Name: tf_efficientnet_lite4
+  Metadata:
+    FLOPs: 5164802912
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 52558819
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite4
+    Crop Pct: '0.92'
+    Image Size: '380'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1640
+  In Collection: TF EfficientNet Lite
+- Name: tf_efficientnet_lite2
+  Metadata:
+    FLOPs: 1068494432
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 24658687
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite2
+    Crop Pct: '0.89'
+    Image Size: '260'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1618
+  In Collection: TF EfficientNet Lite
+- Name: tf_efficientnet_lite1
+  Metadata:
+    FLOPs: 773639520
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 21939331
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite1
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1607
+  In Collection: TF EfficientNet Lite
+- Name: tf_efficientnet_lite0
+  Metadata:
+    FLOPs: 488052032
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 18820223
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite0
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1596
+  In Collection: TF EfficientNet Lite
+Collections:
+- Name: TF EfficientNet Lite
+  Paper:
+    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/tf-efficientnet-lite.md
+++ b/modelindex/.templates/models/tf-efficientnet-lite.md
@@ -148,7 +148,7 @@ Collections:
 - Name: TF EfficientNet Lite
   Paper:
     title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/tf-efficientnet-lite.md
+++ b/modelindex/.templates/models/tf-efficientnet-lite.md
@@ -28,104 +28,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF EfficientNet Lite
+  Paper:
+    Title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    URL: https://paperswithcode.com/paper/efficientnet-rethinking-model-scaling-for
 Models:
-- Name: tf_efficientnet_lite3
-  Metadata:
-    FLOPs: 2011534304
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - RELU6
-    File Size: 33161413
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_lite3
-    Crop Pct: '0.904'
-    Image Size: '300'
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1629
-  In Collection: TF EfficientNet Lite
-- Name: tf_efficientnet_lite4
-  Metadata:
-    FLOPs: 5164802912
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - RELU6
-    File Size: 52558819
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_lite4
-    Crop Pct: '0.92'
-    Image Size: '380'
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1640
-  In Collection: TF EfficientNet Lite
-- Name: tf_efficientnet_lite2
-  Metadata:
-    FLOPs: 1068494432
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - RELU6
-    File Size: 24658687
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_lite2
-    Crop Pct: '0.89'
-    Image Size: '260'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1618
-  In Collection: TF EfficientNet Lite
-- Name: tf_efficientnet_lite1
-  Metadata:
-    FLOPs: 773639520
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - RELU6
-    File Size: 21939331
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_lite1
-    Crop Pct: '0.882'
-    Image Size: '240'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1607
-  In Collection: TF EfficientNet Lite
 - Name: tf_efficientnet_lite0
+  In Collection: TF EfficientNet Lite
   Metadata:
     FLOPs: 488052032
-    Training Data:
-    - ImageNet
+    Parameters: 4650000
+    File Size: 18820223
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -135,20 +50,144 @@ Models:
     - Dropout
     - Inverted Residual Block
     - RELU6
-    File Size: 18820223
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_lite0
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1596
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite0-0aa007d2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.83%
+      Top 5 Accuracy: 92.17%
+- Name: tf_efficientnet_lite1
   In Collection: TF EfficientNet Lite
-Collections:
-- Name: TF EfficientNet Lite
-  Paper:
-    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 773639520
+    Parameters: 5420000
+    File Size: 21939331
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_lite1
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1607
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite1-bde8b488.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.67%
+      Top 5 Accuracy: 93.24%
+- Name: tf_efficientnet_lite2
+  In Collection: TF EfficientNet Lite
+  Metadata:
+    FLOPs: 1068494432
+    Parameters: 6090000
+    File Size: 24658687
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_lite2
+    Crop Pct: '0.89'
+    Image Size: '260'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1618
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite2-dcccb7df.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.48%
+      Top 5 Accuracy: 93.75%
+- Name: tf_efficientnet_lite3
+  In Collection: TF EfficientNet Lite
+  Metadata:
+    FLOPs: 2011534304
+    Parameters: 8199999
+    File Size: 33161413
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_lite3
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1629
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite3-b733e338.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.83%
+      Top 5 Accuracy: 94.91%
+- Name: tf_efficientnet_lite4
+  In Collection: TF EfficientNet Lite
+  Metadata:
+    FLOPs: 5164802912
+    Parameters: 13010000
+    File Size: 52558819
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_lite4
+    Crop Pct: '0.92'
+    Image Size: '380'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1640
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite4-741542c3.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.54%
+      Top 5 Accuracy: 95.66%
 -->

--- a/modelindex/.templates/models/tf-efficientnet.md
+++ b/modelindex/.templates/models/tf-efficientnet.md
@@ -1,0 +1,503 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2), in addition to [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2020efficientnet,
+      title={EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2020},
+      eprint={1905.11946},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_b1
+  Metadata:
+    FLOPs: 883633200
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 31512534
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b1
+    LR: 0.256
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1251
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b4
+  Metadata:
+    FLOPs: 5749638672
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Resources: TPUv3 Cloud TPU
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 77989689
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b4
+    LR: 0.256
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1281
+  Config: ''
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b2
+  Metadata:
+    FLOPs: 1234321170
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 36797929
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b2
+    LR: 0.256
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1261
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b3
+  Metadata:
+    FLOPs: 2275247568
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49381362
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b3
+    LR: 0.256
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1271
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b0
+  Metadata:
+    FLOPs: 488688572
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Resources: TPUv3 Cloud TPU
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 21383997
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b0
+    LR: 0.256
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1241
+  Config: ''
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b5
+  Metadata:
+    FLOPs: 13176501888
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 122403150
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b5
+    LR: 0.256
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1291
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b6
+  Metadata:
+    FLOPs: 24180518488
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 173232007
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b6
+    LR: 0.256
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1301
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b7
+  Metadata:
+    FLOPs: 48205304880
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 266850607
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b7
+    LR: 0.256
+    Crop Pct: '0.949'
+    Momentum: 0.9
+    Image Size: '600'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1312
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b8
+  Metadata:
+    FLOPs: 80962956270
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 351379853
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b8
+    LR: 0.256
+    Crop Pct: '0.954'
+    Momentum: 0.9
+    Image Size: '672'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1323
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_el
+  Metadata:
+    FLOPs: 9356616096
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 42800271
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_el
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1551
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_em
+  Metadata:
+    FLOPs: 3636607040
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 27933644
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_em
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1541
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_es
+  Metadata:
+    FLOPs: 2057577472
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 22008479
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_es
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1531
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_l2_ns_475
+  Metadata:
+    FLOPs: 217795669644
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: TPUv3 Cloud TPU
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 1925950424
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_l2_ns_475
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.936'
+    Momentum: 0.9
+    Image Size: '475'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1509
+  Config: ''
+  In Collection: TF EfficientNet
+Collections:
+- Name: TF EfficientNet
+  Paper:
+    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/tf-efficientnet.md
+++ b/modelindex/.templates/models/tf-efficientnet.md
@@ -497,7 +497,7 @@ Collections:
 - Name: TF EfficientNet
   Paper:
     title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/tf-efficientnet.md
+++ b/modelindex/.templates/models/tf-efficientnet.md
@@ -26,176 +26,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF EfficientNet
+  Paper:
+    Title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    URL: https://paperswithcode.com/paper/efficientnet-rethinking-model-scaling-for
 Models:
-- Name: tf_efficientnet_b1
-  Metadata:
-    FLOPs: 883633200
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 31512534
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b1
-    LR: 0.256
-    Crop Pct: '0.882'
-    Momentum: 0.9
-    Image Size: '240'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1251
-  In Collection: TF EfficientNet
-- Name: tf_efficientnet_b4
-  Metadata:
-    FLOPs: 5749638672
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Training Resources: TPUv3 Cloud TPU
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 77989689
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b4
-    LR: 0.256
-    Crop Pct: '0.922'
-    Momentum: 0.9
-    Image Size: '380'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1281
-  Config: ''
-  In Collection: TF EfficientNet
-- Name: tf_efficientnet_b2
-  Metadata:
-    FLOPs: 1234321170
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 36797929
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b2
-    LR: 0.256
-    Crop Pct: '0.89'
-    Momentum: 0.9
-    Image Size: '260'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1261
-  In Collection: TF EfficientNet
-- Name: tf_efficientnet_b3
-  Metadata:
-    FLOPs: 2275247568
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49381362
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b3
-    LR: 0.256
-    Crop Pct: '0.904'
-    Momentum: 0.9
-    Image Size: '300'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1271
-  In Collection: TF EfficientNet
 - Name: tf_efficientnet_b0
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 488688572
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Training Resources: TPUv3 Cloud TPU
+    Parameters: 5290000
+    File Size: 21383997
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -206,14 +49,23 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 21383997
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: TPUv3 Cloud TPU
     ID: tf_efficientnet_b0
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -221,21 +73,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1241
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b0_aa-827b6e33.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.85%
+      Top 5 Accuracy: 93.23%
+- Name: tf_efficientnet_b1
   In Collection: TF EfficientNet
-- Name: tf_efficientnet_b5
   Metadata:
-    FLOPs: 13176501888
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    FLOPs: 883633200
+    Parameters: 7790000
+    File Size: 31512534
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -246,13 +96,207 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 122403150
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b1
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1251
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b1_aa-ea7a6ee0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.84%
+      Top 5 Accuracy: 94.2%
+- Name: tf_efficientnet_b2
+  In Collection: TF EfficientNet
+  Metadata:
+    FLOPs: 1234321170
+    Parameters: 9110000
+    File Size: 36797929
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b2
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1261
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b2_aa-60c94f97.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.07%
+      Top 5 Accuracy: 94.9%
+- Name: tf_efficientnet_b3
+  In Collection: TF EfficientNet
+  Metadata:
+    FLOPs: 2275247568
+    Parameters: 12230000
+    File Size: 49381362
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b3
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1271
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b3_aa-84b4657e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.65%
+      Top 5 Accuracy: 95.72%
+- Name: tf_efficientnet_b4
+  In Collection: TF EfficientNet
+  Metadata:
+    FLOPs: 5749638672
+    Parameters: 19340000
+    File Size: 77989689
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: TPUv3 Cloud TPU
+    ID: tf_efficientnet_b4
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1281
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b4_aa-818f208c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.03%
+      Top 5 Accuracy: 96.3%
+- Name: tf_efficientnet_b5
+  In Collection: TF EfficientNet
+  Metadata:
+    FLOPs: 13176501888
+    Parameters: 30390000
+    File Size: 122403150
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b5
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.934'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '456'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -260,20 +304,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1291
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_ra-9a3e5369.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.81%
+      Top 5 Accuracy: 96.75%
 - Name: tf_efficientnet_b6
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 24180518488
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 43040000
+    File Size: 173232007
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -284,13 +327,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 173232007
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b6
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.942'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '528'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -298,20 +350,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1301
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b6_aa-80ba17e4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.11%
+      Top 5 Accuracy: 96.89%
 - Name: tf_efficientnet_b7
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 48205304880
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 66349999
+    File Size: 266850607
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -322,13 +373,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 266850607
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b7
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.949'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '600'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -336,20 +396,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1312
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b7_ra-6c08e654.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.93%
+      Top 5 Accuracy: 97.2%
 - Name: tf_efficientnet_b8
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 80962956270
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 87410000
+    File Size: 351379853
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -360,13 +419,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 351379853
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b8
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.954'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '672'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -374,12 +442,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1323
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b8_ra-572d5dd9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.35%
+      Top 5 Accuracy: 97.39%
 - Name: tf_efficientnet_el
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 9356616096
-    Training Data:
-    - ImageNet
+    Parameters: 10590000
+    File Size: 42800271
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -390,20 +465,28 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 42800271
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_el
     Crop Pct: '0.904'
     Image Size: '300'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1551
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_el-5143854e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.45%
+      Top 5 Accuracy: 95.17%
 - Name: tf_efficientnet_em
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 3636607040
-    Training Data:
-    - ImageNet
+    Parameters: 6900000
+    File Size: 27933644
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -414,20 +497,28 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 27933644
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_em
     Crop Pct: '0.882'
     Image Size: '240'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1541
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_em-e78cfe58.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.71%
+      Top 5 Accuracy: 94.33%
 - Name: tf_efficientnet_es
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 2057577472
-    Training Data:
-    - ImageNet
+    Parameters: 5440000
+    File Size: 22008479
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -438,23 +529,40 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 22008479
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_es
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1531
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_es-ca1afbfe.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.28%
+      Top 5 Accuracy: 93.6%
 - Name: tf_efficientnet_l2_ns_475
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 217795669644
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
+    Parameters: 480310000
+    File Size: 1925950424
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
     Training Techniques:
     - AutoAugment
     - FixRes
@@ -463,26 +571,17 @@ Models:
     - RMSProp
     - RandAugment
     - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
     Training Resources: TPUv3 Cloud TPU
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 1925950424
-    Tasks:
-    - Image Classification
-    Training Time: ''
     ID: tf_efficientnet_l2_ns_475
     LR: 0.128
+    Epochs: 350
     Dropout: 0.5
     Crop Pct: '0.936'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '475'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -491,13 +590,11 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1509
-  Config: ''
-  In Collection: TF EfficientNet
-Collections:
-- Name: TF EfficientNet
-  Paper:
-    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_l2_ns_475-bebbd00a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 88.24%
+      Top 5 Accuracy: 98.55%
 -->

--- a/modelindex/.templates/models/tf-inception-v3.md
+++ b/modelindex/.templates/models/tf-inception-v3.md
@@ -31,18 +31,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF Inception v3
+  Paper:
+    Title: Rethinking the Inception Architecture for Computer Vision
+    URL: https://paperswithcode.com/paper/rethinking-the-inception-architecture-for
 Models:
 - Name: tf_inception_v3
+  In Collection: TF Inception v3
   Metadata:
     FLOPs: 7352418880
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Gradient Clipping
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 50x NVIDIA Kepler GPUs
+    Parameters: 23830000
+    File Size: 95549439
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -56,9 +57,16 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 95549439
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Gradient Clipping
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 50x NVIDIA Kepler GPUs
     ID: tf_inception_v3
     LR: 0.045
     Dropout: 0.2
@@ -67,12 +75,11 @@ Models:
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L449
-  In Collection: TF Inception v3
-Collections:
-- Name: TF Inception v3
-  Paper:
-    title: Rethinking the Inception Architecture for Computer Vision
-    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_inception_v3-e0069de4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.87%
+      Top 5 Accuracy: 93.65%
 -->

--- a/modelindex/.templates/models/tf-inception-v3.md
+++ b/modelindex/.templates/models/tf-inception-v3.md
@@ -72,7 +72,7 @@ Collections:
 - Name: TF Inception v3
   Paper:
     title: Rethinking the Inception Architecture for Computer Vision
-    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/tf-inception-v3.md
+++ b/modelindex/.templates/models/tf-inception-v3.md
@@ -1,0 +1,78 @@
+# Summary
+
+**Inception v3** is a convolutional neural network architecture from the Inception family that makes several improvements including using [Label Smoothing](https://paperswithcode.com/method/label-smoothing), Factorized 7 x 7 convolutions, and the use of an [auxiliary classifer](https://paperswithcode.com/method/auxiliary-classifier) to propagate label information lower down the network (along with the use of batch normalization for layers in the sidehead). The key building block is an [Inception Module](https://paperswithcode.com/method/inception-v3-module).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/SzegedyVISW15,
+  author    = {Christian Szegedy and
+               Vincent Vanhoucke and
+               Sergey Ioffe and
+               Jonathon Shlens and
+               Zbigniew Wojna},
+  title     = {Rethinking the Inception Architecture for Computer Vision},
+  journal   = {CoRR},
+  volume    = {abs/1512.00567},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.00567},
+  archivePrefix = {arXiv},
+  eprint    = {1512.00567},
+  timestamp = {Mon, 13 Aug 2018 16:49:07 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/SzegedyVISW15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: tf_inception_v3
+  Metadata:
+    FLOPs: 7352418880
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Gradient Clipping
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 50x NVIDIA Kepler GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 95549439
+    Tasks:
+    - Image Classification
+    ID: tf_inception_v3
+    LR: 0.045
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L449
+  In Collection: TF Inception v3
+Collections:
+- Name: TF Inception v3
+  Paper:
+    title: Rethinking the Inception Architecture for Computer Vision
+    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/tf-mixnet.md
+++ b/modelindex/.templates/models/tf-mixnet.md
@@ -1,0 +1,108 @@
+# Summary
+
+**MixNet** is a type of convolutional neural network discovered via AutoML that utilises [MixConvs](https://paperswithcode.com/method/mixconv) instead of regular [depthwise convolutions](https://paperswithcode.com/method/depthwise-convolution).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2019mixconv,
+      title={MixConv: Mixed Depthwise Convolutional Kernels}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2019},
+      eprint={1907.09595},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: tf_mixnet_l
+  Metadata:
+    FLOPs: 688674516
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 29620756
+    Tasks:
+    - Image Classification
+    ID: tf_mixnet_l
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1720
+  In Collection: TF MixNet
+- Name: tf_mixnet_m
+  Metadata:
+    FLOPs: 416633502
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 20310871
+    Tasks:
+    - Image Classification
+    ID: tf_mixnet_m
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1709
+  In Collection: TF MixNet
+- Name: tf_mixnet_s
+  Metadata:
+    FLOPs: 302587678
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 16738218
+    Tasks:
+    - Image Classification
+    ID: tf_mixnet_s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1698
+  In Collection: TF MixNet
+Collections:
+- Name: TF MixNet
+  Paper:
+    title: 'MixConv: Mixed Depthwise Convolutional Kernels'
+    url: https://papperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/tf-mixnet.md
+++ b/modelindex/.templates/models/tf-mixnet.md
@@ -102,7 +102,7 @@ Collections:
 - Name: TF MixNet
   Paper:
     title: 'MixConv: Mixed Depthwise Convolutional Kernels'
-    url: https://papperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
+    url: https://paperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/tf-mixnet.md
+++ b/modelindex/.templates/models/tf-mixnet.md
@@ -22,14 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF MixNet
+  Paper:
+    Title: 'MixConv: Mixed Depthwise Convolutional Kernels'
+    URL: https://paperswithcode.com/paper/mixnet-mixed-depthwise-convolutional-kernels
 Models:
 - Name: tf_mixnet_l
+  In Collection: TF MixNet
   Metadata:
     FLOPs: 688674516
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
+    Parameters: 7330000
+    File Size: 29620756
     Architecture:
     - Batch Normalization
     - Dense Connections
@@ -39,22 +44,30 @@ Models:
     - MixConv
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 29620756
     Tasks:
     - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
     ID: tf_mixnet_l
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1720
-  In Collection: TF MixNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mixnet_l-6c92e0c8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.78%
+      Top 5 Accuracy: 94.0%
 - Name: tf_mixnet_m
+  In Collection: TF MixNet
   Metadata:
     FLOPs: 416633502
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
+    Parameters: 5010000
+    File Size: 20310871
     Architecture:
     - Batch Normalization
     - Dense Connections
@@ -64,22 +77,30 @@ Models:
     - MixConv
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 20310871
     Tasks:
     - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
     ID: tf_mixnet_m
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1709
-  In Collection: TF MixNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mixnet_m-0f4d8805.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.96%
+      Top 5 Accuracy: 93.16%
 - Name: tf_mixnet_s
+  In Collection: TF MixNet
   Metadata:
     FLOPs: 302587678
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
+    Parameters: 4130000
+    File Size: 16738218
     Architecture:
     - Batch Normalization
     - Dense Connections
@@ -89,20 +110,22 @@ Models:
     - MixConv
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 16738218
     Tasks:
     - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
     ID: tf_mixnet_s
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1698
-  In Collection: TF MixNet
-Collections:
-- Name: TF MixNet
-  Paper:
-    title: 'MixConv: Mixed Depthwise Convolutional Kernels'
-    url: https://paperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mixnet_s-89d3354b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.68%
+      Top 5 Accuracy: 92.64%
 -->

--- a/modelindex/.templates/models/tf-mobilenet-v3.md
+++ b/modelindex/.templates/models/tf-mobilenet-v3.md
@@ -1,0 +1,271 @@
+# Summary
+
+**MobileNetV3** is a convolutional neural network that is designed for mobile phone CPUs. The network design includes the use of a [hard swish activation](https://paperswithcode.com/method/hard-swish) and [squeeze-and-excitation](https://paperswithcode.com/method/squeeze-and-excitation-block) modules in the [MBConv blocks](https://paperswithcode.com/method/inverted-residual-block).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-02244,
+  author    = {Andrew Howard and
+               Mark Sandler and
+               Grace Chu and
+               Liang{-}Chieh Chen and
+               Bo Chen and
+               Mingxing Tan and
+               Weijun Wang and
+               Yukun Zhu and
+               Ruoming Pang and
+               Vijay Vasudevan and
+               Quoc V. Le and
+               Hartwig Adam},
+  title     = {Searching for MobileNetV3},
+  journal   = {CoRR},
+  volume    = {abs/1905.02244},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.02244},
+  archivePrefix = {arXiv},
+  eprint    = {1905.02244},
+  timestamp = {Tue, 12 Jan 2021 15:30:06 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-02244.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: tf_mobilenetv3_large_075
+  Metadata:
+    FLOPs: 194323712
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 16097377
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_large_075
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L394
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_large_100
+  Metadata:
+    FLOPs: 274535288
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 22076649
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_large_100
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L403
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_large_minimal_100
+  Metadata:
+    FLOPs: 267216928
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 15836368
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_large_minimal_100
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L412
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_small_075
+  Metadata:
+    FLOPs: 48457664
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 8242701
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_small_075
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bilinear
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L421
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_small_100
+  Metadata:
+    FLOPs: 65450600
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 10256398
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_small_100
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bilinear
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L430
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_small_minimal_100
+  Metadata:
+    FLOPs: 60827936
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 8258083
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_small_minimal_100
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bilinear
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L439
+  In Collection: TF MobileNet V3
+Collections:
+- Name: TF MobileNet V3
+  Paper:
+    title: Searching for MobileNetV3
+    url: https://papperswithcode.com//paper/searching-for-mobilenetv3
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/tf-mobilenet-v3.md
+++ b/modelindex/.templates/models/tf-mobilenet-v3.md
@@ -265,7 +265,7 @@ Collections:
 - Name: TF MobileNet V3
   Paper:
     title: Searching for MobileNetV3
-    url: https://papperswithcode.com//paper/searching-for-mobilenetv3
+    url: https://paperswithcode.com//paper/searching-for-mobilenetv3
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/tf-mobilenet-v3.md
+++ b/modelindex/.templates/models/tf-mobilenet-v3.md
@@ -38,17 +38,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF MobileNet V3
+  Paper:
+    Title: Searching for MobileNetV3
+    URL: https://paperswithcode.com/paper/searching-for-mobilenetv3
 Models:
 - Name: tf_mobilenetv3_large_075
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 194323712
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
+    Parameters: 3990000
+    File Size: 16097377
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -63,29 +65,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 16097377
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
     ID: tf_mobilenetv3_large_075
     LR: 0.1
     Dropout: 0.8
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L394
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_large_075-150ee8b0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.45%
+      Top 5 Accuracy: 91.34%
 - Name: tf_mobilenetv3_large_100
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 274535288
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
+    Parameters: 5480000
+    File Size: 22076649
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -100,29 +110,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 22076649
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
     ID: tf_mobilenetv3_large_100
     LR: 0.1
     Dropout: 0.8
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L403
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_large_100-427764d5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.51%
+      Top 5 Accuracy: 92.61%
 - Name: tf_mobilenetv3_large_minimal_100
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 267216928
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
+    Parameters: 3920000
+    File Size: 15836368
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -137,29 +155,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 15836368
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
     ID: tf_mobilenetv3_large_minimal_100
     LR: 0.1
     Dropout: 0.8
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L412
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_large_minimal_100-8596ae28.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.24%
+      Top 5 Accuracy: 90.64%
 - Name: tf_mobilenetv3_small_075
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 48457664
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 2040000
+    File Size: 8242701
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -174,29 +200,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 8242701
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: tf_mobilenetv3_small_075
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bilinear
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L421
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_small_075-da427f52.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 65.72%
+      Top 5 Accuracy: 86.13%
 - Name: tf_mobilenetv3_small_100
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 65450600
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 2540000
+    File Size: 10256398
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -211,29 +245,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 10256398
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: tf_mobilenetv3_small_100
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bilinear
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L430
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_small_100-37f49e2b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 67.92%
+      Top 5 Accuracy: 87.68%
 - Name: tf_mobilenetv3_small_minimal_100
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 60827936
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 2040000
+    File Size: 8258083
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -248,24 +290,29 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 8258083
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: tf_mobilenetv3_small_minimal_100
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bilinear
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L439
-  In Collection: TF MobileNet V3
-Collections:
-- Name: TF MobileNet V3
-  Paper:
-    title: Searching for MobileNetV3
-    url: https://paperswithcode.com//paper/searching-for-mobilenetv3
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_small_minimal_100-922a7843.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 62.91%
+      Top 5 Accuracy: 84.24%
 -->

--- a/modelindex/.templates/models/tresnet.md
+++ b/modelindex/.templates/models/tresnet.md
@@ -22,20 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TResNet
+  Paper:
+    Title: 'TResNet: High Performance GPU-Dedicated Architecture'
+    URL: https://paperswithcode.com/paper/tresnet-high-performance-gpu-dedicated
 Models:
 - Name: tresnet_l
+  In Collection: TResNet
   Metadata:
     FLOPs: 10873416792
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 53456696
+    File Size: 224440219
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -46,33 +45,39 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 224440219
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_l
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L267
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_l_81_5-235b486c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.49%
+      Top 5 Accuracy: 95.62%
 - Name: tresnet_l_448
+  In Collection: TResNet
   Metadata:
     FLOPs: 43488238584
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 53456696
+    File Size: 224440219
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -83,33 +88,39 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 224440219
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_l_448
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '448'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L285
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_l_448-940d0cd1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.26%
+      Top 5 Accuracy: 95.98%
 - Name: tresnet_m
+  In Collection: TResNet
   Metadata:
     FLOPs: 5733048064
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 41282200
+    File Size: 125861314
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -120,33 +131,40 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 125861314
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     Training Time: < 24 hours
     ID: tresnet_m
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L261
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_m_80_8-dbc13962.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.8%
+      Top 5 Accuracy: 94.86%
 - Name: tresnet_m_448
+  In Collection: TResNet
   Metadata:
     FLOPs: 22929743104
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 29278464
+    File Size: 125861314
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -157,33 +175,39 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 125861314
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_m_448
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '448'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L279
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_m_448-bc359d10.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.72%
+      Top 5 Accuracy: 95.57%
 - Name: tresnet_xl
+  In Collection: TResNet
   Metadata:
     FLOPs: 15162534034
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 75646610
+    File Size: 314378965
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -194,33 +218,39 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 314378965
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_xl
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L273
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_xl_82_0-a2d51b00.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.05%
+      Top 5 Accuracy: 95.93%
 - Name: tresnet_xl_448
+  In Collection: TResNet
   Metadata:
     FLOPs: 60641712730
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 75646610
+    File Size: 224440219
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -231,25 +261,31 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 224440219
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_xl_448
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '448'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L291
-  Config: ''
-  In Collection: TResNet
-Collections:
-- Name: TResNet
-  Paper:
-    title: 'TResNet: High Performance GPU-Dedicated Architecture'
-    url: https://paperswithcode.com//paper/tresnet-high-performance-gpu-dedicated
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_l_448-940d0cd1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.06%
+      Top 5 Accuracy: 96.19%
 -->

--- a/modelindex/.templates/models/tresnet.md
+++ b/modelindex/.templates/models/tresnet.md
@@ -1,0 +1,255 @@
+# Summary
+
+A **TResNet** is a variant on a [ResNet](https://paperswithcode.com/method/resnet) that aim to boost accuracy while maintaining GPU training and inference efficiency.  They contain several design tricks including a SpaceToDepth stem, [Anti-Alias downsampling](https://paperswithcode.com/method/anti-alias-downsampling), In-Place Activated BatchNorm, Blocks selection and [squeeze-and-excitation layers](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{ridnik2020tresnet,
+      title={TResNet: High Performance GPU-Dedicated Architecture}, 
+      author={Tal Ridnik and Hussam Lawen and Asaf Noy and Emanuel Ben Baruch and Gilad Sharir and Itamar Friedman},
+      year={2020},
+      eprint={2003.13630},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: tresnet_l
+  Metadata:
+    FLOPs: 10873416792
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 224440219
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_l
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L267
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_l_448
+  Metadata:
+    FLOPs: 43488238584
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 224440219
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_l_448
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '448'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L285
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_m
+  Metadata:
+    FLOPs: 5733048064
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 125861314
+    Tasks:
+    - Image Classification
+    Training Time: < 24 hours
+    ID: tresnet_m
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L261
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_m_448
+  Metadata:
+    FLOPs: 22929743104
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 125861314
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_m_448
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '448'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L279
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_xl
+  Metadata:
+    FLOPs: 15162534034
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 314378965
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_xl
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L273
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_xl_448
+  Metadata:
+    FLOPs: 60641712730
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 224440219
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_xl_448
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '448'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L291
+  Config: ''
+  In Collection: TResNet
+Collections:
+- Name: TResNet
+  Paper:
+    title: 'TResNet: High Performance GPU-Dedicated Architecture'
+    url: https://papperswithcode.com//paper/tresnet-high-performance-gpu-dedicated
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/tresnet.md
+++ b/modelindex/.templates/models/tresnet.md
@@ -249,7 +249,7 @@ Collections:
 - Name: TResNet
   Paper:
     title: 'TResNet: High Performance GPU-Dedicated Architecture'
-    url: https://papperswithcode.com//paper/tresnet-high-performance-gpu-dedicated
+    url: https://paperswithcode.com//paper/tresnet-high-performance-gpu-dedicated
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/vision-transformer.md
+++ b/modelindex/.templates/models/vision-transformer.md
@@ -22,55 +22,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Vision Transformer
+  Paper:
+    Title: 'An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale'
+    URL: https://paperswithcode.com/paper/an-image-is-worth-16x16-words-transformers-1
 Models:
-- Name: vit_large_patch16_384
-  Metadata:
-    FLOPs: 174702764032
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
-    Architecture:
-    - Attention Dropout
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - GELU
-    - Layer Normalization
-    - Multi-Head Attention
-    - Scaled Dot-Product Attention
-    - Tanh Activation
-    File Size: 1218907013
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: vit_large_patch16_384
-    Crop Pct: '1.0'
-    Momentum: 0.9
-    Image Size: '384'
-    Weight Decay: 0.0
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L561
-  Config: ''
-  In Collection: Vision Transformer
 - Name: vit_base_patch16_224
+  In Collection: Vision Transformer
   Metadata:
     FLOPs: 67394605056
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    Parameters: 86570000
+    File Size: 346292833
     Architecture:
     - Attention Dropout
     - Convolution
@@ -81,33 +45,40 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 346292833
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_base_patch16_224
     LR: 0.0008
+    Epochs: 90
     Dropout: 0.0
     Crop Pct: '0.9'
+    Batch Size: 4096
     Image Size: '224'
     Warmup Steps: 10000
     Weight Decay: 0.03
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L503
-  Config: ''
-  In Collection: Vision Transformer
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_base_p16_224-80ecf9dd.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.78%
+      Top 5 Accuracy: 96.13%
 - Name: vit_base_patch16_384
+  In Collection: Vision Transformer
   Metadata:
     FLOPs: 49348245504
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    Parameters: 86860000
+    File Size: 347460194
     Architecture:
     - Attention Dropout
     - Convolution
@@ -118,66 +89,37 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 347460194
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_base_patch16_384
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '384'
     Weight Decay: 0.0
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L522
-  Config: ''
-  In Collection: Vision Transformer
-- Name: vit_large_patch16_224
-  Metadata:
-    FLOPs: 119294746624
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
-    Architecture:
-    - Attention Dropout
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - GELU
-    - Layer Normalization
-    - Multi-Head Attention
-    - Scaled Dot-Product Attention
-    - Tanh Activation
-    File Size: 1217350532
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: vit_large_patch16_224
-    Crop Pct: '0.9'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L542
-  Config: ''
-  In Collection: Vision Transformer
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_base_p16_384-83fb41ba.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.2%
+      Top 5 Accuracy: 97.22%
 - Name: vit_base_patch32_384
+  In Collection: Vision Transformer
   Metadata:
     FLOPs: 12656142336
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    Parameters: 88300000
+    File Size: 353210979
     Architecture:
     - Attention Dropout
     - Convolution
@@ -188,31 +130,37 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 353210979
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_base_patch32_384
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '384'
     Weight Decay: 0.0
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L532
-  Config: ''
-  In Collection: Vision Transformer
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_base_p32_384-830016f5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.66%
+      Top 5 Accuracy: 96.13%
 - Name: vit_base_resnet50_384
+  In Collection: Vision Transformer
   Metadata:
     FLOPs: 49461491712
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    Parameters: 98950000
+    File Size: 395854632
     Architecture:
     - Attention Dropout
     - Convolution
@@ -223,30 +171,37 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 395854632
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_base_resnet50_384
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '384'
     Weight Decay: 0.0
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L653
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_base_resnet50_384-9fd3c705.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.99%
+      Top 5 Accuracy: 97.3%
+- Name: vit_large_patch16_224
   In Collection: Vision Transformer
-- Name: vit_small_patch16_224
   Metadata:
-    FLOPs: 28236450816
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    FLOPs: 119294746624
+    Parameters: 304330000
+    File Size: 1217350532
     Architecture:
     - Attention Dropout
     - Convolution
@@ -257,22 +212,108 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 195031454
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
+    ID: vit_large_patch16_224
+    Crop Pct: '0.9'
+    Momentum: 0.9
+    Batch Size: 512
+    Image Size: '224'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L542
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_large_p16_224-4ee7a4dc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.06%
+      Top 5 Accuracy: 96.44%
+- Name: vit_large_patch16_384
+  In Collection: Vision Transformer
+  Metadata:
+    FLOPs: 174702764032
+    Parameters: 304720000
+    File Size: 1218907013
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
+    ID: vit_large_patch16_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Batch Size: 512
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L561
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_large_p16_384-b3be5167.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.17%
+      Top 5 Accuracy: 97.36%
+- Name: vit_small_patch16_224
+  In Collection: Vision Transformer
+  Metadata:
+    FLOPs: 28236450816
+    Parameters: 48750000
+    File Size: 195031454
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_small_patch16_224
     Crop Pct: '0.9'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L490
-  Config: ''
-  In Collection: Vision Transformer
-Collections:
-- Name: Vision Transformer
-  Paper:
-    title: 'An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale'
-    url: https://paperswithcode.com//paper/an-image-is-worth-16x16-words-transformers-1
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/vit_small_p16_224-15ec54c9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.85%
+      Top 5 Accuracy: 93.42%
 -->

--- a/modelindex/.templates/models/vision-transformer.md
+++ b/modelindex/.templates/models/vision-transformer.md
@@ -1,0 +1,278 @@
+# Summary
+
+The **Vision Transformer** is a model for image classification that employs a Transformer-like architecture over patches of the image. This includes the use of [Multi-Head Attention](https://paperswithcode.com/method/multi-head-attention), [Scaled Dot-Product Attention](https://paperswithcode.com/method/scaled) and other architectural features seen in the [Transformer](https://paperswithcode.com/method/transformer) architecture traditionally used for NLP.
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{dosovitskiy2020image,
+      title={An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale}, 
+      author={Alexey Dosovitskiy and Lucas Beyer and Alexander Kolesnikov and Dirk Weissenborn and Xiaohua Zhai and Thomas Unterthiner and Mostafa Dehghani and Matthias Minderer and Georg Heigold and Sylvain Gelly and Jakob Uszkoreit and Neil Houlsby},
+      year={2020},
+      eprint={2010.11929},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: vit_large_patch16_384
+  Metadata:
+    FLOPs: 174702764032
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 1218907013
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_large_patch16_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L561
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_base_patch16_224
+  Metadata:
+    FLOPs: 67394605056
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 346292833
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_base_patch16_224
+    LR: 0.0008
+    Dropout: 0.0
+    Crop Pct: '0.9'
+    Image Size: '224'
+    Warmup Steps: 10000
+    Weight Decay: 0.03
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L503
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_base_patch16_384
+  Metadata:
+    FLOPs: 49348245504
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 347460194
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_base_patch16_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L522
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_large_patch16_224
+  Metadata:
+    FLOPs: 119294746624
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 1217350532
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_large_patch16_224
+    Crop Pct: '0.9'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L542
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_base_patch32_384
+  Metadata:
+    FLOPs: 12656142336
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 353210979
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_base_patch32_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L532
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_base_resnet50_384
+  Metadata:
+    FLOPs: 49461491712
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 395854632
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_base_resnet50_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L653
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_small_patch16_224
+  Metadata:
+    FLOPs: 28236450816
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 195031454
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_small_patch16_224
+    Crop Pct: '0.9'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L490
+  Config: ''
+  In Collection: Vision Transformer
+Collections:
+- Name: Vision Transformer
+  Paper:
+    title: 'An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale'
+    url: https://papperswithcode.com//paper/an-image-is-worth-16x16-words-transformers-1
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/vision-transformer.md
+++ b/modelindex/.templates/models/vision-transformer.md
@@ -272,7 +272,7 @@ Collections:
 - Name: Vision Transformer
   Paper:
     title: 'An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale'
-    url: https://papperswithcode.com//paper/an-image-is-worth-16x16-words-transformers-1
+    url: https://paperswithcode.com//paper/an-image-is-worth-16x16-words-transformers-1
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/wide-resnet.md
+++ b/modelindex/.templates/models/wide-resnet.md
@@ -81,7 +81,7 @@ Collections:
 - Name: Wide ResNet
   Paper:
     title: Wide Residual Networks
-    url: https://papperswithcode.com//paper/wide-residual-networks
+    url: https://paperswithcode.com//paper/wide-residual-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/wide-resnet.md
+++ b/modelindex/.templates/models/wide-resnet.md
@@ -28,12 +28,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Wide ResNet
+  Paper:
+    Title: Wide Residual Networks
+    URL: https://paperswithcode.com/paper/wide-residual-networks
 Models:
 - Name: wide_resnet101_2
+  In Collection: Wide ResNet
   Metadata:
     FLOPs: 29304929280
-    Training Data:
-    - ImageNet
+    Parameters: 126890000
+    File Size: 254695146
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -44,20 +51,28 @@ Models:
     - Residual Connection
     - Softmax
     - Wide Residual Block
-    File Size: 254695146
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: wide_resnet101_2
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/resnet.py#L802
-  In Collection: Wide ResNet
+  Weights: https://download.pytorch.org/models/wide_resnet101_2-32ee1156.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.85%
+      Top 5 Accuracy: 94.28%
 - Name: wide_resnet50_2
+  In Collection: Wide ResNet
   Metadata:
     FLOPs: 14688058368
-    Training Data:
-    - ImageNet
+    Parameters: 68880000
+    File Size: 275853271
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -68,20 +83,20 @@ Models:
     - Residual Connection
     - Softmax
     - Wide Residual Block
-    File Size: 275853271
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: wide_resnet50_2
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/resnet.py#L790
-  In Collection: Wide ResNet
-Collections:
-- Name: Wide ResNet
-  Paper:
-    title: Wide Residual Networks
-    url: https://paperswithcode.com//paper/wide-residual-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/wide_resnet50_racm-8234f177.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.45%
+      Top 5 Accuracy: 95.52%
 -->

--- a/modelindex/.templates/models/wide-resnet.md
+++ b/modelindex/.templates/models/wide-resnet.md
@@ -1,0 +1,87 @@
+# Summary
+
+**Wide Residual Networks** are a variant on [ResNets](https://paperswithcode.com/method/resnet) where we decrease depth and increase the width of residual networks. This is achieved through the use of [wide residual blocks](https://paperswithcode.com/method/wide-residual-block).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/ZagoruykoK16,
+  author    = {Sergey Zagoruyko and
+               Nikos Komodakis},
+  title     = {Wide Residual Networks},
+  journal   = {CoRR},
+  volume    = {abs/1605.07146},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1605.07146},
+  archivePrefix = {arXiv},
+  eprint    = {1605.07146},
+  timestamp = {Mon, 13 Aug 2018 16:46:42 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/ZagoruykoK16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: wide_resnet101_2
+  Metadata:
+    FLOPs: 29304929280
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Wide Residual Block
+    File Size: 254695146
+    Tasks:
+    - Image Classification
+    ID: wide_resnet101_2
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/resnet.py#L802
+  In Collection: Wide ResNet
+- Name: wide_resnet50_2
+  Metadata:
+    FLOPs: 14688058368
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Wide Residual Block
+    File Size: 275853271
+    Tasks:
+    - Image Classification
+    ID: wide_resnet50_2
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/resnet.py#L790
+  In Collection: Wide ResNet
+Collections:
+- Name: Wide ResNet
+  Paper:
+    title: Wide Residual Networks
+    url: https://papperswithcode.com//paper/wide-residual-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/.templates/models/xception.md
+++ b/modelindex/.templates/models/xception.md
@@ -124,7 +124,7 @@ Collections:
 - Name: Xception
   Paper:
     title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
-    url: https://papperswithcode.com//paper/xception-deep-learning-with-depthwise
+    url: https://paperswithcode.com//paper/xception-deep-learning-with-depthwise
   type: model-index
 Type: model-index
 -->

--- a/modelindex/.templates/models/xception.md
+++ b/modelindex/.templates/models/xception.md
@@ -23,12 +23,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Xception
+  Paper:
+    Title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
+    URL: https://paperswithcode.com/paper/xception-deep-learning-with-depthwise
 Models:
 - Name: xception
+  In Collection: Xception
   Metadata:
     FLOPs: 10600506792
-    Training Data:
-    - ImageNet
+    Parameters: 22860000
+    File Size: 91675053
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -39,20 +46,28 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 91675053
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: xception
     Crop Pct: '0.897'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception.py#L229
-  In Collection: Xception
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/xception-43020ad28.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.05%
+      Top 5 Accuracy: 94.4%
 - Name: xception41
+  In Collection: Xception
   Metadata:
     FLOPs: 11681983232
-    Training Data:
-    - ImageNet
+    Parameters: 26970000
+    File Size: 108422028
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -63,20 +78,28 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 108422028
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: xception41
     Crop Pct: '0.903'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L181
-  In Collection: Xception
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_xception_41-e6439c97.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.54%
+      Top 5 Accuracy: 94.28%
 - Name: xception65
+  In Collection: Xception
   Metadata:
     FLOPs: 17585702144
-    Training Data:
-    - ImageNet
+    Parameters: 39920000
+    File Size: 160536780
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -87,20 +110,28 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 160536780
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: xception65
     Crop Pct: '0.903'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L200
-  In Collection: Xception
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_xception_65-c9ae96e8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.55%
+      Top 5 Accuracy: 94.66%
 - Name: xception71
+  In Collection: Xception
   Metadata:
     FLOPs: 22817346560
-    Training Data:
-    - ImageNet
+    Parameters: 42340000
+    File Size: 170295556
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -111,20 +142,20 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 170295556
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: xception71
     Crop Pct: '0.903'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L219
-  In Collection: Xception
-Collections:
-- Name: Xception
-  Paper:
-    title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
-    url: https://paperswithcode.com//paper/xception-deep-learning-with-depthwise
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_xception_71-8eec7df1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.88%
+      Top 5 Accuracy: 94.93%
 -->

--- a/modelindex/.templates/models/xception.md
+++ b/modelindex/.templates/models/xception.md
@@ -1,0 +1,130 @@
+# Summary
+
+**Xception** is a convolutional neural network architecture that relies solely on [depthwise separable convolution layers](https://paperswithcode.com/method/depthwise-separable-convolution).
+
+{% include 'code_snippets.md' %}
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/ZagoruykoK16,
+@misc{chollet2017xception,
+      title={Xception: Deep Learning with Depthwise Separable Convolutions}, 
+      author={François Chollet},
+      year={2017},
+      eprint={1610.02357},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: xception
+  Metadata:
+    FLOPs: 10600506792
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 91675053
+    Tasks:
+    - Image Classification
+    ID: xception
+    Crop Pct: '0.897'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception.py#L229
+  In Collection: Xception
+- Name: xception41
+  Metadata:
+    FLOPs: 11681983232
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 108422028
+    Tasks:
+    - Image Classification
+    ID: xception41
+    Crop Pct: '0.903'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L181
+  In Collection: Xception
+- Name: xception65
+  Metadata:
+    FLOPs: 17585702144
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 160536780
+    Tasks:
+    - Image Classification
+    ID: xception65
+    Crop Pct: '0.903'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L200
+  In Collection: Xception
+- Name: xception71
+  Metadata:
+    FLOPs: 22817346560
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 170295556
+    Tasks:
+    - Image Classification
+    ID: xception71
+    Crop Pct: '0.903'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L219
+  In Collection: Xception
+Collections:
+- Name: Xception
+  Paper:
+    title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
+    url: https://papperswithcode.com//paper/xception-deep-learning-with-depthwise
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/generate_readmes.py
+++ b/modelindex/generate_readmes.py
@@ -1,3 +1,7 @@
+"""
+Run this script to generate the model-index files in `models` from the templates in `.templates/models`.
+"""
+
 import argparse
 from pathlib import Path
 

--- a/modelindex/generate_readmes.py
+++ b/modelindex/generate_readmes.py
@@ -1,0 +1,60 @@
+import argparse
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+import modelindex
+
+
+def generate_readmes(templates_path: Path, dest_path: Path):
+    """Add the code snippet template to the readmes"""
+    readme_templates_path = templates_path / "models"
+    code_template_path = templates_path / "code_snippets.md"
+
+    env = Environment(
+        loader=FileSystemLoader([readme_templates_path, readme_templates_path.parent]),
+    )
+
+    for readme in readme_templates_path.iterdir():
+        if readme.suffix == ".md":
+            template = env.get_template(readme.name)
+
+            # get the first model_name for this model family
+            mi = modelindex.load(str(readme))
+            model_name = mi.models[0].name
+
+            full_content = template.render(model_name=model_name)
+
+            # generate full_readme
+            with open(dest_path / readme.name, "w") as f:
+                f.write(full_content)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Model index generation config")
+    parser.add_argument(
+        "-t",
+        "--templates",
+        default=Path(__file__).parent / ".templates",
+        type=str,
+        help="Location of the markdown templates",
+    )
+    parser.add_argument(
+        "-d",
+        "--dest",
+        default=Path(__file__).parent / "models",
+        type=str,
+        help="Destination folder that contains the generated model-index files.",
+    )
+    args = parser.parse_args()
+    templates_path = Path(args.templates)
+    dest_readmes_path = Path(args.dest)
+
+    generate_readmes(
+        templates_path,
+        dest_readmes_path,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/modelindex/model-index.yml
+++ b/modelindex/model-index.yml
@@ -1,0 +1,14 @@
+Import:
+- ./models/*.md
+Library:
+  Name: PyTorch Image Models
+  Headline: PyTorch image models, scripts, pretrained weights
+  Website: https://rwightman.github.io/pytorch-image-models/
+  Repository: https://github.com/rwightman/pytorch-image-models
+  Docs: https://rwightman.github.io/pytorch-image-models/
+  README: "# PyTorch Image Models\r\n\r\nPyTorch Image Models (TIMM) is a library\
+    \ for state-of-the-art image classification. With this library you can:\r\n\r\n\
+    - Choose from 300+ pre-trained state-of-the-art image classification models.\r\
+    \n- Train models afresh on research datasets such as ImageNet using provided scripts.\r\
+    \n- Finetune pre-trained models on your own datasets, including the latest cutting\
+    \ edge models."

--- a/modelindex/models/adversarial-inception-v3.md
+++ b/modelindex/models/adversarial-inception-v3.md
@@ -144,7 +144,7 @@ Collections:
 - Name: Adversarial Inception v3
   Paper:
     title: Adversarial Attacks and Defences Competition
-    url: https://papperswithcode.com//paper/adversarial-attacks-and-defences-competition
+    url: https://paperswithcode.com//paper/adversarial-attacks-and-defences-competition
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/adversarial-inception-v3.md
+++ b/modelindex/models/adversarial-inception-v3.md
@@ -112,12 +112,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Adversarial Inception v3
+  Paper:
+    Title: Adversarial Attacks and Defences Competition
+    URL: https://paperswithcode.com/paper/adversarial-attacks-and-defences-competition
 Models:
 - Name: adv_inception_v3
+  In Collection: Adversarial Inception v3
   Metadata:
     FLOPs: 7352418880
-    Training Data:
-    - ImageNet
+    Parameters: 23830000
+    File Size: 95549439
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -131,20 +138,20 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 95549439
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: adv_inception_v3
     Crop Pct: '0.875'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L456
-  In Collection: Adversarial Inception v3
-Collections:
-- Name: Adversarial Inception v3
-  Paper:
-    title: Adversarial Attacks and Defences Competition
-    url: https://paperswithcode.com//paper/adversarial-attacks-and-defences-competition
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/adv_inception_v3-9e27bd63.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.58%
+      Top 5 Accuracy: 93.74%
 -->

--- a/modelindex/models/adversarial-inception-v3.md
+++ b/modelindex/models/adversarial-inception-v3.md
@@ -1,0 +1,150 @@
+# Summary
+
+**Inception v3** is a convolutional neural network architecture from the Inception family that makes several improvements including using [Label Smoothing](https://paperswithcode.com/method/label-smoothing), Factorized 7 x 7 convolutions, and the use of an [auxiliary classifer](https://paperswithcode.com/method/auxiliary-classifier) to propagate label information lower down the network (along with the use of batch normalization for layers in the sidehead). The key building block is an [Inception Module](https://paperswithcode.com/method/inception-v3-module).
+
+This particular model was trained for study of adversarial examples (adversarial training).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('adv_inception_v3', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `adv_inception_v3`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('adv_inception_v3', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1804-00097,
+  author    = {Alexey Kurakin and
+               Ian J. Goodfellow and
+               Samy Bengio and
+               Yinpeng Dong and
+               Fangzhou Liao and
+               Ming Liang and
+               Tianyu Pang and
+               Jun Zhu and
+               Xiaolin Hu and
+               Cihang Xie and
+               Jianyu Wang and
+               Zhishuai Zhang and
+               Zhou Ren and
+               Alan L. Yuille and
+               Sangxia Huang and
+               Yao Zhao and
+               Yuzhe Zhao and
+               Zhonglin Han and
+               Junjiajia Long and
+               Yerkebulan Berdibekov and
+               Takuya Akiba and
+               Seiya Tokui and
+               Motoki Abe},
+  title     = {Adversarial Attacks and Defences Competition},
+  journal   = {CoRR},
+  volume    = {abs/1804.00097},
+  year      = {2018},
+  url       = {http://arxiv.org/abs/1804.00097},
+  archivePrefix = {arXiv},
+  eprint    = {1804.00097},
+  timestamp = {Thu, 31 Oct 2019 16:31:22 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1804-00097.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: adv_inception_v3
+  Metadata:
+    FLOPs: 7352418880
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 95549439
+    Tasks:
+    - Image Classification
+    ID: adv_inception_v3
+    Crop Pct: '0.875'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L456
+  In Collection: Adversarial Inception v3
+Collections:
+- Name: Adversarial Inception v3
+  Paper:
+    title: Adversarial Attacks and Defences Competition
+    url: https://papperswithcode.com//paper/adversarial-attacks-and-defences-competition
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/advprop.md
+++ b/modelindex/models/advprop.md
@@ -439,7 +439,7 @@ Collections:
 - Name: AdvProp
   Paper:
     title: Adversarial Examples Improve Image Recognition
-    url: https://papperswithcode.com//paper/adversarial-examples-improve-image
+    url: https://paperswithcode.com//paper/adversarial-examples-improve-image
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/advprop.md
+++ b/modelindex/models/advprop.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('tf_efficientnet_b1_ap', pretrained=True)
+model = timm.create_model('tf_efficientnet_b0_ap', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `tf_efficientnet_b1_ap`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_b0_ap`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('tf_efficientnet_b1_ap', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('tf_efficientnet_b0_ap', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -83,333 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: AdvProp
+  Paper:
+    Title: Adversarial Examples Improve Image Recognition
+    URL: https://paperswithcode.com/paper/adversarial-examples-improve-image
 Models:
-- Name: tf_efficientnet_b1_ap
-  Metadata:
-    FLOPs: 883633200
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 31515350
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b1_ap
-    LR: 0.256
-    Crop Pct: '0.882'
-    Momentum: 0.9
-    Image Size: '240'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1344
-  In Collection: AdvProp
-- Name: tf_efficientnet_b2_ap
-  Metadata:
-    FLOPs: 1234321170
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 36800745
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b2_ap
-    LR: 0.256
-    Crop Pct: '0.89'
-    Momentum: 0.9
-    Image Size: '260'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1354
-  In Collection: AdvProp
-- Name: tf_efficientnet_b3_ap
-  Metadata:
-    FLOPs: 2275247568
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49384538
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b3_ap
-    LR: 0.256
-    Crop Pct: '0.904'
-    Momentum: 0.9
-    Image Size: '300'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1364
-  In Collection: AdvProp
-- Name: tf_efficientnet_b4_ap
-  Metadata:
-    FLOPs: 5749638672
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 77993585
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b4_ap
-    LR: 0.256
-    Crop Pct: '0.922'
-    Momentum: 0.9
-    Image Size: '380'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1374
-  In Collection: AdvProp
-- Name: tf_efficientnet_b5_ap
-  Metadata:
-    FLOPs: 13176501888
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 122403150
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b5_ap
-    LR: 0.256
-    Crop Pct: '0.934'
-    Momentum: 0.9
-    Image Size: '456'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1384
-  In Collection: AdvProp
-- Name: tf_efficientnet_b6_ap
-  Metadata:
-    FLOPs: 24180518488
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 173237466
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b6_ap
-    LR: 0.256
-    Crop Pct: '0.942'
-    Momentum: 0.9
-    Image Size: '528'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1394
-  In Collection: AdvProp
-- Name: tf_efficientnet_b7_ap
-  Metadata:
-    FLOPs: 48205304880
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 266850607
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b7_ap
-    LR: 0.256
-    Crop Pct: '0.949'
-    Momentum: 0.9
-    Image Size: '600'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1405
-  In Collection: AdvProp
-- Name: tf_efficientnet_b8_ap
-  Metadata:
-    FLOPs: 80962956270
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 351412563
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b8_ap
-    LR: 0.128
-    Crop Pct: '0.954'
-    Momentum: 0.9
-    Image Size: '672'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1416
-  In Collection: AdvProp
 - Name: tf_efficientnet_b0_ap
+  In Collection: AdvProp
   Metadata:
     FLOPs: 488688572
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AdvProp
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 5290000
+    File Size: 21385973
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -420,13 +106,23 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 21385973
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b0_ap
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -434,12 +130,387 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1334
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b0_ap-f262efe1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.1%
+      Top 5 Accuracy: 93.26%
+- Name: tf_efficientnet_b1_ap
   In Collection: AdvProp
-Collections:
-- Name: AdvProp
-  Paper:
-    title: Adversarial Examples Improve Image Recognition
-    url: https://paperswithcode.com//paper/adversarial-examples-improve-image
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 883633200
+    Parameters: 7790000
+    File Size: 31515350
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b1_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1344
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b1_ap-44ef0a3d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.28%
+      Top 5 Accuracy: 94.3%
+- Name: tf_efficientnet_b2_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 1234321170
+    Parameters: 9110000
+    File Size: 36800745
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b2_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1354
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b2_ap-2f8e7636.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.3%
+      Top 5 Accuracy: 95.03%
+- Name: tf_efficientnet_b3_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 2275247568
+    Parameters: 12230000
+    File Size: 49384538
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b3_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1364
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b3_ap-aad25bdd.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.82%
+      Top 5 Accuracy: 95.62%
+- Name: tf_efficientnet_b4_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 5749638672
+    Parameters: 19340000
+    File Size: 77993585
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b4_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1374
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b4_ap-dedb23e6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.26%
+      Top 5 Accuracy: 96.39%
+- Name: tf_efficientnet_b5_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 13176501888
+    Parameters: 30390000
+    File Size: 122403150
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b5_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1384
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_ap-9e82fae8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.25%
+      Top 5 Accuracy: 96.97%
+- Name: tf_efficientnet_b6_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 24180518488
+    Parameters: 43040000
+    File Size: 173237466
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b6_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1394
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b6_ap-4ffb161f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.79%
+      Top 5 Accuracy: 97.14%
+- Name: tf_efficientnet_b7_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 48205304880
+    Parameters: 66349999
+    File Size: 266850607
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b7_ap
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.949'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '600'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1405
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b7_ap-ddb28fec.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.12%
+      Top 5 Accuracy: 97.25%
+- Name: tf_efficientnet_b8_ap
+  In Collection: AdvProp
+  Metadata:
+    FLOPs: 80962956270
+    Parameters: 87410000
+    File Size: 351412563
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b8_ap
+    LR: 0.128
+    Epochs: 350
+    Crop Pct: '0.954'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '672'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1416
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b8_ap-00e169fa.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.37%
+      Top 5 Accuracy: 97.3%
 -->

--- a/modelindex/models/advprop.md
+++ b/modelindex/models/advprop.md
@@ -1,0 +1,445 @@
+# Summary
+
+**AdvProp** is an adversarial training scheme which treats adversarial examples as additional examples, to prevent overfitting. Key to the method is the usage of a separate auxiliary batch norm for adversarial examples, as they have different underlying distributions to normal examples.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('tf_efficientnet_b1_ap', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_b1_ap`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('tf_efficientnet_b1_ap', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{xie2020adversarial,
+      title={Adversarial Examples Improve Image Recognition}, 
+      author={Cihang Xie and Mingxing Tan and Boqing Gong and Jiang Wang and Alan Yuille and Quoc V. Le},
+      year={2020},
+      eprint={1911.09665},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_b1_ap
+  Metadata:
+    FLOPs: 883633200
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 31515350
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b1_ap
+    LR: 0.256
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1344
+  In Collection: AdvProp
+- Name: tf_efficientnet_b2_ap
+  Metadata:
+    FLOPs: 1234321170
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 36800745
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b2_ap
+    LR: 0.256
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1354
+  In Collection: AdvProp
+- Name: tf_efficientnet_b3_ap
+  Metadata:
+    FLOPs: 2275247568
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49384538
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b3_ap
+    LR: 0.256
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1364
+  In Collection: AdvProp
+- Name: tf_efficientnet_b4_ap
+  Metadata:
+    FLOPs: 5749638672
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 77993585
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b4_ap
+    LR: 0.256
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1374
+  In Collection: AdvProp
+- Name: tf_efficientnet_b5_ap
+  Metadata:
+    FLOPs: 13176501888
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 122403150
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b5_ap
+    LR: 0.256
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1384
+  In Collection: AdvProp
+- Name: tf_efficientnet_b6_ap
+  Metadata:
+    FLOPs: 24180518488
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 173237466
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b6_ap
+    LR: 0.256
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1394
+  In Collection: AdvProp
+- Name: tf_efficientnet_b7_ap
+  Metadata:
+    FLOPs: 48205304880
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 266850607
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b7_ap
+    LR: 0.256
+    Crop Pct: '0.949'
+    Momentum: 0.9
+    Image Size: '600'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1405
+  In Collection: AdvProp
+- Name: tf_efficientnet_b8_ap
+  Metadata:
+    FLOPs: 80962956270
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 351412563
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b8_ap
+    LR: 0.128
+    Crop Pct: '0.954'
+    Momentum: 0.9
+    Image Size: '672'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1416
+  In Collection: AdvProp
+- Name: tf_efficientnet_b0_ap
+  Metadata:
+    FLOPs: 488688572
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AdvProp
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 21385973
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b0_ap
+    LR: 0.256
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1334
+  In Collection: AdvProp
+Collections:
+- Name: AdvProp
+  Paper:
+    title: Adversarial Examples Improve Image Recognition
+    url: https://papperswithcode.com//paper/adversarial-examples-improve-image
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/big-transfer.md
+++ b/modelindex/models/big-transfer.md
@@ -1,0 +1,316 @@
+# Summary
+
+**Big Transfer (BiT)** is a type of pretraining recipe that pre-trains  on a large supervised source dataset, and fine-tunes the weights on the target task. Models are trained on the JFT-300M dataset. The finetuned models contained in this collection are finetuned on ImageNet.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('resnetv2_152x4_bitm', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `resnetv2_152x4_bitm`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('resnetv2_152x4_bitm', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{kolesnikov2020big,
+      title={Big Transfer (BiT): General Visual Representation Learning}, 
+      author={Alexander Kolesnikov and Lucas Beyer and Xiaohua Zhai and Joan Puigcerver and Jessica Yung and Sylvain Gelly and Neil Houlsby},
+      year={2020},
+      eprint={1912.11370},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: resnetv2_152x4_bitm
+  Metadata:
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 3746270104
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_152x4_bitm
+    Crop Pct: '1.0'
+    Image Size: '480'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L465
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_152x2_bitm
+  Metadata:
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 945476668
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_152x2_bitm
+    Crop Pct: '1.0'
+    Image Size: '480'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L458
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_50x1_bitm
+  Metadata:
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 102242668
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_50x1_bitm
+    LR: 0.03
+    Layers: 50
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L430
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_101x3_bitm
+  Metadata:
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 1551830100
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_101x3_bitm
+    LR: 0.03
+    Layers: 101
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L451
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_50x3_bitm
+  Metadata:
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 869321580
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_50x3_bitm
+    LR: 0.03
+    Layers: 50
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L437
+  Config: ''
+  In Collection: Big Transfer
+- Name: resnetv2_101x1_bitm
+  Metadata:
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: Cloud TPUv3-512
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    File Size: 178256468
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnetv2_101x1_bitm
+    LR: 0.03
+    Layers: 101
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L444
+  Config: ''
+  In Collection: Big Transfer
+Collections:
+- Name: Big Transfer
+  Paper:
+    title: 'Big Transfer (BiT): General Visual Representation Learning'
+    url: https://papperswithcode.com//paper/large-scale-learning-of-general-visual
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/big-transfer.md
+++ b/modelindex/models/big-transfer.md
@@ -310,7 +310,7 @@ Collections:
 - Name: Big Transfer
   Paper:
     title: 'Big Transfer (BiT): General Visual Representation Learning'
-    url: https://papperswithcode.com//paper/large-scale-learning-of-general-visual
+    url: https://paperswithcode.com//paper/large-scale-learning-of-general-visual
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/big-transfer.md
+++ b/modelindex/models/big-transfer.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('resnetv2_152x4_bitm', pretrained=True)
+model = timm.create_model('resnetv2_101x1_bitm', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `resnetv2_152x4_bitm`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `resnetv2_101x1_bitm`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('resnetv2_152x4_bitm', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('resnetv2_101x1_bitm', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -83,50 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Big Transfer
+  Paper:
+    Title: 'Big Transfer (BiT): General Visual Representation Learning'
+    URL: https://paperswithcode.com/paper/large-scale-learning-of-general-visual
 Models:
-- Name: resnetv2_152x4_bitm
-  Metadata:
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
-    Architecture:
-    - 1x1 Convolution
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Group Normalization
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    - Weight Standardization
-    File Size: 3746270104
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnetv2_152x4_bitm
-    Crop Pct: '1.0'
-    Image Size: '480'
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L465
-  Config: ''
+- Name: resnetv2_101x1_bitm
   In Collection: Big Transfer
-- Name: resnetv2_152x2_bitm
   Metadata:
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    FLOPs: 5330896
+    Parameters: 44540000
+    File Size: 178256468
     Architecture:
     - 1x1 Convolution
     - Bottleneck Residual Block
@@ -139,29 +108,125 @@ Models:
     - Residual Connection
     - Softmax
     - Weight Standardization
-    File Size: 945476668
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
+    ID: resnetv2_101x1_bitm
+    LR: 0.03
+    Epochs: 90
+    Layers: 101
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Batch Size: 4096
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L444
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R101x1-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.21%
+      Top 5 Accuracy: 96.47%
+- Name: resnetv2_101x3_bitm
+  In Collection: Big Transfer
+  Metadata:
+    FLOPs: 15988688
+    Parameters: 387930000
+    File Size: 1551830100
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
+    ID: resnetv2_101x3_bitm
+    LR: 0.03
+    Epochs: 90
+    Layers: 101
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Batch Size: 4096
+    Image Size: '480'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L451
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R101x3-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.38%
+      Top 5 Accuracy: 97.37%
+- Name: resnetv2_152x2_bitm
+  In Collection: Big Transfer
+  Metadata:
+    FLOPs: 10659792
+    Parameters: 236340000
+    File Size: 945476668
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
     ID: resnetv2_152x2_bitm
     Crop Pct: '1.0'
     Image Size: '480'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L458
-  Config: ''
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R152x2-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.4%
+      Top 5 Accuracy: 97.43%
+- Name: resnetv2_152x4_bitm
   In Collection: Big Transfer
-- Name: resnetv2_50x1_bitm
   Metadata:
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
+    FLOPs: 21317584
+    Parameters: 936530000
+    File Size: 3746270104
     Architecture:
     - 1x1 Convolution
     - Bottleneck Residual Block
@@ -174,72 +239,80 @@ Models:
     - Residual Connection
     - Softmax
     - Weight Standardization
-    File Size: 102242668
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
+    ID: resnetv2_152x4_bitm
+    Crop Pct: '1.0'
+    Image Size: '480'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L465
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R152x4-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.95%
+      Top 5 Accuracy: 97.45%
+- Name: resnetv2_50x1_bitm
+  In Collection: Big Transfer
+  Metadata:
+    FLOPs: 5330896
+    Parameters: 25550000
+    File Size: 102242668
+    Architecture:
+    - 1x1 Convolution
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Group Normalization
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Weight Standardization
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
     ID: resnetv2_50x1_bitm
     LR: 0.03
+    Epochs: 90
     Layers: 50
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '480'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L430
-  Config: ''
-  In Collection: Big Transfer
-- Name: resnetv2_101x3_bitm
-  Metadata:
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
-    Architecture:
-    - 1x1 Convolution
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Group Normalization
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    - Weight Standardization
-    File Size: 1551830100
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnetv2_101x3_bitm
-    LR: 0.03
-    Layers: 101
-    Crop Pct: '1.0'
-    Momentum: 0.9
-    Image Size: '480'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L451
-  Config: ''
-  In Collection: Big Transfer
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R50x1-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.19%
+      Top 5 Accuracy: 95.63%
 - Name: resnetv2_50x3_bitm
+  In Collection: Big Transfer
   Metadata:
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
+    FLOPs: 15988688
+    Parameters: 217320000
+    File Size: 869321580
     Architecture:
     - 1x1 Convolution
     - Bottleneck Residual Block
@@ -252,65 +325,32 @@ Models:
     - Residual Connection
     - Softmax
     - Weight Standardization
-    File Size: 869321580
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPUv3-512
     ID: resnetv2_50x3_bitm
     LR: 0.03
+    Epochs: 90
     Layers: 50
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '480'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L437
-  Config: ''
-  In Collection: Big Transfer
-- Name: resnetv2_101x1_bitm
-  Metadata:
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: Cloud TPUv3-512
-    Architecture:
-    - 1x1 Convolution
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Group Normalization
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    - Weight Standardization
-    File Size: 178256468
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnetv2_101x1_bitm
-    LR: 0.03
-    Layers: 101
-    Crop Pct: '1.0'
-    Momentum: 0.9
-    Image Size: '480'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnetv2.py#L444
-  Config: ''
-  In Collection: Big Transfer
-Collections:
-- Name: Big Transfer
-  Paper:
-    title: 'Big Transfer (BiT): General Visual Representation Learning'
-    url: https://paperswithcode.com//paper/large-scale-learning-of-general-visual
-  type: model-index
-Type: model-index
+  Weights: https://storage.googleapis.com/bit_models/BiT-M-R50x3-ILSVRC2012.npz
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.75%
+      Top 5 Accuracy: 97.12%
 -->

--- a/modelindex/models/csp-darknet.md
+++ b/modelindex/models/csp-darknet.md
@@ -85,22 +85,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: CSP DarkNet
+  Paper:
+    Title: 'YOLOv4: Optimal Speed and Accuracy of Object Detection'
+    URL: https://paperswithcode.com/paper/yolov4-optimal-speed-and-accuracy-of-object
 Models:
 - Name: cspdarknet53
+  In Collection: CSP DarkNet
   Metadata:
     FLOPs: 8545018880
-    Batch Size: 128
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - CutMix
-    - Label Smoothing
-    - Mosaic
-    - Polynomial Learning Rate Decay
-    - SGD with Momentum
-    - Self-Adversarial Training
-    - Weight Decay
-    Training Resources: 1x NVIDIA RTX 2070 GPU
+    Parameters: 27640000
+    File Size: 110775135
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -109,14 +106,25 @@ Models:
     - Mish
     - Residual Connection
     - Softmax
-    File Size: 110775135
     Tasks:
     - Image Classification
+    Training Techniques:
+    - CutMix
+    - Label Smoothing
+    - Mosaic
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Self-Adversarial Training
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 1x NVIDIA RTX 2070 GPU
     ID: cspdarknet53
     LR: 0.1
     Layers: 53
     Crop Pct: '0.887'
     Momentum: 0.9
+    Batch Size: 128
     Image Size: '256'
     Warmup Steps: 1000
     Weight Decay: 0.0005
@@ -124,12 +132,11 @@ Models:
     Training Steps: 8000000
     FPS (GPU RTX 2070): 66
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L441
-  In Collection: CSP DarkNet
-Collections:
-- Name: CSP DarkNet
-  Paper:
-    title: 'YOLOv4: Optimal Speed and Accuracy of Object Detection'
-    url: https://paperswithcode.com//paper/yolov4-optimal-speed-and-accuracy-of-object
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/cspdarknet53_ra_256-d05c7c21.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.05%
+      Top 5 Accuracy: 95.09%
 -->

--- a/modelindex/models/csp-darknet.md
+++ b/modelindex/models/csp-darknet.md
@@ -129,7 +129,7 @@ Collections:
 - Name: CSP DarkNet
   Paper:
     title: 'YOLOv4: Optimal Speed and Accuracy of Object Detection'
-    url: https://papperswithcode.com//paper/yolov4-optimal-speed-and-accuracy-of-object
+    url: https://paperswithcode.com//paper/yolov4-optimal-speed-and-accuracy-of-object
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/csp-darknet.md
+++ b/modelindex/models/csp-darknet.md
@@ -1,0 +1,135 @@
+# Summary
+
+**CSPDarknet53** is a convolutional neural network and backbone for object detection that uses [DarkNet-53](https://paperswithcode.com/method/darknet-53). It employs a CSPNet strategy to partition the feature map of the base layer into two parts and then merges them through a cross-stage hierarchy. The use of a split and merge strategy allows for more gradient flow through the network. 
+
+This CNN is used as the backbone for [YOLOv4](https://paperswithcode.com/method/yolov4).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('cspdarknet53', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `cspdarknet53`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('cspdarknet53', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{bochkovskiy2020yolov4,
+      title={YOLOv4: Optimal Speed and Accuracy of Object Detection}, 
+      author={Alexey Bochkovskiy and Chien-Yao Wang and Hong-Yuan Mark Liao},
+      year={2020},
+      eprint={2004.10934},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: cspdarknet53
+  Metadata:
+    FLOPs: 8545018880
+    Batch Size: 128
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - CutMix
+    - Label Smoothing
+    - Mosaic
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Self-Adversarial Training
+    - Weight Decay
+    Training Resources: 1x NVIDIA RTX 2070 GPU
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Mish
+    - Residual Connection
+    - Softmax
+    File Size: 110775135
+    Tasks:
+    - Image Classification
+    ID: cspdarknet53
+    LR: 0.1
+    Layers: 53
+    Crop Pct: '0.887'
+    Momentum: 0.9
+    Image Size: '256'
+    Warmup Steps: 1000
+    Weight Decay: 0.0005
+    Interpolation: bilinear
+    Training Steps: 8000000
+    FPS (GPU RTX 2070): 66
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L441
+  In Collection: CSP DarkNet
+Collections:
+- Name: CSP DarkNet
+  Paper:
+    title: 'YOLOv4: Optimal Speed and Accuracy of Object Detection'
+    url: https://papperswithcode.com//paper/yolov4-optimal-speed-and-accuracy-of-object
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/csp-resnet.md
+++ b/modelindex/models/csp-resnet.md
@@ -83,19 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: CSP ResNet
+  Paper:
+    Title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
+    URL: https://paperswithcode.com/paper/cspnet-a-new-backbone-that-can-enhance
 Models:
 - Name: cspresnet50
+  In Collection: CSP ResNet
   Metadata:
     FLOPs: 5924992000
-    Batch Size: 128
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Polynomial Learning Rate Decay
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 21620000
+    File Size: 86679303
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -107,27 +107,31 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 86679303
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: cspresnet50
     LR: 0.1
     Layers: 50
     Crop Pct: '0.887'
     Momentum: 0.9
+    Batch Size: 128
     Image Size: '256'
     Weight Decay: 0.005
     Interpolation: bilinear
     Training Steps: 8000000
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L415
-  Config: ''
-  In Collection: CSP ResNet
-Collections:
-- Name: CSP ResNet
-  Paper:
-    title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
-    url: https://paperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/cspresnet50_ra-d3e8d487.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.57%
+      Top 5 Accuracy: 94.71%
 -->

--- a/modelindex/models/csp-resnet.md
+++ b/modelindex/models/csp-resnet.md
@@ -127,7 +127,7 @@ Collections:
 - Name: CSP ResNet
   Paper:
     title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
-    url: https://papperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
+    url: https://paperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/csp-resnet.md
+++ b/modelindex/models/csp-resnet.md
@@ -1,0 +1,133 @@
+# Summary
+
+**CSPResNet** is a convolutional neural network where we apply the Cross Stage Partial Network (CSPNet) approach to [ResNet](https://paperswithcode.com/method/resnet). The CSPNet partitions the feature map of the base layer into two parts and then merges them through a cross-stage hierarchy. The use of a split and merge strategy allows for more gradient flow through the network.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('cspresnet50', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `cspresnet50`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('cspresnet50', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{wang2019cspnet,
+      title={CSPNet: A New Backbone that can Enhance Learning Capability of CNN}, 
+      author={Chien-Yao Wang and Hong-Yuan Mark Liao and I-Hau Yeh and Yueh-Hua Wu and Ping-Yang Chen and Jun-Wei Hsieh},
+      year={2019},
+      eprint={1911.11929},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: cspresnet50
+  Metadata:
+    FLOPs: 5924992000
+    Batch Size: 128
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 86679303
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: cspresnet50
+    LR: 0.1
+    Layers: 50
+    Crop Pct: '0.887'
+    Momentum: 0.9
+    Image Size: '256'
+    Weight Decay: 0.005
+    Interpolation: bilinear
+    Training Steps: 8000000
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L415
+  Config: ''
+  In Collection: CSP ResNet
+Collections:
+- Name: CSP ResNet
+  Paper:
+    title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
+    url: https://papperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/csp-resnext.md
+++ b/modelindex/models/csp-resnext.md
@@ -127,7 +127,7 @@ Collections:
 - Name: CSP ResNeXt
   Paper:
     title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
-    url: https://papperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
+    url: https://paperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/csp-resnext.md
+++ b/modelindex/models/csp-resnext.md
@@ -83,19 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: CSP ResNeXt
+  Paper:
+    Title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
+    URL: https://paperswithcode.com/paper/cspnet-a-new-backbone-that-can-enhance
 Models:
 - Name: cspresnext50
+  In Collection: CSP ResNeXt
   Metadata:
     FLOPs: 3962945536
-    Batch Size: 128
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Polynomial Learning Rate Decay
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 1x GPU
+    Parameters: 20570000
+    File Size: 82562887
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -107,27 +107,32 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 82562887
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 1x GPU
     ID: cspresnext50
     LR: 0.1
     Layers: 50
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 128
     Image Size: '224'
     Weight Decay: 0.005
     Interpolation: bilinear
     Training Steps: 8000000
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L430
-  Config: ''
-  In Collection: CSP ResNeXt
-Collections:
-- Name: CSP ResNeXt
-  Paper:
-    title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
-    url: https://paperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/cspresnext50_ra_224-648b4713.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.05%
+      Top 5 Accuracy: 94.94%
 -->

--- a/modelindex/models/csp-resnext.md
+++ b/modelindex/models/csp-resnext.md
@@ -1,0 +1,133 @@
+# Summary
+
+**CSPResNeXt** is a convolutional neural network where we apply the Cross Stage Partial Network (CSPNet) approach to [ResNeXt](https://paperswithcode.com/method/resnext). The CSPNet partitions the feature map of the base layer into two parts and then merges them through a cross-stage hierarchy. The use of a split and merge strategy allows for more gradient flow through the network.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('cspresnext50', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `cspresnext50`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('cspresnext50', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{wang2019cspnet,
+      title={CSPNet: A New Backbone that can Enhance Learning Capability of CNN}, 
+      author={Chien-Yao Wang and Hong-Yuan Mark Liao and I-Hau Yeh and Yueh-Hua Wu and Ping-Yang Chen and Jun-Wei Hsieh},
+      year={2019},
+      eprint={1911.11929},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: cspresnext50
+  Metadata:
+    FLOPs: 3962945536
+    Batch Size: 128
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Polynomial Learning Rate Decay
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 1x GPU
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 82562887
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: cspresnext50
+    LR: 0.1
+    Layers: 50
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.005
+    Interpolation: bilinear
+    Training Steps: 8000000
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/cspnet.py#L430
+  Config: ''
+  In Collection: CSP ResNeXt
+Collections:
+- Name: CSP ResNeXt
+  Paper:
+    title: 'CSPNet: A New Backbone that can Enhance Learning Capability of CNN'
+    url: https://papperswithcode.com//paper/cspnet-a-new-backbone-that-can-enhance
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/densenet.md
+++ b/modelindex/models/densenet.md
@@ -316,7 +316,7 @@ Collections:
 - Name: DenseNet
   Paper:
     title: Densely Connected Convolutional Networks
-    url: https://papperswithcode.com//paper/densely-connected-convolutional-networks
+    url: https://paperswithcode.com//paper/densely-connected-convolutional-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/densenet.md
+++ b/modelindex/models/densenet.md
@@ -1,0 +1,322 @@
+# Summary
+
+**DenseNet** is a type of convolutional neural network that utilises dense connections between layers, through [Dense Blocks](http://www.paperswithcode.com/method/dense-block), where we connect *all layers* (with matching feature-map sizes) directly with each other. To preserve the feed-forward nature, each layer obtains additional inputs from all preceding layers and passes on its own feature-maps to all subsequent layers.
+
+The **DenseNet Blur** variant in this collection by Ross Wightman employs [Blur Pooling](http://www.paperswithcode.com/method/blur-pooling)
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('densenetblur121d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `densenetblur121d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('densenetblur121d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/HuangLW16a,
+  author    = {Gao Huang and
+               Zhuang Liu and
+               Kilian Q. Weinberger},
+  title     = {Densely Connected Convolutional Networks},
+  journal   = {CoRR},
+  volume    = {abs/1608.06993},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1608.06993},
+  archivePrefix = {arXiv},
+  eprint    = {1608.06993},
+  timestamp = {Mon, 10 Sep 2018 15:49:32 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/HuangLW16a.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+```
+@misc{rw2019timm,
+  author = {Ross Wightman},
+  title = {PyTorch Image Models},
+  year = {2019},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  doi = {10.5281/zenodo.4414861},
+  howpublished = {\url{https://github.com/rwightman/pytorch-image-models}}
+}
+```
+
+<!--
+Models:
+- Name: densenetblur121d
+  Metadata:
+    FLOPs: 3947812864
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Blur Pooling
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 32456500
+    Tasks:
+    - Image Classification
+    ID: densenetblur121d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L305
+  In Collection: DenseNet
+- Name: tv_densenet121
+  Metadata:
+    FLOPs: 3641843200
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 32342954
+    Tasks:
+    - Image Classification
+    ID: tv_densenet121
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L379
+  In Collection: DenseNet
+- Name: densenet121
+  Metadata:
+    FLOPs: 3641843200
+    Epochs: 90
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 32376726
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: densenet121
+    LR: 0.1
+    Layers: 121
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L295
+  Config: ''
+  In Collection: DenseNet
+- Name: densenet201
+  Metadata:
+    FLOPs: 5514321024
+    Epochs: 90
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 81131730
+    Tasks:
+    - Image Classification
+    ID: densenet201
+    LR: 0.1
+    Layers: 201
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L337
+  In Collection: DenseNet
+- Name: densenet169
+  Metadata:
+    FLOPs: 4316945792
+    Epochs: 90
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 57365526
+    Tasks:
+    - Image Classification
+    ID: densenet169
+    LR: 0.1
+    Layers: 169
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L327
+  In Collection: DenseNet
+- Name: densenet161
+  Metadata:
+    FLOPs: 9931959264
+    Epochs: 90
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 115730790
+    Tasks:
+    - Image Classification
+    ID: densenet161
+    LR: 0.1
+    Layers: 161
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L347
+  In Collection: DenseNet
+Collections:
+- Name: DenseNet
+  Paper:
+    title: Densely Connected Convolutional Networks
+    url: https://papperswithcode.com//paper/densely-connected-convolutional-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/densenet.md
+++ b/modelindex/models/densenet.md
@@ -9,7 +9,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('densenetblur121d', pretrained=True)
+model = timm.create_model('densenet121', pretrained=True)
 model.eval()
 ```
 
@@ -55,14 +55,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `densenetblur121d`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `densenet121`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('densenetblur121d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('densenet121', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -104,12 +104,195 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: DenseNet
+  Paper:
+    Title: Densely Connected Convolutional Networks
+    URL: https://paperswithcode.com/paper/densely-connected-convolutional-networks
 Models:
-- Name: densenetblur121d
+- Name: densenet121
+  In Collection: DenseNet
   Metadata:
-    FLOPs: 3947812864
+    FLOPs: 3641843200
+    Parameters: 7980000
+    File Size: 32376726
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
     Training Data:
     - ImageNet
+    ID: densenet121
+    LR: 0.1
+    Epochs: 90
+    Layers: 121
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L295
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/densenet121_ra-50efcf5c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.56%
+      Top 5 Accuracy: 92.65%
+- Name: densenet161
+  In Collection: DenseNet
+  Metadata:
+    FLOPs: 9931959264
+    Parameters: 28680000
+    File Size: 115730790
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: densenet161
+    LR: 0.1
+    Epochs: 90
+    Layers: 161
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L347
+  Weights: https://download.pytorch.org/models/densenet161-8d451a50.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.36%
+      Top 5 Accuracy: 93.63%
+- Name: densenet169
+  In Collection: DenseNet
+  Metadata:
+    FLOPs: 4316945792
+    Parameters: 14150000
+    File Size: 57365526
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: densenet169
+    LR: 0.1
+    Epochs: 90
+    Layers: 169
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L327
+  Weights: https://download.pytorch.org/models/densenet169-b2777c0a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.9%
+      Top 5 Accuracy: 93.02%
+- Name: densenet201
+  In Collection: DenseNet
+  Metadata:
+    FLOPs: 5514321024
+    Parameters: 20010000
+    File Size: 81131730
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Block
+    - Dense Connections
+    - Dropout
+    - Max Pooling
+    - ReLU
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Kaiming Initialization
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: densenet201
+    LR: 0.1
+    Epochs: 90
+    Layers: 201
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L337
+  Weights: https://download.pytorch.org/models/densenet201-c1103571.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.29%
+      Top 5 Accuracy: 93.48%
+- Name: densenetblur121d
+  In Collection: DenseNet
+  Metadata:
+    FLOPs: 3947812864
+    Parameters: 8000000
+    File Size: 32456500
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -121,25 +304,28 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 32456500
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: densenetblur121d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L305
-  In Collection: DenseNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/densenetblur121d_ra-100dcfbc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.59%
+      Top 5 Accuracy: 93.2%
 - Name: tv_densenet121
+  In Collection: DenseNet
   Metadata:
     FLOPs: 3641843200
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    Parameters: 7980000
+    File Size: 32342954
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -151,172 +337,30 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 32342954
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tv_densenet121
     LR: 0.1
+    Epochs: 90
     Crop Pct: '0.875'
     LR Gamma: 0.1
     Momentum: 0.9
+    Batch Size: 32
     Image Size: '224'
     LR Step Size: 30
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L379
-  In Collection: DenseNet
-- Name: densenet121
-  Metadata:
-    FLOPs: 3641843200
-    Epochs: 90
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Kaiming Initialization
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: ''
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Block
-    - Dense Connections
-    - Dropout
-    - Max Pooling
-    - ReLU
-    - Softmax
-    File Size: 32376726
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: densenet121
-    LR: 0.1
-    Layers: 121
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L295
-  Config: ''
-  In Collection: DenseNet
-- Name: densenet201
-  Metadata:
-    FLOPs: 5514321024
-    Epochs: 90
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Kaiming Initialization
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Block
-    - Dense Connections
-    - Dropout
-    - Max Pooling
-    - ReLU
-    - Softmax
-    File Size: 81131730
-    Tasks:
-    - Image Classification
-    ID: densenet201
-    LR: 0.1
-    Layers: 201
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L337
-  In Collection: DenseNet
-- Name: densenet169
-  Metadata:
-    FLOPs: 4316945792
-    Epochs: 90
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Kaiming Initialization
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Block
-    - Dense Connections
-    - Dropout
-    - Max Pooling
-    - ReLU
-    - Softmax
-    File Size: 57365526
-    Tasks:
-    - Image Classification
-    ID: densenet169
-    LR: 0.1
-    Layers: 169
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L327
-  In Collection: DenseNet
-- Name: densenet161
-  Metadata:
-    FLOPs: 9931959264
-    Epochs: 90
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Kaiming Initialization
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Block
-    - Dense Connections
-    - Dropout
-    - Max Pooling
-    - ReLU
-    - Softmax
-    File Size: 115730790
-    Tasks:
-    - Image Classification
-    ID: densenet161
-    LR: 0.1
-    Layers: 161
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/densenet.py#L347
-  In Collection: DenseNet
-Collections:
-- Name: DenseNet
-  Paper:
-    title: Densely Connected Convolutional Networks
-    url: https://paperswithcode.com//paper/densely-connected-convolutional-networks
-  type: model-index
-Type: model-index
+  Weights: https://download.pytorch.org/models/densenet121-a639ec97.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.74%
+      Top 5 Accuracy: 92.15%
 -->

--- a/modelindex/models/dla.md
+++ b/modelindex/models/dla.md
@@ -537,7 +537,7 @@ Collections:
 - Name: DLA
   Paper:
     title: Deep Layer Aggregation
-    url: https://papperswithcode.com//paper/deep-layer-aggregation
+    url: https://paperswithcode.com//paper/deep-layer-aggregation
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/dla.md
+++ b/modelindex/models/dla.md
@@ -1,0 +1,543 @@
+# Summary
+
+Extending  “shallow” skip connections, **Dense Layer Aggregation (DLA)** incorporates more depth and sharing. The authors introduce two structures for deep layer aggregation (DLA): iterative deep aggregation (IDA) and hierarchical deep aggregation (HDA). These structures are expressed through an architectural framework, independent of the choice of backbone, for compatibility with current and future networks. 
+
+IDA focuses on fusing resolutions and scales while HDA focuses on merging features from all modules and channels. IDA follows the base hierarchy to refine resolution and aggregate scale stage-bystage. HDA assembles its own hierarchy of tree-structured connections that cross and merge stages to aggregate different levels of representation. 
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('dla60', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `dla60`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('dla60', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{yu2019deep,
+      title={Deep Layer Aggregation}, 
+      author={Fisher Yu and Dequan Wang and Evan Shelhamer and Trevor Darrell},
+      year={2019},
+      eprint={1707.06484},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: dla60
+  Metadata:
+    FLOPs: 4256251880
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 89560235
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60
+    LR: 0.1
+    Layers: 60
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L394
+  Config: ''
+  In Collection: DLA
+- Name: dla46_c
+  Metadata:
+    FLOPs: 583277288
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 5307963
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla46_c
+    LR: 0.1
+    Layers: 46
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L369
+  Config: ''
+  In Collection: DLA
+- Name: dla102x2
+  Metadata:
+    FLOPs: 9343847400
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 167645295
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla102x2
+    LR: 0.1
+    Layers: 102
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L426
+  Config: ''
+  In Collection: DLA
+- Name: dla102
+  Metadata:
+    FLOPs: 7192952808
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 135290579
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla102
+    LR: 0.1
+    Layers: 102
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L410
+  Config: ''
+  In Collection: DLA
+- Name: dla102x
+  Metadata:
+    FLOPs: 5886821352
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 107552695
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla102x
+    LR: 0.1
+    Layers: 102
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L418
+  Config: ''
+  In Collection: DLA
+- Name: dla169
+  Metadata:
+    FLOPs: 11598004200
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 216547113
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla169
+    LR: 0.1
+    Layers: 169
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L434
+  Config: ''
+  In Collection: DLA
+- Name: dla46x_c
+  Metadata:
+    FLOPs: 544052200
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 4387641
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla46x_c
+    LR: 0.1
+    Layers: 46
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L378
+  Config: ''
+  In Collection: DLA
+- Name: dla60_res2net
+  Metadata:
+    FLOPs: 4147578504
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 84886593
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60_res2net
+    Layers: 60
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L346
+  Config: ''
+  In Collection: DLA
+- Name: dla60_res2next
+  Metadata:
+    FLOPs: 3485335272
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 69639245
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60_res2next
+    Layers: 60
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L354
+  Config: ''
+  In Collection: DLA
+- Name: dla34
+  Metadata:
+    FLOPs: 3070105576
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 63228658
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla34
+    LR: 0.1
+    Layers: 32
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L362
+  Config: ''
+  In Collection: DLA
+- Name: dla60x
+  Metadata:
+    FLOPs: 3544204264
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 70883139
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60x
+    LR: 0.1
+    Layers: 60
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L402
+  Config: ''
+  In Collection: DLA
+- Name: dla60x_c
+  Metadata:
+    FLOPs: 593325032
+    Epochs: 120
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 5454396
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: dla60x_c
+    LR: 0.1
+    Layers: 60
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L386
+  Config: ''
+  In Collection: DLA
+Collections:
+- Name: DLA
+  Paper:
+    title: Deep Layer Aggregation
+    url: https://papperswithcode.com//paper/deep-layer-aggregation
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/dla.md
+++ b/modelindex/models/dla.md
@@ -9,7 +9,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('dla60', pretrained=True)
+model = timm.create_model('dla102', pretrained=True)
 model.eval()
 ```
 
@@ -55,14 +55,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `dla60`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `dla102`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('dla60', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('dla102', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -85,133 +85,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: DLA
+  Paper:
+    Title: Deep Layer Aggregation
+    URL: https://paperswithcode.com/paper/deep-layer-aggregation
 Models:
-- Name: dla60
-  Metadata:
-    FLOPs: 4256251880
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - DLA Bottleneck Residual Block
-    - DLA Residual Block
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 89560235
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: dla60
-    LR: 0.1
-    Layers: 60
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L394
-  Config: ''
-  In Collection: DLA
-- Name: dla46_c
-  Metadata:
-    FLOPs: 583277288
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - DLA Bottleneck Residual Block
-    - DLA Residual Block
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 5307963
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: dla46_c
-    LR: 0.1
-    Layers: 46
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L369
-  Config: ''
-  In Collection: DLA
-- Name: dla102x2
-  Metadata:
-    FLOPs: 9343847400
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - DLA Bottleneck Residual Block
-    - DLA Residual Block
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 167645295
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: dla102x2
-    LR: 0.1
-    Layers: 102
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L426
-  Config: ''
-  In Collection: DLA
 - Name: dla102
+  In Collection: DLA
   Metadata:
     FLOPs: 7192952808
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 33270000
+    File Size: 135290579
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -224,32 +110,38 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 135290579
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: dla102
     LR: 0.1
+    Epochs: 120
     Layers: 102
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L410
-  Config: ''
-  In Collection: DLA
+  Weights: http://dl.yf.io/dla/models/imagenet/dla102-d94d9790.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.03%
+      Top 5 Accuracy: 93.95%
 - Name: dla102x
+  In Collection: DLA
   Metadata:
     FLOPs: 5886821352
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 26310000
+    File Size: 107552695
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -262,32 +154,38 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 107552695
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: dla102x
     LR: 0.1
+    Epochs: 120
     Layers: 102
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L418
-  Config: ''
+  Weights: http://dl.yf.io/dla/models/imagenet/dla102x-ad62be81.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.51%
+      Top 5 Accuracy: 94.23%
+- Name: dla102x2
   In Collection: DLA
-- Name: dla169
   Metadata:
-    FLOPs: 11598004200
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    FLOPs: 9343847400
+    Parameters: 41280000
+    File Size: 167645295
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -300,32 +198,82 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 216547113
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
+    ID: dla102x2
+    LR: 0.1
+    Epochs: 120
+    Layers: 102
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L426
+  Weights: http://dl.yf.io/dla/models/imagenet/dla102x2-262837b6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.44%
+      Top 5 Accuracy: 94.65%
+- Name: dla169
+  In Collection: DLA
+  Metadata:
+    FLOPs: 11598004200
+    Parameters: 53390000
+    File Size: 216547113
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: dla169
     LR: 0.1
+    Epochs: 120
     Layers: 169
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L434
-  Config: ''
+  Weights: http://dl.yf.io/dla/models/imagenet/dla169-0914e092.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.69%
+      Top 5 Accuracy: 94.33%
+- Name: dla34
   In Collection: DLA
-- Name: dla46x_c
   Metadata:
-    FLOPs: 544052200
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    FLOPs: 3070105576
+    Parameters: 15740000
+    File Size: 63228658
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -338,30 +286,123 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 4387641
     Tasks:
     - Image Classification
-    Training Time: ''
-    ID: dla46x_c
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: dla34
     LR: 0.1
+    Epochs: 120
+    Layers: 32
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L362
+  Weights: http://dl.yf.io/dla/models/imagenet/dla34-ba72cf86.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.62%
+      Top 5 Accuracy: 92.06%
+- Name: dla46_c
+  In Collection: DLA
+  Metadata:
+    FLOPs: 583277288
+    Parameters: 1300000
+    File Size: 5307963
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: dla46_c
+    LR: 0.1
+    Epochs: 120
     Layers: 46
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L369
+  Weights: http://dl.yf.io/dla/models/imagenet/dla46_c-2bfd52c3.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 64.87%
+      Top 5 Accuracy: 86.29%
+- Name: dla46x_c
+  In Collection: DLA
+  Metadata:
+    FLOPs: 544052200
+    Parameters: 1070000
+    File Size: 4387641
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: dla46x_c
+    LR: 0.1
+    Epochs: 120
+    Layers: 46
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L378
-  Config: ''
+  Weights: http://dl.yf.io/dla/models/imagenet/dla46x_c-d761bae7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 65.98%
+      Top 5 Accuracy: 86.99%
+- Name: dla60
   In Collection: DLA
-- Name: dla60_res2net
   Metadata:
-    FLOPs: 4147578504
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    FLOPs: 4256251880
+    Parameters: 22040000
+    File Size: 89560235
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -374,27 +415,76 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 84886593
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: dla60
+    LR: 0.1
+    Epochs: 120
+    Layers: 60
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L394
+  Weights: http://dl.yf.io/dla/models/imagenet/dla60-24839fc4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.04%
+      Top 5 Accuracy: 93.32%
+- Name: dla60_res2net
+  In Collection: DLA
+  Metadata:
+    FLOPs: 4147578504
+    Parameters: 20850000
+    File Size: 84886593
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - DLA Bottleneck Residual Block
+    - DLA Residual Block
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: dla60_res2net
     Layers: 60
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L346
-  Config: ''
-  In Collection: DLA
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net_dla60_4s-d88db7f9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.46%
+      Top 5 Accuracy: 94.21%
 - Name: dla60_res2next
+  In Collection: DLA
   Metadata:
     FLOPs: 3485335272
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 17030000
+    File Size: 69639245
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -407,67 +497,32 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 69639245
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: dla60_res2next
     Layers: 60
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L354
-  Config: ''
-  In Collection: DLA
-- Name: dla34
-  Metadata:
-    FLOPs: 3070105576
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - DLA Bottleneck Residual Block
-    - DLA Residual Block
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 63228658
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: dla34
-    LR: 0.1
-    Layers: 32
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L362
-  Config: ''
-  In Collection: DLA
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2next_dla60_4s-d327927b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.44%
+      Top 5 Accuracy: 94.16%
 - Name: dla60x
+  In Collection: DLA
   Metadata:
     FLOPs: 3544204264
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 17350000
+    File Size: 70883139
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -480,32 +535,37 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 70883139
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: dla60x
     LR: 0.1
+    Epochs: 120
     Layers: 60
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L402
-  Config: ''
-  In Collection: DLA
+  Weights: http://dl.yf.io/dla/models/imagenet/dla60x-d15cacda.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.25%
+      Top 5 Accuracy: 94.02%
 - Name: dla60x_c
+  In Collection: DLA
   Metadata:
     FLOPs: 593325032
-    Epochs: 120
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 1320000
+    File Size: 5454396
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -518,26 +578,29 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 5454396
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: dla60x_c
     LR: 0.1
+    Epochs: 120
     Layers: 60
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dla.py#L386
-  Config: ''
-  In Collection: DLA
-Collections:
-- Name: DLA
-  Paper:
-    title: Deep Layer Aggregation
-    url: https://paperswithcode.com//paper/deep-layer-aggregation
-  type: model-index
-Type: model-index
+  Weights: http://dl.yf.io/dla/models/imagenet/dla60x_c-b870c45c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 67.91%
+      Top 5 Accuracy: 88.42%
 -->

--- a/modelindex/models/dpn.md
+++ b/modelindex/models/dpn.md
@@ -9,7 +9,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('dpn68', pretrained=True)
+model = timm.create_model('dpn107', pretrained=True)
 model.eval()
 ```
 
@@ -55,14 +55,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `dpn68`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `dpn107`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('dpn68', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('dpn107', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -85,133 +85,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: DPN
+  Paper:
+    Title: Dual Path Networks
+    URL: https://paperswithcode.com/paper/dual-path-networks
 Models:
-- Name: dpn68
-  Metadata:
-    FLOPs: 2990567880
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - DPN Block
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - Softmax
-    File Size: 50761994
-    Tasks:
-    - Image Classification
-    ID: dpn68
-    LR: 0.316
-    Layers: 68
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L270
-  In Collection: DPN
-- Name: dpn68b
-  Metadata:
-    FLOPs: 2990567880
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - DPN Block
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - Softmax
-    File Size: 50781025
-    Tasks:
-    - Image Classification
-    ID: dpn68b
-    LR: 0.316
-    Layers: 68
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L278
-  In Collection: DPN
-- Name: dpn92
-  Metadata:
-    FLOPs: 8357659624
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - DPN Block
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - Softmax
-    File Size: 151248422
-    Tasks:
-    - Image Classification
-    ID: dpn92
-    LR: 0.316
-    Layers: 92
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L286
-  In Collection: DPN
-- Name: dpn131
-  Metadata:
-    FLOPs: 20586274792
-    Batch Size: 960
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - DPN Block
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - Softmax
-    File Size: 318016207
-    Tasks:
-    - Image Classification
-    ID: dpn131
-    LR: 0.316
-    Layers: 131
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L302
-  In Collection: DPN
 - Name: dpn107
+  In Collection: DPN
   Metadata:
     FLOPs: 23524280296
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
+    Parameters: 86920000
+    File Size: 348612331
     Architecture:
     - Batch Normalization
     - Convolution
@@ -220,27 +106,35 @@ Models:
     - Global Average Pooling
     - Max Pooling
     - Softmax
-    File Size: 348612331
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
     ID: dpn107
     LR: 0.316
     Layers: 107
     Crop Pct: '0.875'
+    Batch Size: 1280
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L310
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn107_extra-1ac7121e2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.16%
+      Top 5 Accuracy: 94.91%
+- Name: dpn131
   In Collection: DPN
-- Name: dpn98
   Metadata:
-    FLOPs: 15003675112
-    Batch Size: 1280
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 40x K80 GPUs
+    FLOPs: 20586274792
+    Parameters: 79250000
+    File Size: 318016207
     Architecture:
     - Batch Normalization
     - Convolution
@@ -249,22 +143,175 @@ Models:
     - Global Average Pooling
     - Max Pooling
     - Softmax
-    File Size: 247021307
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
+    ID: dpn131
+    LR: 0.316
+    Layers: 131
+    Crop Pct: '0.875'
+    Batch Size: 960
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L302
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn131-71dfe43e0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.83%
+      Top 5 Accuracy: 94.71%
+- Name: dpn68
+  In Collection: DPN
+  Metadata:
+    FLOPs: 2990567880
+    Parameters: 12610000
+    File Size: 50761994
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
+    ID: dpn68
+    LR: 0.316
+    Layers: 68
+    Crop Pct: '0.875'
+    Batch Size: 1280
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L270
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn68-66bebafa7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.31%
+      Top 5 Accuracy: 92.97%
+- Name: dpn68b
+  In Collection: DPN
+  Metadata:
+    FLOPs: 2990567880
+    Parameters: 12610000
+    File Size: 50781025
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
+    ID: dpn68b
+    LR: 0.316
+    Layers: 68
+    Crop Pct: '0.875'
+    Batch Size: 1280
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L278
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/dpn68b_ra-a31ca160.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.21%
+      Top 5 Accuracy: 94.42%
+- Name: dpn92
+  In Collection: DPN
+  Metadata:
+    FLOPs: 8357659624
+    Parameters: 37670000
+    File Size: 151248422
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
+    ID: dpn92
+    LR: 0.316
+    Layers: 92
+    Crop Pct: '0.875'
+    Batch Size: 1280
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L286
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn92_extra-b040e4a9b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.99%
+      Top 5 Accuracy: 94.84%
+- Name: dpn98
+  In Collection: DPN
+  Metadata:
+    FLOPs: 15003675112
+    Parameters: 61570000
+    File Size: 247021307
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 40x K80 GPUs
     ID: dpn98
     LR: 0.4
     Layers: 98
     Crop Pct: '0.875'
+    Batch Size: 1280
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L294
-  In Collection: DPN
-Collections:
-- Name: DPN
-  Paper:
-    title: Dual Path Networks
-    url: https://paperswithcode.com//paper/dual-path-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-dpn-pretrained/releases/download/v0.1/dpn98-5b90dec4d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.65%
+      Top 5 Accuracy: 94.61%
 -->

--- a/modelindex/models/dpn.md
+++ b/modelindex/models/dpn.md
@@ -264,7 +264,7 @@ Collections:
 - Name: DPN
   Paper:
     title: Dual Path Networks
-    url: https://papperswithcode.com//paper/dual-path-networks
+    url: https://paperswithcode.com//paper/dual-path-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/dpn.md
+++ b/modelindex/models/dpn.md
@@ -1,0 +1,270 @@
+# Summary
+
+A **Dual Path Network (DPN)** is a convolutional neural network which presents a new topology of connection paths internally. The intuition is that [ResNets](https://paperswithcode.com/method/resnet) enables feature re-usage while DenseNet enables new feature exploration, and both are important for learning good representations. To enjoy the benefits from both path topologies, Dual Path Networks share common features while maintaining the flexibility to explore new features through dual path architectures. 
+
+The principal building block is an [DPN Block](https://paperswithcode.com/method/dpn-block).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('dpn68', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `dpn68`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('dpn68', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{chen2017dual,
+      title={Dual Path Networks}, 
+      author={Yunpeng Chen and Jianan Li and Huaxin Xiao and Xiaojie Jin and Shuicheng Yan and Jiashi Feng},
+      year={2017},
+      eprint={1707.01629},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: dpn68
+  Metadata:
+    FLOPs: 2990567880
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 50761994
+    Tasks:
+    - Image Classification
+    ID: dpn68
+    LR: 0.316
+    Layers: 68
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L270
+  In Collection: DPN
+- Name: dpn68b
+  Metadata:
+    FLOPs: 2990567880
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 50781025
+    Tasks:
+    - Image Classification
+    ID: dpn68b
+    LR: 0.316
+    Layers: 68
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L278
+  In Collection: DPN
+- Name: dpn92
+  Metadata:
+    FLOPs: 8357659624
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 151248422
+    Tasks:
+    - Image Classification
+    ID: dpn92
+    LR: 0.316
+    Layers: 92
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L286
+  In Collection: DPN
+- Name: dpn131
+  Metadata:
+    FLOPs: 20586274792
+    Batch Size: 960
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 318016207
+    Tasks:
+    - Image Classification
+    ID: dpn131
+    LR: 0.316
+    Layers: 131
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L302
+  In Collection: DPN
+- Name: dpn107
+  Metadata:
+    FLOPs: 23524280296
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 348612331
+    Tasks:
+    - Image Classification
+    ID: dpn107
+    LR: 0.316
+    Layers: 107
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L310
+  In Collection: DPN
+- Name: dpn98
+  Metadata:
+    FLOPs: 15003675112
+    Batch Size: 1280
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 40x K80 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - DPN Block
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    File Size: 247021307
+    Tasks:
+    - Image Classification
+    ID: dpn98
+    LR: 0.4
+    Layers: 98
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/dpn.py#L294
+  In Collection: DPN
+Collections:
+- Name: DPN
+  Paper:
+    title: Dual Path Networks
+    url: https://papperswithcode.com//paper/dual-path-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/ecaresnet.md
+++ b/modelindex/models/ecaresnet.md
@@ -255,7 +255,7 @@ Collections:
 - Name: ECAResNet
   Paper:
     title: 'ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks'
-    url: https://papperswithcode.com//paper/eca-net-efficient-channel-attention-for-deep
+    url: https://paperswithcode.com//paper/eca-net-efficient-channel-attention-for-deep
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/ecaresnet.md
+++ b/modelindex/models/ecaresnet.md
@@ -83,18 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ECAResNet
+  Paper:
+    Title: 'ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks'
+    URL: https://paperswithcode.com/paper/eca-net-efficient-channel-attention-for-deep
 Models:
 - Name: ecaresnet101d
+  In Collection: ECAResNet
   Metadata:
     FLOPs: 10377193728
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x RTX 2080Ti GPUs
+    Parameters: 44570000
+    File Size: 178815067
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -108,27 +109,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 178815067
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x RTX 2080Ti GPUs
     ID: ecaresnet101d
     LR: 0.1
+    Epochs: 100
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1087
-  In Collection: ECAResNet
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45402/outputs/ECAResNet101D_281c5844.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.18%
+      Top 5 Accuracy: 96.06%
 - Name: ecaresnet101d_pruned
+  In Collection: ECAResNet
   Metadata:
     FLOPs: 4463972081
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: ''
+    Parameters: 24880000
+    File Size: 99852736
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -142,26 +153,32 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 99852736
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: ecaresnet101d_pruned
     Layers: 101
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1097
-  Config: ''
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45610/outputs/ECAResNet101D_P_75a3370e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.82%
+      Top 5 Accuracy: 95.64%
+- Name: ecaresnet50d
   In Collection: ECAResNet
-- Name: ecaresnet50d_pruned
   Metadata:
-    FLOPs: 3250730657
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    FLOPs: 5591090432
+    Parameters: 25580000
+    File Size: 102579290
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -175,60 +192,76 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 79990436
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x RTX 2080Ti GPUs
+    ID: ecaresnet50d
+    LR: 0.1
+    Epochs: 100
+    Layers: 50
+    Crop Pct: '0.875'
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1045
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45402/outputs/ECAResNet50D_833caf58.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.61%
+      Top 5 Accuracy: 95.31%
+- Name: ecaresnet50d_pruned
+  In Collection: ECAResNet
+  Metadata:
+    FLOPs: 3250730657
+    Parameters: 19940000
+    File Size: 79990436
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: ecaresnet50d_pruned
     Layers: 50
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1055
-  In Collection: ECAResNet
-- Name: ecaresnet50d
-  Metadata:
-    FLOPs: 5591090432
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x RTX 2080Ti GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Efficient Channel Attention
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    - Squeeze-and-Excitation Block
-    File Size: 102579290
-    Tasks:
-    - Image Classification
-    ID: ecaresnet50d
-    LR: 0.1
-    Layers: 50
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1045
-  In Collection: ECAResNet
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45899/outputs/ECAResNet50D_P_9c67f710.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.71%
+      Top 5 Accuracy: 94.88%
 - Name: ecaresnetlight
+  In Collection: ECAResNet
   Metadata:
     FLOPs: 5276118784
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    Parameters: 30160000
+    File Size: 120956612
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -242,20 +275,23 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 120956612
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: ecaresnetlight
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1077
-  In Collection: ECAResNet
-Collections:
-- Name: ECAResNet
-  Paper:
-    title: 'ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks'
-    url: https://paperswithcode.com//paper/eca-net-efficient-channel-attention-for-deep
-  type: model-index
-Type: model-index
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45402/outputs/ECAResNetLight_4f34b35b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.46%
+      Top 5 Accuracy: 95.25%
 -->

--- a/modelindex/models/ecaresnet.md
+++ b/modelindex/models/ecaresnet.md
@@ -1,0 +1,261 @@
+# Summary
+
+An **ECA ResNet** is a variant on a [ResNet](https://paperswithcode.com/method/resnet) that utilises an [Efficient Channel Attention module](https://paperswithcode.com/method/efficient-channel-attention). Efficient Channel Attention is an architectural unit based on [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) that reduces model complexity without dimensionality reduction. 
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('ecaresnet101d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `ecaresnet101d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('ecaresnet101d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{wang2020ecanet,
+      title={ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks}, 
+      author={Qilong Wang and Banggu Wu and Pengfei Zhu and Peihua Li and Wangmeng Zuo and Qinghua Hu},
+      year={2020},
+      eprint={1910.03151},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: ecaresnet101d
+  Metadata:
+    FLOPs: 10377193728
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x RTX 2080Ti GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 178815067
+    Tasks:
+    - Image Classification
+    ID: ecaresnet101d
+    LR: 0.1
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1087
+  In Collection: ECAResNet
+- Name: ecaresnet101d_pruned
+  Metadata:
+    FLOPs: 4463972081
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: ''
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 99852736
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: ecaresnet101d_pruned
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1097
+  Config: ''
+  In Collection: ECAResNet
+- Name: ecaresnet50d_pruned
+  Metadata:
+    FLOPs: 3250730657
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 79990436
+    Tasks:
+    - Image Classification
+    ID: ecaresnet50d_pruned
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1055
+  In Collection: ECAResNet
+- Name: ecaresnet50d
+  Metadata:
+    FLOPs: 5591090432
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x RTX 2080Ti GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 102579290
+    Tasks:
+    - Image Classification
+    ID: ecaresnet50d
+    LR: 0.1
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1045
+  In Collection: ECAResNet
+- Name: ecaresnetlight
+  Metadata:
+    FLOPs: 5276118784
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Efficient Channel Attention
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 120956612
+    Tasks:
+    - Image Classification
+    ID: ecaresnetlight
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1077
+  In Collection: ECAResNet
+Collections:
+- Name: ECAResNet
+  Paper:
+    title: 'ECA-Net: Efficient Channel Attention for Deep Convolutional Neural Networks'
+    url: https://papperswithcode.com//paper/eca-net-efficient-channel-attention-for-deep
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/efficientnet-pruned.md
+++ b/modelindex/models/efficientnet-pruned.md
@@ -1,0 +1,184 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2), in addition to [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+This collection consists of pruned EfficientNet models.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('efficientnet_b1_pruned', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `efficientnet_b1_pruned`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('efficientnet_b1_pruned', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2020efficientnet,
+      title={EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2020},
+      eprint={1905.11946},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+```
+@misc{rw2019timm,
+  author = {Ross Wightman},
+  title = {PyTorch Image Models},
+  year = {2019},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  doi = {10.5281/zenodo.4414861},
+  howpublished = {\url{https://github.com/rwightman/pytorch-image-models}}
+}
+```
+
+<!--
+Models:
+- Name: efficientnet_b1_pruned
+  Metadata:
+    FLOPs: 489653114
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 25595162
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b1_pruned
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1208
+  In Collection: EfficientNet Pruned
+- Name: efficientnet_b3_pruned
+  Metadata:
+    FLOPs: 1239590641
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 39770812
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b3_pruned
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1230
+  In Collection: EfficientNet Pruned
+- Name: efficientnet_b2_pruned
+  Metadata:
+    FLOPs: 878133915
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 33555005
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b2_pruned
+    Crop Pct: '0.89'
+    Image Size: '260'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1219
+  In Collection: EfficientNet Pruned
+Collections:
+- Name: EfficientNet Pruned
+  Paper:
+    title: Knapsack Pruning with Inner Distillation
+    url: https://papperswithcode.com//paper/knapsack-pruning-with-inner-distillation
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/efficientnet-pruned.md
+++ b/modelindex/models/efficientnet-pruned.md
@@ -101,12 +101,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: EfficientNet Pruned
+  Paper:
+    Title: Knapsack Pruning with Inner Distillation
+    URL: https://paperswithcode.com/paper/knapsack-pruning-with-inner-distillation
 Models:
 - Name: efficientnet_b1_pruned
+  In Collection: EfficientNet Pruned
   Metadata:
     FLOPs: 489653114
-    Training Data:
-    - ImageNet
+    Parameters: 6330000
+    File Size: 25595162
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -117,44 +124,28 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 25595162
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b1_pruned
     Crop Pct: '0.882'
     Image Size: '240'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1208
-  In Collection: EfficientNet Pruned
-- Name: efficientnet_b3_pruned
-  Metadata:
-    FLOPs: 1239590641
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 39770812
-    Tasks:
-    - Image Classification
-    ID: efficientnet_b3_pruned
-    Crop Pct: '0.904'
-    Image Size: '300'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1230
-  In Collection: EfficientNet Pruned
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45403/outputs/effnetb1_pruned_9ebb3fe6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.25%
+      Top 5 Accuracy: 93.84%
 - Name: efficientnet_b2_pruned
+  In Collection: EfficientNet Pruned
   Metadata:
     FLOPs: 878133915
-    Training Data:
-    - ImageNet
+    Parameters: 8310000
+    File Size: 33555005
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -165,20 +156,52 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 33555005
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b2_pruned
     Crop Pct: '0.89'
     Image Size: '260'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1219
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45403/outputs/effnetb2_pruned_203f55bc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.91%
+      Top 5 Accuracy: 94.86%
+- Name: efficientnet_b3_pruned
   In Collection: EfficientNet Pruned
-Collections:
-- Name: EfficientNet Pruned
-  Paper:
-    title: Knapsack Pruning with Inner Distillation
-    url: https://paperswithcode.com//paper/knapsack-pruning-with-inner-distillation
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 1239590641
+    Parameters: 9860000
+    File Size: 39770812
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_b3_pruned
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1230
+  Weights: https://imvl-automl-sh.oss-cn-shanghai.aliyuncs.com/darts/hyperml/hyperml/job_45403/outputs/effnetb3_pruned_5abcc29f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.86%
+      Top 5 Accuracy: 95.24%
 -->

--- a/modelindex/models/efficientnet-pruned.md
+++ b/modelindex/models/efficientnet-pruned.md
@@ -178,7 +178,7 @@ Collections:
 - Name: EfficientNet Pruned
   Paper:
     title: Knapsack Pruning with Inner Distillation
-    url: https://papperswithcode.com//paper/knapsack-pruning-with-inner-distillation
+    url: https://paperswithcode.com//paper/knapsack-pruning-with-inner-distillation
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/efficientnet.md
+++ b/modelindex/models/efficientnet.md
@@ -1,0 +1,315 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2), in addition to [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('efficientnet_b2a', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `efficientnet_b2a`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('efficientnet_b2a', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2020efficientnet,
+      title={EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2020},
+      eprint={1905.11946},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: efficientnet_b2a
+  Metadata:
+    FLOPs: 1452041554
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49369973
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b2a
+    Crop Pct: '1.0'
+    Image Size: '288'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1029
+  In Collection: EfficientNet
+- Name: efficientnet_b3a
+  Metadata:
+    FLOPs: 2600628304
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49369973
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b3a
+    Crop Pct: '1.0'
+    Image Size: '320'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1047
+  In Collection: EfficientNet
+- Name: efficientnet_em
+  Metadata:
+    FLOPs: 3935516480
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 27927309
+    Tasks:
+    - Image Classification
+    ID: efficientnet_em
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1118
+  In Collection: EfficientNet
+- Name: efficientnet_lite0
+  Metadata:
+    FLOPs: 510605024
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 18820005
+    Tasks:
+    - Image Classification
+    ID: efficientnet_lite0
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1163
+  In Collection: EfficientNet
+- Name: efficientnet_es
+  Metadata:
+    FLOPs: 2317181824
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 22003339
+    Tasks:
+    - Image Classification
+    ID: efficientnet_es
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1110
+  In Collection: EfficientNet
+- Name: efficientnet_b3
+  Metadata:
+    FLOPs: 2327905920
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49369973
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b3
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1038
+  In Collection: EfficientNet
+- Name: efficientnet_b0
+  Metadata:
+    FLOPs: 511241564
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 21376743
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b0
+    Layers: 18
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1002
+  In Collection: EfficientNet
+- Name: efficientnet_b1
+  Metadata:
+    FLOPs: 909691920
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 31502706
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b1
+    Crop Pct: '0.875'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1011
+  In Collection: EfficientNet
+- Name: efficientnet_b2
+  Metadata:
+    FLOPs: 1265324514
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 36788104
+    Tasks:
+    - Image Classification
+    ID: efficientnet_b2
+    Crop Pct: '0.875'
+    Image Size: '260'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1020
+  In Collection: EfficientNet
+Collections:
+- Name: EfficientNet
+  Paper:
+    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/efficientnet.md
+++ b/modelindex/models/efficientnet.md
@@ -11,7 +11,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('efficientnet_b2a', pretrained=True)
+model = timm.create_model('efficientnet_b0', pretrained=True)
 model.eval()
 ```
 
@@ -57,14 +57,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `efficientnet_b2a`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `efficientnet_b0`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('efficientnet_b2a', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('efficientnet_b0', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -87,156 +87,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: EfficientNet
+  Paper:
+    Title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    URL: https://paperswithcode.com/paper/efficientnet-rethinking-model-scaling-for
 Models:
-- Name: efficientnet_b2a
-  Metadata:
-    FLOPs: 1452041554
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49369973
-    Tasks:
-    - Image Classification
-    ID: efficientnet_b2a
-    Crop Pct: '1.0'
-    Image Size: '288'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1029
-  In Collection: EfficientNet
-- Name: efficientnet_b3a
-  Metadata:
-    FLOPs: 2600628304
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49369973
-    Tasks:
-    - Image Classification
-    ID: efficientnet_b3a
-    Crop Pct: '1.0'
-    Image Size: '320'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1047
-  In Collection: EfficientNet
-- Name: efficientnet_em
-  Metadata:
-    FLOPs: 3935516480
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 27927309
-    Tasks:
-    - Image Classification
-    ID: efficientnet_em
-    Crop Pct: '0.882'
-    Image Size: '240'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1118
-  In Collection: EfficientNet
-- Name: efficientnet_lite0
-  Metadata:
-    FLOPs: 510605024
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 18820005
-    Tasks:
-    - Image Classification
-    ID: efficientnet_lite0
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1163
-  In Collection: EfficientNet
-- Name: efficientnet_es
-  Metadata:
-    FLOPs: 2317181824
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 22003339
-    Tasks:
-    - Image Classification
-    ID: efficientnet_es
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1110
-  In Collection: EfficientNet
-- Name: efficientnet_b3
-  Metadata:
-    FLOPs: 2327905920
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49369973
-    Tasks:
-    - Image Classification
-    ID: efficientnet_b3
-    Crop Pct: '0.904'
-    Image Size: '300'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1038
-  In Collection: EfficientNet
 - Name: efficientnet_b0
+  In Collection: EfficientNet
   Metadata:
     FLOPs: 511241564
-    Training Data:
-    - ImageNet
+    Parameters: 5290000
+    File Size: 21376743
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -247,21 +110,29 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 21376743
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b0
     Layers: 18
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1002
-  In Collection: EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b0_ra-3dd342df.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.71%
+      Top 5 Accuracy: 93.52%
 - Name: efficientnet_b1
+  In Collection: EfficientNet
   Metadata:
     FLOPs: 909691920
-    Training Data:
-    - ImageNet
+    Parameters: 7790000
+    File Size: 31502706
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -272,20 +143,28 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 31502706
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b1
     Crop Pct: '0.875'
     Image Size: '240'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1011
-  In Collection: EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b1-533bc792.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.71%
+      Top 5 Accuracy: 94.15%
 - Name: efficientnet_b2
+  In Collection: EfficientNet
   Metadata:
     FLOPs: 1265324514
-    Training Data:
-    - ImageNet
+    Parameters: 9110000
+    File Size: 36788104
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -296,20 +175,212 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 36788104
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: efficientnet_b2
     Crop Pct: '0.875'
     Image Size: '260'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1020
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b2_ra-bcdf34b7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.38%
+      Top 5 Accuracy: 95.08%
+- Name: efficientnet_b2a
   In Collection: EfficientNet
-Collections:
-- Name: EfficientNet
-  Paper:
-    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 1452041554
+    Parameters: 9110000
+    File Size: 49369973
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_b2a
+    Crop Pct: '1.0'
+    Image Size: '288'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1029
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b3_ra2-cf984f9c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.61%
+      Top 5 Accuracy: 95.32%
+- Name: efficientnet_b3
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 2327905920
+    Parameters: 12230000
+    File Size: 49369973
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_b3
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1038
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b3_ra2-cf984f9c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.08%
+      Top 5 Accuracy: 96.03%
+- Name: efficientnet_b3a
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 2600628304
+    Parameters: 12230000
+    File Size: 49369973
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_b3a
+    Crop Pct: '1.0'
+    Image Size: '320'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1047
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b3_ra2-cf984f9c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.25%
+      Top 5 Accuracy: 96.11%
+- Name: efficientnet_em
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 3935516480
+    Parameters: 6900000
+    File Size: 27927309
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_em
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1118
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_em_ra2-66250f76.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.26%
+      Top 5 Accuracy: 94.79%
+- Name: efficientnet_es
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 2317181824
+    Parameters: 5440000
+    File Size: 22003339
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_es
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1110
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_es_ra-f111e99c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.09%
+      Top 5 Accuracy: 93.93%
+- Name: efficientnet_lite0
+  In Collection: EfficientNet
+  Metadata:
+    FLOPs: 510605024
+    Parameters: 4650000
+    File Size: 18820005
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: efficientnet_lite0
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/efficientnet.py#L1163
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_lite0_ra-37913777.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.5%
+      Top 5 Accuracy: 92.51%
 -->

--- a/modelindex/models/efficientnet.md
+++ b/modelindex/models/efficientnet.md
@@ -309,7 +309,7 @@ Collections:
 - Name: EfficientNet
   Paper:
     title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/ensemble-adversarial.md
+++ b/modelindex/models/ensemble-adversarial.md
@@ -112,12 +112,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Ensemble Adversarial
+  Paper:
+    Title: Adversarial Attacks and Defences Competition
+    URL: https://paperswithcode.com/paper/adversarial-attacks-and-defences-competition
 Models:
 - Name: ens_adv_inception_resnet_v2
+  In Collection: Ensemble Adversarial
   Metadata:
     FLOPs: 16959133120
-    Training Data:
-    - ImageNet
+    Parameters: 55850000
+    File Size: 223774238
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -131,20 +138,20 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 223774238
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: ens_adv_inception_resnet_v2
     Crop Pct: '0.897'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_resnet_v2.py#L351
-  In Collection: Ensemble Adversarial
-Collections:
-- Name: Ensemble Adversarial
-  Paper:
-    title: Adversarial Attacks and Defences Competition
-    url: https://paperswithcode.com//paper/adversarial-attacks-and-defences-competition
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/ens_adv_inception_resnet_v2-2592a550.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 1.0%
+      Top 5 Accuracy: 17.32%
 -->

--- a/modelindex/models/ensemble-adversarial.md
+++ b/modelindex/models/ensemble-adversarial.md
@@ -1,0 +1,150 @@
+# Summary
+
+**Inception-ResNet-v2** is a convolutional neural architecture that builds on the Inception family of architectures but incorporates [residual connections](https://paperswithcode.com/method/residual-connection) (replacing the filter concatenation stage of the Inception architecture).
+
+This particular model was trained for study of adversarial examples (adversarial training).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('ens_adv_inception_resnet_v2', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `ens_adv_inception_resnet_v2`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('ens_adv_inception_resnet_v2', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1804-00097,
+  author    = {Alexey Kurakin and
+               Ian J. Goodfellow and
+               Samy Bengio and
+               Yinpeng Dong and
+               Fangzhou Liao and
+               Ming Liang and
+               Tianyu Pang and
+               Jun Zhu and
+               Xiaolin Hu and
+               Cihang Xie and
+               Jianyu Wang and
+               Zhishuai Zhang and
+               Zhou Ren and
+               Alan L. Yuille and
+               Sangxia Huang and
+               Yao Zhao and
+               Yuzhe Zhao and
+               Zhonglin Han and
+               Junjiajia Long and
+               Yerkebulan Berdibekov and
+               Takuya Akiba and
+               Seiya Tokui and
+               Motoki Abe},
+  title     = {Adversarial Attacks and Defences Competition},
+  journal   = {CoRR},
+  volume    = {abs/1804.00097},
+  year      = {2018},
+  url       = {http://arxiv.org/abs/1804.00097},
+  archivePrefix = {arXiv},
+  eprint    = {1804.00097},
+  timestamp = {Thu, 31 Oct 2019 16:31:22 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1804-00097.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: ens_adv_inception_resnet_v2
+  Metadata:
+    FLOPs: 16959133120
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 223774238
+    Tasks:
+    - Image Classification
+    ID: ens_adv_inception_resnet_v2
+    Crop Pct: '0.897'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_resnet_v2.py#L351
+  In Collection: Ensemble Adversarial
+Collections:
+- Name: Ensemble Adversarial
+  Paper:
+    title: Adversarial Attacks and Defences Competition
+    url: https://papperswithcode.com//paper/adversarial-attacks-and-defences-competition
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/ensemble-adversarial.md
+++ b/modelindex/models/ensemble-adversarial.md
@@ -144,7 +144,7 @@ Collections:
 - Name: Ensemble Adversarial
   Paper:
     title: Adversarial Attacks and Defences Competition
-    url: https://papperswithcode.com//paper/adversarial-attacks-and-defences-competition
+    url: https://paperswithcode.com//paper/adversarial-attacks-and-defences-competition
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/ese-vovnet.md
+++ b/modelindex/models/ese-vovnet.md
@@ -9,7 +9,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('ese_vovnet39b', pretrained=True)
+model = timm.create_model('ese_vovnet19b_dw', pretrained=True)
 model.eval()
 ```
 
@@ -55,14 +55,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `ese_vovnet39b`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `ese_vovnet19b_dw`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('ese_vovnet39b', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('ese_vovnet19b_dw', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -85,54 +85,69 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ESE VovNet
+  Paper:
+    Title: 'CenterMask : Real-Time Anchor-Free Instance Segmentation'
+    URL: https://paperswithcode.com/paper/centermask-real-time-anchor-free-instance-1
 Models:
-- Name: ese_vovnet39b
-  Metadata:
-    FLOPs: 9089259008
-    Training Data:
-    - ImageNet
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - Max Pooling
-    - One-Shot Aggregation
-    - ReLU
-    File Size: 98397138
-    Tasks:
-    - Image Classification
-    ID: ese_vovnet39b
-    Layers: 39
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L371
-  In Collection: ESE VovNet
 - Name: ese_vovnet19b_dw
+  In Collection: ESE VovNet
   Metadata:
     FLOPs: 1711959904
-    Training Data:
-    - ImageNet
+    Parameters: 6540000
+    File Size: 26243175
     Architecture:
     - Batch Normalization
     - Convolution
     - Max Pooling
     - One-Shot Aggregation
     - ReLU
-    File Size: 26243175
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: ese_vovnet19b_dw
     Layers: 19
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L361
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/ese_vovnet19b_dw-a8741004.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.82%
+      Top 5 Accuracy: 93.28%
+- Name: ese_vovnet39b
   In Collection: ESE VovNet
-Collections:
-- Name: ESE VovNet
-  Paper:
-    title: 'CenterMask : Real-Time Anchor-Free Instance Segmentation'
-    url: https://paperswithcode.com//paper/centermask-real-time-anchor-free-instance-1
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 9089259008
+    Parameters: 24570000
+    File Size: 98397138
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Max Pooling
+    - One-Shot Aggregation
+    - ReLU
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: ese_vovnet39b
+    Layers: 39
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L371
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/ese_vovnet39b-f912fe73.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.31%
+      Top 5 Accuracy: 94.72%
 -->

--- a/modelindex/models/ese-vovnet.md
+++ b/modelindex/models/ese-vovnet.md
@@ -132,7 +132,7 @@ Collections:
 - Name: ESE VovNet
   Paper:
     title: 'CenterMask : Real-Time Anchor-Free Instance Segmentation'
-    url: https://papperswithcode.com//paper/centermask-real-time-anchor-free-instance-1
+    url: https://paperswithcode.com//paper/centermask-real-time-anchor-free-instance-1
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/ese-vovnet.md
+++ b/modelindex/models/ese-vovnet.md
@@ -1,0 +1,138 @@
+# Summary
+
+**VoVNet** is a convolutional neural network that seeks to make [DenseNet](https://paperswithcode.com/method/densenet) more efficient by concatenating all features only once in the last feature map, which makes input size constant and enables enlarging new output channel. 
+
+Read about [one-shot aggregation here](https://paperswithcode.com/method/one-shot-aggregation).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('ese_vovnet39b', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `ese_vovnet39b`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('ese_vovnet39b', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{lee2019energy,
+      title={An Energy and GPU-Computation Efficient Backbone Network for Real-Time Object Detection}, 
+      author={Youngwan Lee and Joong-won Hwang and Sangrok Lee and Yuseok Bae and Jongyoul Park},
+      year={2019},
+      eprint={1904.09730},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: ese_vovnet39b
+  Metadata:
+    FLOPs: 9089259008
+    Training Data:
+    - ImageNet
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Max Pooling
+    - One-Shot Aggregation
+    - ReLU
+    File Size: 98397138
+    Tasks:
+    - Image Classification
+    ID: ese_vovnet39b
+    Layers: 39
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L371
+  In Collection: ESE VovNet
+- Name: ese_vovnet19b_dw
+  Metadata:
+    FLOPs: 1711959904
+    Training Data:
+    - ImageNet
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Max Pooling
+    - One-Shot Aggregation
+    - ReLU
+    File Size: 26243175
+    Tasks:
+    - Image Classification
+    ID: ese_vovnet19b_dw
+    Layers: 19
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/vovnet.py#L361
+  In Collection: ESE VovNet
+Collections:
+- Name: ESE VovNet
+  Paper:
+    title: 'CenterMask : Real-Time Anchor-Free Instance Segmentation'
+    url: https://papperswithcode.com//paper/centermask-real-time-anchor-free-instance-1
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/fbnet.md
+++ b/modelindex/models/fbnet.md
@@ -85,18 +85,20 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: FBNet
+  Paper:
+    Title: 'FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural
+      Architecture Search'
+    URL: https://paperswithcode.com/paper/fbnet-hardware-aware-efficient-convnet-design
 Models:
 - Name: fbnetc_100
+  In Collection: FBNet
   Metadata:
     FLOPs: 508940064
-    Epochs: 360
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 5570000
+    File Size: 22525094
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -105,26 +107,31 @@ Models:
     - FBNet Block
     - Global Average Pooling
     - Softmax
-    File Size: 22525094
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: fbnetc_100
     LR: 0.1
+    Epochs: 360
     Layers: 22
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0005
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L985
-  In Collection: FBNet
-Collections:
-- Name: FBNet
-  Paper:
-    title: 'FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural
-      Architecture Search'
-    url: https://paperswithcode.com//paper/fbnet-hardware-aware-efficient-convnet-design
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/fbnetc_100-c345b898.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.12%
+      Top 5 Accuracy: 92.37%
 -->

--- a/modelindex/models/fbnet.md
+++ b/modelindex/models/fbnet.md
@@ -1,0 +1,130 @@
+# Summary
+
+**FBNet** is a type of convolutional neural architectures discovered through [DNAS](https://paperswithcode.com/method/dnas) neural architecture search. It utilises a basic type of image model block inspired by [MobileNetv2](https://paperswithcode.com/method/mobilenetv2) that utilises depthwise convolutions and an inverted residual structure (see components).
+
+The principal building block is the [FBNet Block](https://paperswithcode.com/method/fbnet-block).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('fbnetc_100', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `fbnetc_100`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('fbnetc_100', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{wu2019fbnet,
+      title={FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural Architecture Search}, 
+      author={Bichen Wu and Xiaoliang Dai and Peizhao Zhang and Yanghan Wang and Fei Sun and Yiming Wu and Yuandong Tian and Peter Vajda and Yangqing Jia and Kurt Keutzer},
+      year={2019},
+      eprint={1812.03443},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: fbnetc_100
+  Metadata:
+    FLOPs: 508940064
+    Epochs: 360
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - FBNet Block
+    - Global Average Pooling
+    - Softmax
+    File Size: 22525094
+    Tasks:
+    - Image Classification
+    ID: fbnetc_100
+    LR: 0.1
+    Layers: 22
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0005
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L985
+  In Collection: FBNet
+Collections:
+- Name: FBNet
+  Paper:
+    title: 'FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural
+      Architecture Search'
+    url: https://papperswithcode.com//paper/fbnet-hardware-aware-efficient-convnet-design
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/fbnet.md
+++ b/modelindex/models/fbnet.md
@@ -124,7 +124,7 @@ Collections:
   Paper:
     title: 'FBNet: Hardware-Aware Efficient ConvNet Design via Differentiable Neural
       Architecture Search'
-    url: https://papperswithcode.com//paper/fbnet-hardware-aware-efficient-convnet-design
+    url: https://paperswithcode.com//paper/fbnet-hardware-aware-efficient-convnet-design
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/gloun-inception-v3.md
+++ b/modelindex/models/gloun-inception-v3.md
@@ -1,0 +1,132 @@
+# Summary
+
+**Inception v3** is a convolutional neural network architecture from the Inception family that makes several improvements including using [Label Smoothing](https://paperswithcode.com/method/label-smoothing), Factorized 7 x 7 convolutions, and the use of an [auxiliary classifer](https://paperswithcode.com/method/auxiliary-classifier) to propagate label information lower down the network (along with the use of batch normalization for layers in the sidehead). The key building block is an [Inception Module](https://paperswithcode.com/method/inception-v3-module).
+
+The weights from this model were ported from Gluon.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('gluon_inception_v3', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `gluon_inception_v3`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('gluon_inception_v3', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/SzegedyVISW15,
+  author    = {Christian Szegedy and
+               Vincent Vanhoucke and
+               Sergey Ioffe and
+               Jonathon Shlens and
+               Zbigniew Wojna},
+  title     = {Rethinking the Inception Architecture for Computer Vision},
+  journal   = {CoRR},
+  volume    = {abs/1512.00567},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.00567},
+  archivePrefix = {arXiv},
+  eprint    = {1512.00567},
+  timestamp = {Mon, 13 Aug 2018 16:49:07 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/SzegedyVISW15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: gluon_inception_v3
+  Metadata:
+    FLOPs: 7352418880
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 95567055
+    Tasks:
+    - Image Classification
+    ID: gluon_inception_v3
+    Crop Pct: '0.875'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L464
+  In Collection: Gloun Inception v3
+Collections:
+- Name: Gloun Inception v3
+  Paper:
+    title: Rethinking the Inception Architecture for Computer Vision
+    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/gloun-inception-v3.md
+++ b/modelindex/models/gloun-inception-v3.md
@@ -94,12 +94,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun Inception v3
+  Paper:
+    Title: Rethinking the Inception Architecture for Computer Vision
+    URL: https://paperswithcode.com/paper/rethinking-the-inception-architecture-for
 Models:
 - Name: gluon_inception_v3
+  In Collection: Gloun Inception v3
   Metadata:
     FLOPs: 7352418880
-    Training Data:
-    - ImageNet
+    Parameters: 23830000
+    File Size: 95567055
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -113,20 +120,20 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 95567055
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_inception_v3
     Crop Pct: '0.875'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L464
-  In Collection: Gloun Inception v3
-Collections:
-- Name: Gloun Inception v3
-  Paper:
-    title: Rethinking the Inception Architecture for Computer Vision
-    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/gluon_inception_v3-9f746940.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.8%
+      Top 5 Accuracy: 94.38%
 -->

--- a/modelindex/models/gloun-inception-v3.md
+++ b/modelindex/models/gloun-inception-v3.md
@@ -126,7 +126,7 @@ Collections:
 - Name: Gloun Inception v3
   Paper:
     title: Rethinking the Inception Architecture for Computer Vision
-    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/gloun-resnet.md
+++ b/modelindex/models/gloun-resnet.md
@@ -448,7 +448,7 @@ Collections:
 - Name: Gloun ResNet
   Paper:
     title: Deep Residual Learning for Image Recognition
-    url: https://papperswithcode.com//paper/deep-residual-learning-for-image-recognition
+    url: https://paperswithcode.com//paper/deep-residual-learning-for-image-recognition
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/gloun-resnet.md
+++ b/modelindex/models/gloun-resnet.md
@@ -1,0 +1,454 @@
+# Summary
+
+**Residual Networks**, or **ResNets**, learn residual functions with reference to the layer inputs, instead of learning unreferenced functions. Instead of hoping each few stacked layers directly fit a desired underlying mapping, residual nets let these layers fit a residual mapping. They stack [residual blocks](https://paperswithcode.com/method/residual-block) ontop of each other to form network: e.g. a ResNet-50 has fifty layers using these blocks. 
+
+The weights from this model were ported from Gluon.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('gluon_resnet101_v1b', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `gluon_resnet101_v1b`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('gluon_resnet101_v1b', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/HeZRS15,
+  author    = {Kaiming He and
+               Xiangyu Zhang and
+               Shaoqing Ren and
+               Jian Sun},
+  title     = {Deep Residual Learning for Image Recognition},
+  journal   = {CoRR},
+  volume    = {abs/1512.03385},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.03385},
+  archivePrefix = {arXiv},
+  eprint    = {1512.03385},
+  timestamp = {Wed, 17 Apr 2019 17:23:45 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/HeZRS15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: gluon_resnet101_v1b
+  Metadata:
+    FLOPs: 10068547584
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178723172
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet101_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L89
+  In Collection: Gloun ResNet
+- Name: gluon_resnet101_v1s
+  Metadata:
+    FLOPs: 11805511680
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 179221777
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet101_v1s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L166
+  In Collection: Gloun ResNet
+- Name: gluon_resnet101_v1c
+  Metadata:
+    FLOPs: 10376567296
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178802575
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet101_v1c
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L113
+  In Collection: Gloun ResNet
+- Name: gluon_resnet152_v1c
+  Metadata:
+    FLOPs: 15165680128
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241613404
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet152_v1c
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L121
+  In Collection: Gloun ResNet
+- Name: gluon_resnet152_v1b
+  Metadata:
+    FLOPs: 14857660416
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241534001
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet152_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L97
+  In Collection: Gloun ResNet
+- Name: gluon_resnet101_v1d
+  Metadata:
+    FLOPs: 10377018880
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178802755
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet101_v1d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L138
+  In Collection: Gloun ResNet
+- Name: gluon_resnet152_v1d
+  Metadata:
+    FLOPs: 15166131712
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241613584
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet152_v1d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L147
+  In Collection: Gloun ResNet
+- Name: gluon_resnet152_v1s
+  Metadata:
+    FLOPs: 16594624512
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 242032606
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet152_v1s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L175
+  In Collection: Gloun ResNet
+- Name: gluon_resnet50_v1b
+  Metadata:
+    FLOPs: 5282531328
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102493763
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet50_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L81
+  In Collection: Gloun ResNet
+- Name: gluon_resnet18_v1b
+  Metadata:
+    FLOPs: 2337073152
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46816736
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet18_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L65
+  In Collection: Gloun ResNet
+- Name: gluon_resnet34_v1b
+  Metadata:
+    FLOPs: 4718469120
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 87295112
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet34_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L73
+  In Collection: Gloun ResNet
+- Name: gluon_resnet50_v1c
+  Metadata:
+    FLOPs: 5590551040
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102573166
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet50_v1c
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L105
+  In Collection: Gloun ResNet
+- Name: gluon_resnet50_v1d
+  Metadata:
+    FLOPs: 5591002624
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102573346
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet50_v1d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L129
+  In Collection: Gloun ResNet
+- Name: gluon_resnet50_v1s
+  Metadata:
+    FLOPs: 7019495424
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102992368
+    Tasks:
+    - Image Classification
+    ID: gluon_resnet50_v1s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L156
+  In Collection: Gloun ResNet
+Collections:
+- Name: Gloun ResNet
+  Paper:
+    title: Deep Residual Learning for Image Recognition
+    url: https://papperswithcode.com//paper/deep-residual-learning-for-image-recognition
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/gloun-resnet.md
+++ b/modelindex/models/gloun-resnet.md
@@ -93,12 +93,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun ResNet
+  Paper:
+    Title: Deep Residual Learning for Image Recognition
+    URL: https://paperswithcode.com/paper/deep-residual-learning-for-image-recognition
 Models:
 - Name: gluon_resnet101_v1b
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 10068547584
-    Training Data:
-    - ImageNet
+    Parameters: 44550000
+    File Size: 178723172
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -110,45 +117,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178723172
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet101_v1b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L89
-  In Collection: Gloun ResNet
-- Name: gluon_resnet101_v1s
-  Metadata:
-    FLOPs: 11805511680
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 179221777
-    Tasks:
-    - Image Classification
-    ID: gluon_resnet101_v1s
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L166
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet101_v1b-3b017079.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.3%
+      Top 5 Accuracy: 94.53%
 - Name: gluon_resnet101_v1c
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 10376567296
-    Training Data:
-    - ImageNet
+    Parameters: 44570000
+    File Size: 178802575
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -160,70 +150,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178802575
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet101_v1c
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L113
-  In Collection: Gloun ResNet
-- Name: gluon_resnet152_v1c
-  Metadata:
-    FLOPs: 15165680128
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 241613404
-    Tasks:
-    - Image Classification
-    ID: gluon_resnet152_v1c
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L121
-  In Collection: Gloun ResNet
-- Name: gluon_resnet152_v1b
-  Metadata:
-    FLOPs: 14857660416
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 241534001
-    Tasks:
-    - Image Classification
-    ID: gluon_resnet152_v1b
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L97
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet101_v1c-1f26822a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.53%
+      Top 5 Accuracy: 94.59%
 - Name: gluon_resnet101_v1d
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 10377018880
-    Training Data:
-    - ImageNet
+    Parameters: 44570000
+    File Size: 178802755
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -235,20 +183,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178802755
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet101_v1d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L138
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet101_v1d-0f9c8644.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.4%
+      Top 5 Accuracy: 95.02%
+- Name: gluon_resnet101_v1s
   In Collection: Gloun ResNet
-- Name: gluon_resnet152_v1d
   Metadata:
-    FLOPs: 15166131712
-    Training Data:
-    - ImageNet
+    FLOPs: 11805511680
+    Parameters: 44670000
+    File Size: 179221777
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -260,20 +216,127 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 241613584
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnet101_v1s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L166
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet101_v1s-60fe0cc1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.29%
+      Top 5 Accuracy: 95.16%
+- Name: gluon_resnet152_v1b
+  In Collection: Gloun ResNet
+  Metadata:
+    FLOPs: 14857660416
+    Parameters: 60190000
+    File Size: 241534001
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnet152_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L97
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet152_v1b-c1edb0dd.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.69%
+      Top 5 Accuracy: 94.73%
+- Name: gluon_resnet152_v1c
+  In Collection: Gloun ResNet
+  Metadata:
+    FLOPs: 15165680128
+    Parameters: 60210000
+    File Size: 241613404
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnet152_v1c
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L121
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet152_v1c-a3bb0b98.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.91%
+      Top 5 Accuracy: 94.85%
+- Name: gluon_resnet152_v1d
+  In Collection: Gloun ResNet
+  Metadata:
+    FLOPs: 15166131712
+    Parameters: 60210000
+    File Size: 241613584
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet152_v1d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L147
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet152_v1d-bd354e12.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.48%
+      Top 5 Accuracy: 95.2%
 - Name: gluon_resnet152_v1s
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 16594624512
-    Training Data:
-    - ImageNet
+    Parameters: 60320000
+    File Size: 242032606
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -285,45 +348,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 242032606
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet152_v1s
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L175
-  In Collection: Gloun ResNet
-- Name: gluon_resnet50_v1b
-  Metadata:
-    FLOPs: 5282531328
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 102493763
-    Tasks:
-    - Image Classification
-    ID: gluon_resnet50_v1b
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L81
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet152_v1s-dcc41b81.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.02%
+      Top 5 Accuracy: 95.42%
 - Name: gluon_resnet18_v1b
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 2337073152
-    Training Data:
-    - ImageNet
+    Parameters: 11690000
+    File Size: 46816736
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -335,20 +381,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 46816736
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet18_v1b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L65
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet18_v1b-0757602b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 70.84%
+      Top 5 Accuracy: 89.76%
 - Name: gluon_resnet34_v1b
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 4718469120
-    Training Data:
-    - ImageNet
+    Parameters: 21800000
+    File Size: 87295112
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -360,20 +414,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 87295112
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet34_v1b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L73
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet34_v1b-c6d82d59.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.59%
+      Top 5 Accuracy: 92.0%
+- Name: gluon_resnet50_v1b
   In Collection: Gloun ResNet
-- Name: gluon_resnet50_v1c
   Metadata:
-    FLOPs: 5590551040
-    Training Data:
-    - ImageNet
+    FLOPs: 5282531328
+    Parameters: 25560000
+    File Size: 102493763
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -385,20 +447,61 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102573166
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnet50_v1b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L81
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet50_v1b-0ebe02e2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.58%
+      Top 5 Accuracy: 93.72%
+- Name: gluon_resnet50_v1c
+  In Collection: Gloun ResNet
+  Metadata:
+    FLOPs: 5590551040
+    Parameters: 25580000
+    File Size: 102573166
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet50_v1c
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L105
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet50_v1c-48092f55.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.01%
+      Top 5 Accuracy: 93.99%
 - Name: gluon_resnet50_v1d
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 5591002624
-    Training Data:
-    - ImageNet
+    Parameters: 25580000
+    File Size: 102573346
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -410,20 +513,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102573346
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet50_v1d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L129
-  In Collection: Gloun ResNet
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet50_v1d-818a1b1b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.06%
+      Top 5 Accuracy: 94.46%
 - Name: gluon_resnet50_v1s
+  In Collection: Gloun ResNet
   Metadata:
     FLOPs: 7019495424
-    Training Data:
-    - ImageNet
+    Parameters: 25680000
+    File Size: 102992368
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -435,20 +546,20 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102992368
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnet50_v1s
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L156
-  In Collection: Gloun ResNet
-Collections:
-- Name: Gloun ResNet
-  Paper:
-    title: Deep Residual Learning for Image Recognition
-    url: https://paperswithcode.com//paper/deep-residual-learning-for-image-recognition
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnet50_v1s-1762acc0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.7%
+      Top 5 Accuracy: 94.25%
 -->

--- a/modelindex/models/gloun-resnext.md
+++ b/modelindex/models/gloun-resnext.md
@@ -1,0 +1,180 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+The weights from this model were ported from Gluon.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('gluon_resnext50_32x4d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `gluon_resnext50_32x4d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('gluon_resnext50_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/XieGDTH16,
+  author    = {Saining Xie and
+               Ross B. Girshick and
+               Piotr Doll{\'{a}}r and
+               Zhuowen Tu and
+               Kaiming He},
+  title     = {Aggregated Residual Transformations for Deep Neural Networks},
+  journal   = {CoRR},
+  volume    = {abs/1611.05431},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1611.05431},
+  archivePrefix = {arXiv},
+  eprint    = {1611.05431},
+  timestamp = {Mon, 13 Aug 2018 16:45:58 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/XieGDTH16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: gluon_resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100441719
+    Tasks:
+    - Image Classification
+    ID: gluon_resnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L185
+  In Collection: Gloun ResNeXt
+- Name: gluon_resnext101_32x4d
+  Metadata:
+    FLOPs: 10298145792
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 177367414
+    Tasks:
+    - Image Classification
+    ID: gluon_resnext101_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L193
+  In Collection: Gloun ResNeXt
+- Name: gluon_resnext101_64x4d
+  Metadata:
+    FLOPs: 19954172928
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 334737852
+    Tasks:
+    - Image Classification
+    ID: gluon_resnext101_64x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L201
+  In Collection: Gloun ResNeXt
+Collections:
+- Name: Gloun ResNeXt
+  Paper:
+    title: Aggregated Residual Transformations for Deep Neural Networks
+    url: https://papperswithcode.com//paper/aggregated-residual-transformations-for-deep
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/gloun-resnext.md
+++ b/modelindex/models/gloun-resnext.md
@@ -9,7 +9,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('gluon_resnext50_32x4d', pretrained=True)
+model = timm.create_model('gluon_resnext101_32x4d', pretrained=True)
 model.eval()
 ```
 
@@ -55,14 +55,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `gluon_resnext50_32x4d`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `gluon_resnext101_32x4d`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('gluon_resnext50_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('gluon_resnext101_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -94,37 +94,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun ResNeXt
+  Paper:
+    Title: Aggregated Residual Transformations for Deep Neural Networks
+    URL: https://paperswithcode.com/paper/aggregated-residual-transformations-for-deep
 Models:
-- Name: gluon_resnext50_32x4d
-  Metadata:
-    FLOPs: 5472648192
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 100441719
-    Tasks:
-    - Image Classification
-    ID: gluon_resnext50_32x4d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L185
-  In Collection: Gloun ResNeXt
 - Name: gluon_resnext101_32x4d
+  In Collection: Gloun ResNeXt
   Metadata:
     FLOPs: 10298145792
-    Training Data:
-    - ImageNet
+    Parameters: 44180000
+    File Size: 177367414
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -136,20 +118,28 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 177367414
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnext101_32x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L193
-  In Collection: Gloun ResNeXt
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnext101_32x4d-b253c8c4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.33%
+      Top 5 Accuracy: 94.91%
 - Name: gluon_resnext101_64x4d
+  In Collection: Gloun ResNeXt
   Metadata:
     FLOPs: 19954172928
-    Training Data:
-    - ImageNet
+    Parameters: 83460000
+    File Size: 334737852
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -161,20 +151,53 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 334737852
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_resnext101_64x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L201
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnext101_64x4d-f9a8e184.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.63%
+      Top 5 Accuracy: 95.0%
+- Name: gluon_resnext50_32x4d
   In Collection: Gloun ResNeXt
-Collections:
-- Name: Gloun ResNeXt
-  Paper:
-    title: Aggregated Residual Transformations for Deep Neural Networks
-    url: https://paperswithcode.com//paper/aggregated-residual-transformations-for-deep
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5472648192
+    Parameters: 25030000
+    File Size: 100441719
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_resnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L185
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_resnext50_32x4d-e6a097c1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.35%
+      Top 5 Accuracy: 94.42%
 -->

--- a/modelindex/models/gloun-resnext.md
+++ b/modelindex/models/gloun-resnext.md
@@ -174,7 +174,7 @@ Collections:
 - Name: Gloun ResNeXt
   Paper:
     title: Aggregated Residual Transformations for Deep Neural Networks
-    url: https://papperswithcode.com//paper/aggregated-residual-transformations-for-deep
+    url: https://paperswithcode.com//paper/aggregated-residual-transformations-for-deep
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/gloun-senet.md
+++ b/modelindex/models/gloun-senet.md
@@ -1,0 +1,117 @@
+# Summary
+
+A **SENet** is a convolutional neural network architecture that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+The weights from this model were ported from Gluon.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('gluon_senet154', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `gluon_senet154`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('gluon_senet154', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: gluon_senet154
+  Metadata:
+    FLOPs: 26681705136
+    Training Data:
+    - ImageNet
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 461546622
+    Tasks:
+    - Image Classification
+    ID: gluon_senet154
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L239
+  In Collection: Gloun SENet
+Collections:
+- Name: Gloun SENet
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/gloun-senet.md
+++ b/modelindex/models/gloun-senet.md
@@ -111,7 +111,7 @@ Collections:
 - Name: Gloun SENet
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/gloun-senet.md
+++ b/modelindex/models/gloun-senet.md
@@ -85,12 +85,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun SENet
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: gluon_senet154
+  In Collection: Gloun SENet
   Metadata:
     FLOPs: 26681705136
-    Training Data:
-    - ImageNet
+    Parameters: 115090000
+    File Size: 461546622
     Architecture:
     - Convolution
     - Dense Connections
@@ -98,20 +105,20 @@ Models:
     - Max Pooling
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 461546622
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_senet154
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L239
-  In Collection: Gloun SENet
-Collections:
-- Name: Gloun SENet
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_senet154-70a1a3c0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.23%
+      Top 5 Accuracy: 95.35%
 -->

--- a/modelindex/models/gloun-seresnext.md
+++ b/modelindex/models/gloun-seresnext.md
@@ -9,7 +9,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('gluon_seresnext50_32x4d', pretrained=True)
+model = timm.create_model('gluon_seresnext101_32x4d', pretrained=True)
 model.eval()
 ```
 
@@ -55,14 +55,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `gluon_seresnext50_32x4d`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `gluon_seresnext101_32x4d`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('gluon_seresnext50_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('gluon_seresnext101_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -85,38 +85,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun SEResNeXt
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
-- Name: gluon_seresnext50_32x4d
-  Metadata:
-    FLOPs: 5475179184
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    - Squeeze-and-Excitation Block
-    File Size: 110578827
-    Tasks:
-    - Image Classification
-    ID: gluon_seresnext50_32x4d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L209
-  In Collection: Gloun SEResNeXt
 - Name: gluon_seresnext101_32x4d
+  In Collection: Gloun SEResNeXt
   Metadata:
     FLOPs: 10302923504
-    Training Data:
-    - ImageNet
+    Parameters: 48960000
+    File Size: 196505510
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -129,20 +110,28 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 196505510
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_seresnext101_32x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L219
-  In Collection: Gloun SEResNeXt
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_seresnext101_32x4d-cf52900d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.87%
+      Top 5 Accuracy: 95.29%
 - Name: gluon_seresnext101_64x4d
+  In Collection: Gloun SEResNeXt
   Metadata:
     FLOPs: 19958950640
-    Training Data:
-    - ImageNet
+    Parameters: 88230000
+    File Size: 353875948
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -155,20 +144,54 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 353875948
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_seresnext101_64x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L229
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_seresnext101_64x4d-f9926f93.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.88%
+      Top 5 Accuracy: 95.31%
+- Name: gluon_seresnext50_32x4d
   In Collection: Gloun SEResNeXt
-Collections:
-- Name: Gloun SEResNeXt
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5475179184
+    Parameters: 27560000
+    File Size: 110578827
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: gluon_seresnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L209
+  Weights: https://github.com/rwightman/pytorch-pretrained-gluonresnet/releases/download/v0.1/gluon_seresnext50_32x4d-90cf2d6e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.92%
+      Top 5 Accuracy: 94.82%
 -->

--- a/modelindex/models/gloun-seresnext.md
+++ b/modelindex/models/gloun-seresnext.md
@@ -1,0 +1,174 @@
+# Summary
+
+**SE ResNeXt** is a variant of a [ResNext](https://www.paperswithcode.com/method/resnext) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+The weights from this model were ported from Gluon.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('gluon_seresnext50_32x4d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `gluon_seresnext50_32x4d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('gluon_seresnext50_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: gluon_seresnext50_32x4d
+  Metadata:
+    FLOPs: 5475179184
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 110578827
+    Tasks:
+    - Image Classification
+    ID: gluon_seresnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L209
+  In Collection: Gloun SEResNeXt
+- Name: gluon_seresnext101_32x4d
+  Metadata:
+    FLOPs: 10302923504
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 196505510
+    Tasks:
+    - Image Classification
+    ID: gluon_seresnext101_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L219
+  In Collection: Gloun SEResNeXt
+- Name: gluon_seresnext101_64x4d
+  Metadata:
+    FLOPs: 19958950640
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 353875948
+    Tasks:
+    - Image Classification
+    ID: gluon_seresnext101_64x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_resnet.py#L229
+  In Collection: Gloun SEResNeXt
+Collections:
+- Name: Gloun SEResNeXt
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/gloun-seresnext.md
+++ b/modelindex/models/gloun-seresnext.md
@@ -168,7 +168,7 @@ Collections:
 - Name: Gloun SEResNeXt
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/gloun-xception.md
+++ b/modelindex/models/gloun-xception.md
@@ -1,0 +1,118 @@
+# Summary
+
+**Xception** is a convolutional neural network architecture that relies solely on [depthwise separable convolution](https://paperswithcode.com/method/depthwise-separable-convolution) layers. The weights from this model were ported from Gluon.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('gluon_xception65', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `gluon_xception65`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('gluon_xception65', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{chollet2017xception,
+      title={Xception: Deep Learning with Depthwise Separable Convolutions}, 
+      author={François Chollet},
+      year={2017},
+      eprint={1610.02357},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: gluon_xception65
+  Metadata:
+    FLOPs: 17594889728
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 160551306
+    Tasks:
+    - Image Classification
+    ID: gluon_xception65
+    Crop Pct: '0.903'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_xception.py#L241
+  In Collection: Gloun Xception
+Collections:
+- Name: Gloun Xception
+  Paper:
+    title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
+    url: https://papperswithcode.com//paper/xception-deep-learning-with-depthwise
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/gloun-xception.md
+++ b/modelindex/models/gloun-xception.md
@@ -83,12 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Gloun Xception
+  Paper:
+    Title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
+    URL: https://paperswithcode.com/paper/xception-deep-learning-with-depthwise
 Models:
 - Name: gluon_xception65
+  In Collection: Gloun Xception
   Metadata:
     FLOPs: 17594889728
-    Training Data:
-    - ImageNet
+    Parameters: 39920000
+    File Size: 160551306
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -99,20 +106,20 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 160551306
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: gluon_xception65
     Crop Pct: '0.903'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/gluon_xception.py#L241
-  In Collection: Gloun Xception
-Collections:
-- Name: Gloun Xception
-  Paper:
-    title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
-    url: https://paperswithcode.com//paper/xception-deep-learning-with-depthwise
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/gluon_xception-7015a15c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.7%
+      Top 5 Accuracy: 94.87%
 -->

--- a/modelindex/models/gloun-xception.md
+++ b/modelindex/models/gloun-xception.md
@@ -112,7 +112,7 @@ Collections:
 - Name: Gloun Xception
   Paper:
     title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
-    url: https://papperswithcode.com//paper/xception-deep-learning-with-depthwise
+    url: https://paperswithcode.com//paper/xception-deep-learning-with-depthwise
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/hrnet.md
+++ b/modelindex/models/hrnet.md
@@ -358,7 +358,7 @@ Collections:
 - Name: HRNet
   Paper:
     title: Deep High-Resolution Representation Learning for Visual Recognition
-    url: https://papperswithcode.com//paper/190807919
+    url: https://paperswithcode.com//paper/190807919
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/hrnet.md
+++ b/modelindex/models/hrnet.md
@@ -1,0 +1,364 @@
+# Summary
+
+**HRNet**, or **High-Resolution Net**, is a general purpose convolutional neural network for tasks like semantic segmentation, object detection and image classification. It is able to maintain high resolution representations through the whole process. We start from a high-resolution convolution stream, gradually add high-to-low resolution convolution streams one by one, and connect the multi-resolution streams in parallel. The resulting network consists of several ($4$ in the paper) stages and the $n$th stage contains $n$ streams corresponding to $n$ resolutions. The authors conduct repeated multi-resolution fusions by exchanging the information across the parallel streams over and over.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('hrnet_w18_small', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `hrnet_w18_small`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('hrnet_w18_small', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{sun2019highresolution,
+      title={High-Resolution Representations for Labeling Pixels and Regions}, 
+      author={Ke Sun and Yang Zhao and Borui Jiang and Tianheng Cheng and Bin Xiao and Dong Liu and Yadong Mu and Xinggang Wang and Wenyu Liu and Jingdong Wang},
+      year={2019},
+      eprint={1904.04514},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: hrnet_w18_small
+  Metadata:
+    FLOPs: 2071651488
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 52934302
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w18_small
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L790
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w18_small_v2
+  Metadata:
+    FLOPs: 3360023160
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 62682879
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w18_small_v2
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L795
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w32
+  Metadata:
+    FLOPs: 11524528320
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 165547812
+    Tasks:
+    - Image Classification
+    Training Time: 60 hours
+    ID: hrnet_w32
+    Layers: 32
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L810
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w40
+  Metadata:
+    FLOPs: 16381182192
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 230899236
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w40
+    Layers: 40
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L815
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w44
+  Metadata:
+    FLOPs: 19202520264
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 268957432
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w44
+    Layers: 44
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L820
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w48
+  Metadata:
+    FLOPs: 22285865760
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 310603710
+    Tasks:
+    - Image Classification
+    Training Time: 80 hours
+    ID: hrnet_w48
+    Layers: 48
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L825
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w18
+  Metadata:
+    FLOPs: 5547205500
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 85718883
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w18
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L800
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w64
+  Metadata:
+    FLOPs: 37239321984
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 513071818
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w64
+    Layers: 64
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L830
+  Config: ''
+  In Collection: HRNet
+- Name: hrnet_w30
+  Metadata:
+    FLOPs: 10474119492
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    File Size: 151452218
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: hrnet_w30
+    Layers: 30
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L805
+  Config: ''
+  In Collection: HRNet
+Collections:
+- Name: HRNet
+  Paper:
+    title: Deep High-Resolution Representation Learning for Visual Recognition
+    url: https://papperswithcode.com//paper/190807919
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/hrnet.md
+++ b/modelindex/models/hrnet.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('hrnet_w18_small', pretrained=True)
+model = timm.create_model('hrnet_w18', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `hrnet_w18_small`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `hrnet_w18`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('hrnet_w18_small', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('hrnet_w18', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -83,282 +83,337 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: HRNet
+  Paper:
+    Title: Deep High-Resolution Representation Learning for Visual Recognition
+    URL: https://paperswithcode.com/paper/190807919
 Models:
-- Name: hrnet_w18_small
-  Metadata:
-    FLOPs: 2071651488
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 52934302
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: hrnet_w18_small
-    Layers: 18
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L790
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w18_small_v2
-  Metadata:
-    FLOPs: 3360023160
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 62682879
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: hrnet_w18_small_v2
-    Layers: 18
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L795
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w32
-  Metadata:
-    FLOPs: 11524528320
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 165547812
-    Tasks:
-    - Image Classification
-    Training Time: 60 hours
-    ID: hrnet_w32
-    Layers: 32
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L810
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w40
-  Metadata:
-    FLOPs: 16381182192
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 230899236
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: hrnet_w40
-    Layers: 40
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L815
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w44
-  Metadata:
-    FLOPs: 19202520264
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 268957432
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: hrnet_w44
-    Layers: 44
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L820
-  Config: ''
-  In Collection: HRNet
-- Name: hrnet_w48
-  Metadata:
-    FLOPs: 22285865760
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - ReLU
-    - Residual Connection
-    File Size: 310603710
-    Tasks:
-    - Image Classification
-    Training Time: 80 hours
-    ID: hrnet_w48
-    Layers: 48
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L825
-  Config: ''
-  In Collection: HRNet
 - Name: hrnet_w18
+  In Collection: HRNet
   Metadata:
     FLOPs: 5547205500
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 21300000
+    File Size: 85718883
     Architecture:
     - Batch Normalization
     - Convolution
     - ReLU
     - Residual Connection
-    File Size: 85718883
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: hrnet_w18
+    Epochs: 100
     Layers: 18
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L800
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w18-8cb57bb9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.76%
+      Top 5 Accuracy: 93.44%
+- Name: hrnet_w18_small
   In Collection: HRNet
-- Name: hrnet_w64
   Metadata:
-    FLOPs: 37239321984
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    FLOPs: 2071651488
+    Parameters: 13190000
+    File Size: 52934302
     Architecture:
     - Batch Normalization
     - Convolution
     - ReLU
     - Residual Connection
-    File Size: 513071818
     Tasks:
     - Image Classification
-    Training Time: ''
-    ID: hrnet_w64
-    Layers: 64
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w18_small
+    Epochs: 100
+    Layers: 18
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L830
-  Config: ''
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L790
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnet_w18_small_v1-f460c6bc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.34%
+      Top 5 Accuracy: 90.68%
+- Name: hrnet_w18_small_v2
   In Collection: HRNet
-- Name: hrnet_w30
   Metadata:
-    FLOPs: 10474119492
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    FLOPs: 3360023160
+    Parameters: 15600000
+    File Size: 62682879
     Architecture:
     - Batch Normalization
     - Convolution
     - ReLU
     - Residual Connection
-    File Size: 151452218
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w18_small_v2
+    Epochs: 100
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L795
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnet_w18_small_v2-4c50a8cb.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.11%
+      Top 5 Accuracy: 92.41%
+- Name: hrnet_w30
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 10474119492
+    Parameters: 37710000
+    File Size: 151452218
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: hrnet_w30
+    Epochs: 100
     Layers: 30
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L805
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w30-8d7f8dab.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.21%
+      Top 5 Accuracy: 94.22%
+- Name: hrnet_w32
   In Collection: HRNet
-Collections:
-- Name: HRNet
-  Paper:
-    title: Deep High-Resolution Representation Learning for Visual Recognition
-    url: https://paperswithcode.com//paper/190807919
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 11524528320
+    Parameters: 41230000
+    File Size: 165547812
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    Training Time: 60 hours
+    ID: hrnet_w32
+    Epochs: 100
+    Layers: 32
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L810
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w32-90d8c5fb.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.45%
+      Top 5 Accuracy: 94.19%
+- Name: hrnet_w40
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 16381182192
+    Parameters: 57560000
+    File Size: 230899236
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w40
+    Epochs: 100
+    Layers: 40
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L815
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w40-7cd397a4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.93%
+      Top 5 Accuracy: 94.48%
+- Name: hrnet_w44
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 19202520264
+    Parameters: 67060000
+    File Size: 268957432
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w44
+    Epochs: 100
+    Layers: 44
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L820
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w44-c9ac8c18.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.89%
+      Top 5 Accuracy: 94.37%
+- Name: hrnet_w48
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 22285865760
+    Parameters: 77470000
+    File Size: 310603710
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    Training Time: 80 hours
+    ID: hrnet_w48
+    Epochs: 100
+    Layers: 48
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L825
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w48-abd2e6ab.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.32%
+      Top 5 Accuracy: 94.51%
+- Name: hrnet_w64
+  In Collection: HRNet
+  Metadata:
+    FLOPs: 37239321984
+    Parameters: 128060000
+    File Size: 513071818
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - ReLU
+    - Residual Connection
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
+    ID: hrnet_w64
+    Epochs: 100
+    Layers: 64
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/hrnet.py#L830
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-hrnet/hrnetv2_w64-b47cc881.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.46%
+      Top 5 Accuracy: 94.65%
 -->

--- a/modelindex/models/ig-resnext.md
+++ b/modelindex/models/ig-resnext.md
@@ -233,7 +233,7 @@ Collections:
 - Name: IG ResNeXt
   Paper:
     title: Exploring the Limits of Weakly Supervised Pretraining
-    url: https://papperswithcode.com//paper/exploring-the-limits-of-weakly-supervised
+    url: https://paperswithcode.com//paper/exploring-the-limits-of-weakly-supervised
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/ig-resnext.md
+++ b/modelindex/models/ig-resnext.md
@@ -1,0 +1,239 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+This model was trained on billions of Instagram images using thousands of distinct hashtags as labels exhibit excellent transfer learning performance. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('ig_resnext101_32x32d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `ig_resnext101_32x32d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('ig_resnext101_32x32d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{mahajan2018exploring,
+      title={Exploring the Limits of Weakly Supervised Pretraining}, 
+      author={Dhruv Mahajan and Ross Girshick and Vignesh Ramanathan and Kaiming He and Manohar Paluri and Yixuan Li and Ashwin Bharambe and Laurens van der Maaten},
+      year={2018},
+      eprint={1805.00932},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: ig_resnext101_32x32d
+  Metadata:
+    FLOPs: 112225170432
+    Epochs: 100
+    Batch Size: 8064
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 336x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 1876573776
+    Tasks:
+    - Image Classification
+    ID: ig_resnext101_32x32d
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+    Minibatch Size: 8064
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L885
+  In Collection: IG ResNeXt
+- Name: ig_resnext101_32x16d
+  Metadata:
+    FLOPs: 46623691776
+    Epochs: 100
+    Batch Size: 8064
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 336x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 777518664
+    Tasks:
+    - Image Classification
+    ID: ig_resnext101_32x16d
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L874
+  In Collection: IG ResNeXt
+- Name: ig_resnext101_32x48d
+  Metadata:
+    FLOPs: 197446554624
+    Epochs: 100
+    Batch Size: 8064
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 336x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 3317136976
+    Tasks:
+    - Image Classification
+    ID: ig_resnext101_32x48d
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L896
+  In Collection: IG ResNeXt
+- Name: ig_resnext101_32x8d
+  Metadata:
+    FLOPs: 21180417024
+    Epochs: 100
+    Batch Size: 8064
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 336x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 356056638
+    Tasks:
+    - Image Classification
+    ID: ig_resnext101_32x8d
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L863
+  In Collection: IG ResNeXt
+Collections:
+- Name: IG ResNeXt
+  Paper:
+    title: Exploring the Limits of Weakly Supervised Pretraining
+    url: https://papperswithcode.com//paper/exploring-the-limits-of-weakly-supervised
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/ig-resnext.md
+++ b/modelindex/models/ig-resnext.md
@@ -11,7 +11,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('ig_resnext101_32x32d', pretrained=True)
+model = timm.create_model('ig_resnext101_32x16d', pretrained=True)
 model.eval()
 ```
 
@@ -57,14 +57,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `ig_resnext101_32x32d`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `ig_resnext101_32x16d`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('ig_resnext101_32x32d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('ig_resnext101_32x16d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -87,19 +87,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: IG ResNeXt
+  Paper:
+    Title: Exploring the Limits of Weakly Supervised Pretraining
+    URL: https://paperswithcode.com/paper/exploring-the-limits-of-weakly-supervised
 Models:
-- Name: ig_resnext101_32x32d
+- Name: ig_resnext101_32x16d
+  In Collection: IG ResNeXt
   Metadata:
-    FLOPs: 112225170432
-    Epochs: 100
-    Batch Size: 8064
-    Training Data:
-    - IG-3.5B-17k
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 336x GPUs
+    FLOPs: 46623691776
+    Parameters: 194030000
+    File Size: 777518664
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -111,66 +111,82 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 1876573776
     Tasks:
     - Image Classification
-    ID: ig_resnext101_32x32d
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Resources: 336x GPUs
+    ID: ig_resnext101_32x16d
+    Epochs: 100
     Layers: 101
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8064
+    Image Size: '224'
+    Weight Decay: 0.001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L874
+  Weights: https://download.pytorch.org/models/ig_resnext101_32x16-c6f796b0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.16%
+      Top 5 Accuracy: 97.19%
+- Name: ig_resnext101_32x32d
+  In Collection: IG ResNeXt
+  Metadata:
+    FLOPs: 112225170432
+    Parameters: 468530000
+    File Size: 1876573776
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Resources: 336x GPUs
+    ID: ig_resnext101_32x32d
+    Epochs: 100
+    Layers: 101
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 8064
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
     Minibatch Size: 8064
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L885
-  In Collection: IG ResNeXt
-- Name: ig_resnext101_32x16d
-  Metadata:
-    FLOPs: 46623691776
-    Epochs: 100
-    Batch Size: 8064
-    Training Data:
-    - IG-3.5B-17k
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 336x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 777518664
-    Tasks:
-    - Image Classification
-    ID: ig_resnext101_32x16d
-    Layers: 101
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L874
-  In Collection: IG ResNeXt
+  Weights: https://download.pytorch.org/models/ig_resnext101_32x32-e4b90b00.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.09%
+      Top 5 Accuracy: 97.44%
 - Name: ig_resnext101_32x48d
+  In Collection: IG ResNeXt
   Metadata:
     FLOPs: 197446554624
-    Epochs: 100
-    Batch Size: 8064
-    Training Data:
-    - IG-3.5B-17k
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 336x GPUs
+    Parameters: 828410000
+    File Size: 3317136976
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -182,30 +198,38 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 3317136976
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Resources: 336x GPUs
     ID: ig_resnext101_32x48d
+    Epochs: 100
     Layers: 101
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8064
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L896
-  In Collection: IG ResNeXt
+  Weights: https://download.pytorch.org/models/ig_resnext101_32x48-3e41cc8a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.42%
+      Top 5 Accuracy: 97.58%
 - Name: ig_resnext101_32x8d
+  In Collection: IG ResNeXt
   Metadata:
     FLOPs: 21180417024
-    Epochs: 100
-    Batch Size: 8064
-    Training Data:
-    - IG-3.5B-17k
-    - ImageNet
-    Training Techniques:
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 336x GPUs
+    Parameters: 88790000
+    File Size: 356056638
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -217,23 +241,30 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 356056638
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - IG-3.5B-17k
+    - ImageNet
+    Training Resources: 336x GPUs
     ID: ig_resnext101_32x8d
+    Epochs: 100
     Layers: 101
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8064
     Image Size: '224'
     Weight Decay: 0.001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L863
-  In Collection: IG ResNeXt
-Collections:
-- Name: IG ResNeXt
-  Paper:
-    title: Exploring the Limits of Weakly Supervised Pretraining
-    url: https://paperswithcode.com//paper/exploring-the-limits-of-weakly-supervised
-  type: model-index
-Type: model-index
+  Weights: https://download.pytorch.org/models/ig_resnext101_32x8-c38310e5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.7%
+      Top 5 Accuracy: 96.64%
 -->

--- a/modelindex/models/inception-resnet-v2.md
+++ b/modelindex/models/inception-resnet-v2.md
@@ -120,7 +120,7 @@ Collections:
   Paper:
     title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
       Learning
-    url: https://papperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
+    url: https://paperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/inception-resnet-v2.md
+++ b/modelindex/models/inception-resnet-v2.md
@@ -83,17 +83,20 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Inception ResNet v2
+  Paper:
+    Title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
+      Learning
+    URL: https://paperswithcode.com/paper/inception-v4-inception-resnet-and-the-impact
 Models:
 - Name: inception_resnet_v2
+  In Collection: Inception ResNet v2
   Metadata:
     FLOPs: 16959133120
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 20x NVIDIA Kepler GPUs
+    Parameters: 55850000
+    File Size: 223774238
     Architecture:
     - Average Pooling
     - Dropout
@@ -103,9 +106,15 @@ Models:
     - Inception-ResNet-v2-C
     - Reduction-A
     - Softmax
-    File Size: 223774238
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 20x NVIDIA Kepler GPUs
     ID: inception_resnet_v2
     LR: 0.045
     Dropout: 0.2
@@ -114,13 +123,11 @@ Models:
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_resnet_v2.py#L343
-  In Collection: Inception ResNet v2
-Collections:
-- Name: Inception ResNet v2
-  Paper:
-    title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
-      Learning
-    url: https://paperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/inception_resnet_v2-940b1cd6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 0.95%
+      Top 5 Accuracy: 17.29%
 -->

--- a/modelindex/models/inception-resnet-v2.md
+++ b/modelindex/models/inception-resnet-v2.md
@@ -1,0 +1,126 @@
+# Summary
+
+**Inception-ResNet-v2** is a convolutional neural architecture that builds on the Inception family of architectures but incorporates [residual connections](https://paperswithcode.com/method/residual-connection) (replacing the filter concatenation stage of the Inception architecture).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('inception_resnet_v2', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `inception_resnet_v2`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('inception_resnet_v2', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{szegedy2016inceptionv4,
+      title={Inception-v4, Inception-ResNet and the Impact of Residual Connections on Learning}, 
+      author={Christian Szegedy and Sergey Ioffe and Vincent Vanhoucke and Alex Alemi},
+      year={2016},
+      eprint={1602.07261},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: inception_resnet_v2
+  Metadata:
+    FLOPs: 16959133120
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 20x NVIDIA Kepler GPUs
+    Architecture:
+    - Average Pooling
+    - Dropout
+    - Inception-ResNet-v2 Reduction-B
+    - Inception-ResNet-v2-A
+    - Inception-ResNet-v2-B
+    - Inception-ResNet-v2-C
+    - Reduction-A
+    - Softmax
+    File Size: 223774238
+    Tasks:
+    - Image Classification
+    ID: inception_resnet_v2
+    LR: 0.045
+    Dropout: 0.2
+    Crop Pct: '0.897'
+    Momentum: 0.9
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_resnet_v2.py#L343
+  In Collection: Inception ResNet v2
+Collections:
+- Name: Inception ResNet v2
+  Paper:
+    title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
+      Learning
+    url: https://papperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/inception-v3.md
+++ b/modelindex/models/inception-v3.md
@@ -133,7 +133,7 @@ Collections:
 - Name: Inception v3
   Paper:
     title: Rethinking the Inception Architecture for Computer Vision
-    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/inception-v3.md
+++ b/modelindex/models/inception-v3.md
@@ -1,0 +1,139 @@
+# Summary
+
+**Inception v3** is a convolutional neural network architecture from the Inception family that makes several improvements including using [Label Smoothing](https://paperswithcode.com/method/label-smoothing), Factorized 7 x 7 convolutions, and the use of an [auxiliary classifer](https://paperswithcode.com/method/auxiliary-classifier) to propagate label information lower down the network (along with the use of batch normalization for layers in the sidehead). The key building block is an [Inception Module](https://paperswithcode.com/method/inception-v3-module).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('inception_v3', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `inception_v3`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('inception_v3', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/SzegedyVISW15,
+  author    = {Christian Szegedy and
+               Vincent Vanhoucke and
+               Sergey Ioffe and
+               Jonathon Shlens and
+               Zbigniew Wojna},
+  title     = {Rethinking the Inception Architecture for Computer Vision},
+  journal   = {CoRR},
+  volume    = {abs/1512.00567},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.00567},
+  archivePrefix = {arXiv},
+  eprint    = {1512.00567},
+  timestamp = {Mon, 13 Aug 2018 16:49:07 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/SzegedyVISW15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: inception_v3
+  Metadata:
+    FLOPs: 7352418880
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Gradient Clipping
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 50x NVIDIA Kepler GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 108857766
+    Tasks:
+    - Image Classification
+    ID: inception_v3
+    LR: 0.045
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L442
+  In Collection: Inception v3
+Collections:
+- Name: Inception v3
+  Paper:
+    title: Rethinking the Inception Architecture for Computer Vision
+    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/inception-v3.md
+++ b/modelindex/models/inception-v3.md
@@ -92,18 +92,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Inception v3
+  Paper:
+    Title: Rethinking the Inception Architecture for Computer Vision
+    URL: https://paperswithcode.com/paper/rethinking-the-inception-architecture-for
 Models:
 - Name: inception_v3
+  In Collection: Inception v3
   Metadata:
     FLOPs: 7352418880
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Gradient Clipping
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 50x NVIDIA Kepler GPUs
+    Parameters: 23830000
+    File Size: 108857766
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -117,9 +118,16 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 108857766
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Gradient Clipping
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 50x NVIDIA Kepler GPUs
     ID: inception_v3
     LR: 0.045
     Dropout: 0.2
@@ -128,12 +136,11 @@ Models:
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L442
-  In Collection: Inception v3
-Collections:
-- Name: Inception v3
-  Paper:
-    title: Rethinking the Inception Architecture for Computer Vision
-    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
-  type: model-index
-Type: model-index
+  Weights: https://download.pytorch.org/models/inception_v3_google-1a9a5a14.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.46%
+      Top 5 Accuracy: 93.48%
 -->

--- a/modelindex/models/inception-v4.md
+++ b/modelindex/models/inception-v4.md
@@ -1,0 +1,125 @@
+# Summary
+
+**Inception-v4** is a convolutional neural network architecture that builds on previous iterations of the Inception family by simplifying the architecture and using more inception modules than [Inception-v3](https://paperswithcode.com/method/inception-v3).
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('inception_v4', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `inception_v4`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('inception_v4', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{szegedy2016inceptionv4,
+      title={Inception-v4, Inception-ResNet and the Impact of Residual Connections on Learning}, 
+      author={Christian Szegedy and Sergey Ioffe and Vincent Vanhoucke and Alex Alemi},
+      year={2016},
+      eprint={1602.07261},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: inception_v4
+  Metadata:
+    FLOPs: 15806527936
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 20x NVIDIA Kepler GPUs
+    Architecture:
+    - Average Pooling
+    - Dropout
+    - Inception-A
+    - Inception-B
+    - Inception-C
+    - Reduction-A
+    - Reduction-B
+    - Softmax
+    File Size: 171082495
+    Tasks:
+    - Image Classification
+    ID: inception_v4
+    LR: 0.045
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v4.py#L313
+  In Collection: Inception v4
+Collections:
+- Name: Inception v4
+  Paper:
+    title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
+      Learning
+    url: https://papperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/inception-v4.md
+++ b/modelindex/models/inception-v4.md
@@ -119,7 +119,7 @@ Collections:
   Paper:
     title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
       Learning
-    url: https://papperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
+    url: https://paperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/inception-v4.md
+++ b/modelindex/models/inception-v4.md
@@ -82,17 +82,20 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Inception v4
+  Paper:
+    Title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
+      Learning
+    URL: https://paperswithcode.com/paper/inception-v4-inception-resnet-and-the-impact
 Models:
 - Name: inception_v4
+  In Collection: Inception v4
   Metadata:
     FLOPs: 15806527936
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 20x NVIDIA Kepler GPUs
+    Parameters: 42680000
+    File Size: 171082495
     Architecture:
     - Average Pooling
     - Dropout
@@ -102,9 +105,15 @@ Models:
     - Reduction-A
     - Reduction-B
     - Softmax
-    File Size: 171082495
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 20x NVIDIA Kepler GPUs
     ID: inception_v4
     LR: 0.045
     Dropout: 0.2
@@ -113,13 +122,11 @@ Models:
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v4.py#L313
-  In Collection: Inception v4
-Collections:
-- Name: Inception v4
-  Paper:
-    title: Inception-v4, Inception-ResNet and the Impact of Residual Connections on
-      Learning
-    url: https://paperswithcode.com//paper/inception-v4-inception-resnet-and-the-impact
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/inceptionv4-8e4777a0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 1.01%
+      Top 5 Accuracy: 16.85%
 -->

--- a/modelindex/models/legacy-se-resnet.md
+++ b/modelindex/models/legacy-se-resnet.md
@@ -1,0 +1,279 @@
+# Summary
+
+**SE ResNet** is a variant of a [ResNet](https://www.paperswithcode.com/method/resnet) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('legacy_seresnet101', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `legacy_seresnet101`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('legacy_seresnet101', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: legacy_seresnet101
+  Metadata:
+    FLOPs: 9762614000
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 197822624
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet101
+    LR: 0.6
+    Layers: 101
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L426
+  In Collection: Legacy SE ResNet
+- Name: legacy_seresnet152
+  Metadata:
+    FLOPs: 14553578160
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 268033864
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet152
+    LR: 0.6
+    Layers: 152
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L433
+  In Collection: Legacy SE ResNet
+- Name: legacy_seresnet18
+  Metadata:
+    FLOPs: 2328876024
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 47175663
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet18
+    LR: 0.6
+    Layers: 18
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L405
+  In Collection: Legacy SE ResNet
+- Name: legacy_seresnet34
+  Metadata:
+    FLOPs: 4706201004
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 87958697
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet34
+    LR: 0.6
+    Layers: 34
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L412
+  In Collection: Legacy SE ResNet
+- Name: legacy_seresnet50
+  Metadata:
+    FLOPs: 4974351024
+    Epochs: 100
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 112611220
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnet50
+    LR: 0.6
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+    Minibatch Size: 1024
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L419
+  In Collection: Legacy SE ResNet
+Collections:
+- Name: Legacy SE ResNet
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/legacy-se-resnet.md
+++ b/modelindex/models/legacy-se-resnet.md
@@ -273,7 +273,7 @@ Collections:
 - Name: Legacy SE ResNet
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/legacy-se-resnet.md
+++ b/modelindex/models/legacy-se-resnet.md
@@ -83,19 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Legacy SE ResNet
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: legacy_seresnet101
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 9762614000
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 49330000
+    File Size: 197822624
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -108,31 +108,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 197822624
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet101
     LR: 0.6
+    Epochs: 100
     Layers: 101
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L426
-  In Collection: Legacy SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/se_resnet101-7e38fcc6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.38%
+      Top 5 Accuracy: 94.26%
 - Name: legacy_seresnet152
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 14553578160
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 66819999
+    File Size: 268033864
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -145,31 +153,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 268033864
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet152
     LR: 0.6
+    Epochs: 100
     Layers: 152
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L433
-  In Collection: Legacy SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/se_resnet152-d17c99b7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.67%
+      Top 5 Accuracy: 94.38%
 - Name: legacy_seresnet18
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 2328876024
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 11780000
+    File Size: 47175663
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -182,31 +198,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 47175663
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet18
     LR: 0.6
+    Epochs: 100
     Layers: 18
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L405
-  In Collection: Legacy SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnet18-4bb0ce65.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 71.74%
+      Top 5 Accuracy: 90.34%
 - Name: legacy_seresnet34
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 4706201004
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 21960000
+    File Size: 87958697
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -219,30 +243,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 87958697
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet34
     LR: 0.6
+    Epochs: 100
     Layers: 34
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L412
-  In Collection: Legacy SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnet34-a4004e63.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.79%
+      Top 5 Accuracy: 92.13%
 - Name: legacy_seresnet50
+  In Collection: Legacy SE ResNet
   Metadata:
     FLOPs: 4974351024
-    Epochs: 100
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 28090000
+    File Size: 112611220
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -255,11 +288,18 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 112611220
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnet50
     LR: 0.6
+    Epochs: 100
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
@@ -268,12 +308,11 @@ Models:
     Interpolation: bilinear
     Minibatch Size: 1024
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L419
-  In Collection: Legacy SE ResNet
-Collections:
-- Name: Legacy SE ResNet
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/se_resnet50-ce0d4300.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.64%
+      Top 5 Accuracy: 93.74%
 -->

--- a/modelindex/models/legacy-se-resnext.md
+++ b/modelindex/models/legacy-se-resnext.md
@@ -199,7 +199,7 @@ Collections:
 - Name: Legacy SE ResNeXt
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/legacy-se-resnext.md
+++ b/modelindex/models/legacy-se-resnext.md
@@ -83,19 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Legacy SE ResNeXt
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: legacy_seresnext101_32x4d
+  In Collection: Legacy SE ResNeXt
   Metadata:
     FLOPs: 10287698672
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 48960000
+    File Size: 196466866
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -108,31 +108,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 196466866
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnext101_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 101
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L462
-  In Collection: Legacy SE ResNeXt
+  Weights: http://data.lip6.fr/cadene/pretrainedmodels/se_resnext101_32x4d-3b2fe3d8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.23%
+      Top 5 Accuracy: 95.02%
 - Name: legacy_seresnext26_32x4d
+  In Collection: Legacy SE ResNeXt
   Metadata:
     FLOPs: 3187342304
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 16790000
+    File Size: 67346327
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -145,31 +153,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 67346327
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnext26_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 26
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L448
-  In Collection: Legacy SE ResNeXt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnext26_32x4d-65ebdb501.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.11%
+      Top 5 Accuracy: 93.31%
 - Name: legacy_seresnext50_32x4d
+  In Collection: Legacy SE ResNeXt
   Metadata:
     FLOPs: 5459954352
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 27560000
+    File Size: 110559176
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -182,24 +198,31 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 110559176
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_seresnext50_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L455
-  In Collection: Legacy SE ResNeXt
-Collections:
-- Name: Legacy SE ResNeXt
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: http://data.lip6.fr/cadene/pretrainedmodels/se_resnext50_32x4d-a260b3a4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.08%
+      Top 5 Accuracy: 94.43%
 -->

--- a/modelindex/models/legacy-se-resnext.md
+++ b/modelindex/models/legacy-se-resnext.md
@@ -1,0 +1,205 @@
+# Summary
+
+**SE ResNeXt** is a variant of a [ResNeXt](https://www.paperswithcode.com/method/resnext) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('legacy_seresnext101_32x4d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `legacy_seresnext101_32x4d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('legacy_seresnext101_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: legacy_seresnext101_32x4d
+  Metadata:
+    FLOPs: 10287698672
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 196466866
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnext101_32x4d
+    LR: 0.6
+    Layers: 101
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L462
+  In Collection: Legacy SE ResNeXt
+- Name: legacy_seresnext26_32x4d
+  Metadata:
+    FLOPs: 3187342304
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 67346327
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnext26_32x4d
+    LR: 0.6
+    Layers: 26
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L448
+  In Collection: Legacy SE ResNeXt
+- Name: legacy_seresnext50_32x4d
+  Metadata:
+    FLOPs: 5459954352
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 110559176
+    Tasks:
+    - Image Classification
+    ID: legacy_seresnext50_32x4d
+    LR: 0.6
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L455
+  In Collection: Legacy SE ResNeXt
+Collections:
+- Name: Legacy SE ResNeXt
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/legacy-senet.md
+++ b/modelindex/models/legacy-senet.md
@@ -85,19 +85,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Legacy SENet
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: legacy_senet154
+  In Collection: Legacy SENet
   Metadata:
     FLOPs: 26659556016
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 115090000
+    File Size: 461488402
     Architecture:
     - Convolution
     - Dense Connections
@@ -105,24 +105,31 @@ Models:
     - Max Pooling
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 461488402
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: legacy_senet154
     LR: 0.6
+    Epochs: 100
     Layers: 154
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L440
-  In Collection: Legacy SENet
-Collections:
-- Name: Legacy SENet
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: http://data.lip6.fr/cadene/pretrainedmodels/senet154-c7b49a05.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.33%
+      Top 5 Accuracy: 95.51%
 -->

--- a/modelindex/models/legacy-senet.md
+++ b/modelindex/models/legacy-senet.md
@@ -122,7 +122,7 @@ Collections:
 - Name: Legacy SENet
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/legacy-senet.md
+++ b/modelindex/models/legacy-senet.md
@@ -1,0 +1,128 @@
+# Summary
+
+A **SENet** is a convolutional neural network architecture that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+The weights from this model were ported from Gluon.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('legacy_senet154', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `legacy_senet154`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('legacy_senet154', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: legacy_senet154
+  Metadata:
+    FLOPs: 26659556016
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 461488402
+    Tasks:
+    - Image Classification
+    ID: legacy_senet154
+    LR: 0.6
+    Layers: 154
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/senet.py#L440
+  In Collection: Legacy SENet
+Collections:
+- Name: Legacy SENet
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/mixnet.md
+++ b/modelindex/models/mixnet.md
@@ -188,7 +188,7 @@ Collections:
 - Name: MixNet
   Paper:
     title: 'MixConv: Mixed Depthwise Convolutional Kernels'
-    url: https://papperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
+    url: https://paperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/mixnet.md
+++ b/modelindex/models/mixnet.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('mixnet_xl', pretrained=True)
+model = timm.create_model('mixnet_l', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `mixnet_xl`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `mixnet_l`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('mixnet_xl', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('mixnet_l', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -83,89 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: MixNet
+  Paper:
+    Title: 'MixConv: Mixed Depthwise Convolutional Kernels'
+    URL: https://paperswithcode.com/paper/mixnet-mixed-depthwise-convolutional-kernels
 Models:
-- Name: mixnet_xl
-  Metadata:
-    FLOPs: 1195880424
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
-    Architecture:
-    - Batch Normalization
-    - Dense Connections
-    - Dropout
-    - Global Average Pooling
-    - Grouped Convolution
-    - MixConv
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 48001170
-    Tasks:
-    - Image Classification
-    ID: mixnet_xl
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1678
-  In Collection: MixNet
-- Name: mixnet_m
-  Metadata:
-    FLOPs: 454543374
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
-    Architecture:
-    - Batch Normalization
-    - Dense Connections
-    - Dropout
-    - Global Average Pooling
-    - Grouped Convolution
-    - MixConv
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 20298347
-    Tasks:
-    - Image Classification
-    ID: mixnet_m
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1660
-  In Collection: MixNet
-- Name: mixnet_s
-  Metadata:
-    FLOPs: 321264910
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
-    Architecture:
-    - Batch Normalization
-    - Dense Connections
-    - Dropout
-    - Global Average Pooling
-    - Grouped Convolution
-    - MixConv
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 16727982
-    Tasks:
-    - Image Classification
-    ID: mixnet_s
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1651
-  In Collection: MixNet
 - Name: mixnet_l
+  In Collection: MixNet
   Metadata:
     FLOPs: 738671316
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
+    Parameters: 7330000
+    File Size: 29608232
     Architecture:
     - Batch Normalization
     - Dense Connections
@@ -175,20 +105,121 @@ Models:
     - MixConv
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 29608232
     Tasks:
     - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
     ID: mixnet_l
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1669
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mixnet_l-5a9a2ed8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.98%
+      Top 5 Accuracy: 94.18%
+- Name: mixnet_m
   In Collection: MixNet
-Collections:
-- Name: MixNet
-  Paper:
-    title: 'MixConv: Mixed Depthwise Convolutional Kernels'
-    url: https://paperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 454543374
+    Parameters: 5010000
+    File Size: 20298347
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
+    ID: mixnet_m
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1660
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mixnet_m-4647fc68.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.27%
+      Top 5 Accuracy: 93.42%
+- Name: mixnet_s
+  In Collection: MixNet
+  Metadata:
+    FLOPs: 321264910
+    Parameters: 4130000
+    File Size: 16727982
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
+    ID: mixnet_s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1651
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mixnet_s-a907afbc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.99%
+      Top 5 Accuracy: 92.79%
+- Name: mixnet_xl
+  In Collection: MixNet
+  Metadata:
+    FLOPs: 1195880424
+    Parameters: 11900000
+    File Size: 48001170
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
+    ID: mixnet_xl
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1678
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mixnet_xl_ra-aac3c00c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.47%
+      Top 5 Accuracy: 94.93%
 -->

--- a/modelindex/models/mixnet.md
+++ b/modelindex/models/mixnet.md
@@ -1,0 +1,194 @@
+# Summary
+
+**MixNet** is a type of convolutional neural network discovered via AutoML that utilises [MixConvs](https://paperswithcode.com/method/mixconv) instead of regular [depthwise convolutions](https://paperswithcode.com/method/depthwise-convolution).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('mixnet_xl', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `mixnet_xl`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('mixnet_xl', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2019mixconv,
+      title={MixConv: Mixed Depthwise Convolutional Kernels}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2019},
+      eprint={1907.09595},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: mixnet_xl
+  Metadata:
+    FLOPs: 1195880424
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 48001170
+    Tasks:
+    - Image Classification
+    ID: mixnet_xl
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1678
+  In Collection: MixNet
+- Name: mixnet_m
+  Metadata:
+    FLOPs: 454543374
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 20298347
+    Tasks:
+    - Image Classification
+    ID: mixnet_m
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1660
+  In Collection: MixNet
+- Name: mixnet_s
+  Metadata:
+    FLOPs: 321264910
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 16727982
+    Tasks:
+    - Image Classification
+    ID: mixnet_s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1651
+  In Collection: MixNet
+- Name: mixnet_l
+  Metadata:
+    FLOPs: 738671316
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 29608232
+    Tasks:
+    - Image Classification
+    ID: mixnet_l
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1669
+  In Collection: MixNet
+Collections:
+- Name: MixNet
+  Paper:
+    title: 'MixConv: Mixed Depthwise Convolutional Kernels'
+    url: https://papperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/mnasnet.md
+++ b/modelindex/models/mnasnet.md
@@ -1,0 +1,155 @@
+# Summary
+
+**MnasNet** is a type of convolutional neural network optimized for mobile devices that is discovered through mobile neural architecture search, which explicitly incorporates model latency into the main objective so that the search can identify a model that achieves a good trade-off between accuracy and latency. The main building block is an [inverted residual block](https://paperswithcode.com/method/inverted-residual-block) (from [MobileNetV2](https://paperswithcode.com/method/mobilenetv2)).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('semnasnet_100', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `semnasnet_100`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('semnasnet_100', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2019mnasnet,
+      title={MnasNet: Platform-Aware Neural Architecture Search for Mobile}, 
+      author={Mingxing Tan and Bo Chen and Ruoming Pang and Vijay Vasudevan and Mark Sandler and Andrew Howard and Quoc V. Le},
+      year={2019},
+      eprint={1807.11626},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: semnasnet_100
+  Metadata:
+    FLOPs: 414570766
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 15731489
+    Tasks:
+    - Image Classification
+    ID: semnasnet_100
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L928
+  In Collection: MNASNet
+- Name: mnasnet_100
+  Metadata:
+    FLOPs: 416415488
+    Batch Size: 4000
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 17731774
+    Tasks:
+    - Image Classification
+    ID: mnasnet_100
+    Layers: 100
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L894
+  In Collection: MNASNet
+Collections:
+- Name: MNASNet
+  Paper:
+    title: 'MnasNet: Platform-Aware Neural Architecture Search for Mobile'
+    url: https://papperswithcode.com//paper/mnasnet-platform-aware-neural-architecture
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/mnasnet.md
+++ b/modelindex/models/mnasnet.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('semnasnet_100', pretrained=True)
+model = timm.create_model('mnasnet_100', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `semnasnet_100`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `mnasnet_100`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('semnasnet_100', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('mnasnet_100', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -83,12 +83,61 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: MNASNet
+  Paper:
+    Title: 'MnasNet: Platform-Aware Neural Architecture Search for Mobile'
+    URL: https://paperswithcode.com/paper/mnasnet-platform-aware-neural-architecture
 Models:
-- Name: semnasnet_100
+- Name: mnasnet_100
+  In Collection: MNASNet
   Metadata:
-    FLOPs: 414570766
+    FLOPs: 416415488
+    Parameters: 4380000
+    File Size: 17731774
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
     Training Data:
     - ImageNet
+    ID: mnasnet_100
+    Layers: 100
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 4000
+    Image Size: '224'
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L894
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mnasnet_b1-74cb7081.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.67%
+      Top 5 Accuracy: 92.1%
+- Name: semnasnet_100
+  In Collection: MNASNet
+  Metadata:
+    FLOPs: 414570766
+    Parameters: 3890000
+    File Size: 15731489
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -102,54 +151,20 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 15731489
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: semnasnet_100
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L928
-  In Collection: MNASNet
-- Name: mnasnet_100
-  Metadata:
-    FLOPs: 416415488
-    Batch Size: 4000
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Depthwise Separable Convolution
-    - Dropout
-    - Global Average Pooling
-    - Inverted Residual Block
-    - Max Pooling
-    - ReLU
-    - Residual Connection
-    - Softmax
-    File Size: 17731774
-    Tasks:
-    - Image Classification
-    ID: mnasnet_100
-    Layers: 100
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L894
-  In Collection: MNASNet
-Collections:
-- Name: MNASNet
-  Paper:
-    title: 'MnasNet: Platform-Aware Neural Architecture Search for Mobile'
-    url: https://paperswithcode.com//paper/mnasnet-platform-aware-neural-architecture
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mnasnet_a1-d9418771.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.45%
+      Top 5 Accuracy: 92.61%
 -->

--- a/modelindex/models/mnasnet.md
+++ b/modelindex/models/mnasnet.md
@@ -149,7 +149,7 @@ Collections:
 - Name: MNASNet
   Paper:
     title: 'MnasNet: Platform-Aware Neural Architecture Search for Mobile'
-    url: https://papperswithcode.com//paper/mnasnet-platform-aware-neural-architecture
+    url: https://paperswithcode.com//paper/mnasnet-platform-aware-neural-architecture
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/mobilenet-v2.md
+++ b/modelindex/models/mobilenet-v2.md
@@ -1,0 +1,240 @@
+# Summary
+
+**MobileNetV2** is a convolutional neural network architecture that seeks to perform well on mobile devices. It is based on an [inverted residual structure](https://paperswithcode.com/method/inverted-residual-block) where the residual connections are between the bottleneck layers.  The intermediate expansion layer uses lightweight depthwise convolutions to filter features as a source of non-linearity. As a whole, the architecture of MobileNetV2 contains the initial fully convolution layer with 32 filters, followed by 19 residual bottleneck layers.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('mobilenetv2_100', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `mobilenetv2_100`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('mobilenetv2_100', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1801-04381,
+  author    = {Mark Sandler and
+               Andrew G. Howard and
+               Menglong Zhu and
+               Andrey Zhmoginov and
+               Liang{-}Chieh Chen},
+  title     = {Inverted Residuals and Linear Bottlenecks: Mobile Networks for Classification,
+               Detection and Segmentation},
+  journal   = {CoRR},
+  volume    = {abs/1801.04381},
+  year      = {2018},
+  url       = {http://arxiv.org/abs/1801.04381},
+  archivePrefix = {arXiv},
+  eprint    = {1801.04381},
+  timestamp = {Tue, 12 Jan 2021 15:30:06 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1801-04381.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: mobilenetv2_100
+  Metadata:
+    FLOPs: 401920448
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU6
+    - Residual Connection
+    - Softmax
+    File Size: 14202571
+    Tasks:
+    - Image Classification
+    ID: mobilenetv2_100
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L955
+  In Collection: MobileNet V2
+- Name: mobilenetv2_110d
+  Metadata:
+    FLOPs: 573958832
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU6
+    - Residual Connection
+    - Softmax
+    File Size: 18316431
+    Tasks:
+    - Image Classification
+    ID: mobilenetv2_110d
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L969
+  In Collection: MobileNet V2
+- Name: mobilenetv2_120d
+  Metadata:
+    FLOPs: 888510048
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU6
+    - Residual Connection
+    - Softmax
+    File Size: 23651121
+    Tasks:
+    - Image Classification
+    ID: mobilenetv2_120d
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L977
+  In Collection: MobileNet V2
+- Name: mobilenetv2_140
+  Metadata:
+    FLOPs: 770196784
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - Inverted Residual Block
+    - Max Pooling
+    - ReLU6
+    - Residual Connection
+    - Softmax
+    File Size: 24673555
+    Tasks:
+    - Image Classification
+    ID: mobilenetv2_140
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L962
+  In Collection: MobileNet V2
+Collections:
+- Name: MobileNet V2
+  Paper:
+    title: 'MobileNetV2: Inverted Residuals and Linear Bottlenecks'
+    url: https://papperswithcode.com//paper/mobilenetv2-inverted-residuals-and-linear
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/mobilenet-v2.md
+++ b/modelindex/models/mobilenet-v2.md
@@ -93,17 +93,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: MobileNet V2
+  Paper:
+    Title: 'MobileNetV2: Inverted Residuals and Linear Bottlenecks'
+    URL: https://paperswithcode.com/paper/mobilenetv2-inverted-residuals-and-linear
 Models:
 - Name: mobilenetv2_100
+  In Collection: MobileNet V2
   Metadata:
     FLOPs: 401920448
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 3500000
+    File Size: 14202571
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -115,29 +117,37 @@ Models:
     - ReLU6
     - Residual Connection
     - Softmax
-    File Size: 14202571
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: mobilenetv2_100
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L955
-  In Collection: MobileNet V2
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv2_100_ra-b33bc2c4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.95%
+      Top 5 Accuracy: 91.0%
 - Name: mobilenetv2_110d
+  In Collection: MobileNet V2
   Metadata:
     FLOPs: 573958832
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 4520000
+    File Size: 18316431
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -149,29 +159,37 @@ Models:
     - ReLU6
     - Residual Connection
     - Softmax
-    File Size: 18316431
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: mobilenetv2_110d
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L969
-  In Collection: MobileNet V2
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv2_110d_ra-77090ade.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.05%
+      Top 5 Accuracy: 92.19%
 - Name: mobilenetv2_120d
+  In Collection: MobileNet V2
   Metadata:
     FLOPs: 888510048
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 5830000
+    File Size: 23651121
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -183,29 +201,37 @@ Models:
     - ReLU6
     - Residual Connection
     - Softmax
-    File Size: 23651121
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: mobilenetv2_120d
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L977
-  In Collection: MobileNet V2
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv2_120d_ra-5987e2ed.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.28%
+      Top 5 Accuracy: 93.51%
 - Name: mobilenetv2_140
+  In Collection: MobileNet V2
   Metadata:
     FLOPs: 770196784
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 6110000
+    File Size: 24673555
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -217,24 +243,29 @@ Models:
     - ReLU6
     - Residual Connection
     - Softmax
-    File Size: 24673555
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: mobilenetv2_140
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L962
-  In Collection: MobileNet V2
-Collections:
-- Name: MobileNet V2
-  Paper:
-    title: 'MobileNetV2: Inverted Residuals and Linear Bottlenecks'
-    url: https://paperswithcode.com//paper/mobilenetv2-inverted-residuals-and-linear
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv2_140_ra-21a4e913.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.51%
+      Top 5 Accuracy: 93.0%
 -->

--- a/modelindex/models/mobilenet-v2.md
+++ b/modelindex/models/mobilenet-v2.md
@@ -234,7 +234,7 @@ Collections:
 - Name: MobileNet V2
   Paper:
     title: 'MobileNetV2: Inverted Residuals and Linear Bottlenecks'
-    url: https://papperswithcode.com//paper/mobilenetv2-inverted-residuals-and-linear
+    url: https://paperswithcode.com//paper/mobilenetv2-inverted-residuals-and-linear
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/mobilenet-v3.md
+++ b/modelindex/models/mobilenet-v3.md
@@ -1,0 +1,184 @@
+# Summary
+
+**MobileNetV3** is a convolutional neural network that is designed for mobile phone CPUs. The network design includes the use of a [hard swish activation](https://paperswithcode.com/method/hard-swish) and [squeeze-and-excitation](https://paperswithcode.com/method/squeeze-and-excitation-block) modules in the [MBConv blocks](https://paperswithcode.com/method/inverted-residual-block).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('mobilenetv3_rw', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `mobilenetv3_rw`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('mobilenetv3_rw', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-02244,
+  author    = {Andrew Howard and
+               Mark Sandler and
+               Grace Chu and
+               Liang{-}Chieh Chen and
+               Bo Chen and
+               Mingxing Tan and
+               Weijun Wang and
+               Yukun Zhu and
+               Ruoming Pang and
+               Vijay Vasudevan and
+               Quoc V. Le and
+               Hartwig Adam},
+  title     = {Searching for MobileNetV3},
+  journal   = {CoRR},
+  volume    = {abs/1905.02244},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.02244},
+  archivePrefix = {arXiv},
+  eprint    = {1905.02244},
+  timestamp = {Tue, 12 Jan 2021 15:30:06 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-02244.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: mobilenetv3_rw
+  Metadata:
+    FLOPs: 287190638
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 22064048
+    Tasks:
+    - Image Classification
+    ID: mobilenetv3_rw
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L384
+  In Collection: MobileNet V3
+- Name: mobilenetv3_large_100
+  Metadata:
+    FLOPs: 287193752
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 22076443
+    Tasks:
+    - Image Classification
+    ID: mobilenetv3_large_100
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L363
+  In Collection: MobileNet V3
+Collections:
+- Name: MobileNet V3
+  Paper:
+    title: Searching for MobileNetV3
+    url: https://papperswithcode.com//paper/searching-for-mobilenetv3
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/mobilenet-v3.md
+++ b/modelindex/models/mobilenet-v3.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('mobilenetv3_rw', pretrained=True)
+model = timm.create_model('mobilenetv3_large_100', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `mobilenetv3_rw`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `mobilenetv3_large_100`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('mobilenetv3_rw', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('mobilenetv3_large_100', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -99,54 +99,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: MobileNet V3
+  Paper:
+    Title: Searching for MobileNetV3
+    URL: https://paperswithcode.com/paper/searching-for-mobilenetv3
 Models:
-- Name: mobilenetv3_rw
-  Metadata:
-    FLOPs: 287190638
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Depthwise Separable Convolution
-    - Dropout
-    - Global Average Pooling
-    - Hard Swish
-    - Inverted Residual Block
-    - ReLU
-    - Residual Connection
-    - Softmax
-    - Squeeze-and-Excitation Block
-    File Size: 22064048
-    Tasks:
-    - Image Classification
-    ID: mobilenetv3_rw
-    LR: 0.1
-    Dropout: 0.8
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L384
-  In Collection: MobileNet V3
 - Name: mobilenetv3_large_100
+  In Collection: MobileNet V3
   Metadata:
     FLOPs: 287193752
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
+    Parameters: 5480000
+    File Size: 22076443
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -161,24 +126,74 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 22076443
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
     ID: mobilenetv3_large_100
     LR: 0.1
     Dropout: 0.8
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L363
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv3_large_100_ra-f55367f5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.77%
+      Top 5 Accuracy: 92.54%
+- Name: mobilenetv3_rw
   In Collection: MobileNet V3
-Collections:
-- Name: MobileNet V3
-  Paper:
-    title: Searching for MobileNetV3
-    url: https://paperswithcode.com//paper/searching-for-mobilenetv3
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 287190638
+    Parameters: 5480000
+    File Size: 22064048
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
+    ID: mobilenetv3_rw
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 4096
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L384
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/mobilenetv3_100-35495452.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.62%
+      Top 5 Accuracy: 92.71%
 -->

--- a/modelindex/models/mobilenet-v3.md
+++ b/modelindex/models/mobilenet-v3.md
@@ -178,7 +178,7 @@ Collections:
 - Name: MobileNet V3
   Paper:
     title: Searching for MobileNetV3
-    url: https://papperswithcode.com//paper/searching-for-mobilenetv3
+    url: https://paperswithcode.com//paper/searching-for-mobilenetv3
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/nasnet.md
+++ b/modelindex/models/nasnet.md
@@ -83,17 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: NASNet
+  Paper:
+    Title: Learning Transferable Architectures for Scalable Image Recognition
+    URL: https://paperswithcode.com/paper/learning-transferable-architectures-for
 Models:
 - Name: nasnetalarge
+  In Collection: NASNet
   Metadata:
     FLOPs: 30242402862
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 50x Tesla K40 GPUs
+    Parameters: 88750000
+    File Size: 356056626
     Architecture:
     - Average Pooling
     - Batch Normalization
@@ -101,10 +103,15 @@ Models:
     - Depthwise Separable Convolution
     - Dropout
     - ReLU
-    File Size: 356056626
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 50x Tesla K40 GPUs
     ID: nasnetalarge
     Dropout: 0.5
     Crop Pct: '0.911'
@@ -114,13 +121,11 @@ Models:
     Label Smoothing: 0.1
     RMSProp $\epsilon$: 1.0
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/nasnet.py#L562
-  Config: ''
-  In Collection: NASNet
-Collections:
-- Name: NASNet
-  Paper:
-    title: Learning Transferable Architectures for Scalable Image Recognition
-    url: https://paperswithcode.com//paper/learning-transferable-architectures-for
-  type: model-index
-Type: model-index
+  Weights: http://data.lip6.fr/cadene/pretrainedmodels/nasnetalarge-a1897284.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.63%
+      Top 5 Accuracy: 96.05%
 -->

--- a/modelindex/models/nasnet.md
+++ b/modelindex/models/nasnet.md
@@ -120,7 +120,7 @@ Collections:
 - Name: NASNet
   Paper:
     title: Learning Transferable Architectures for Scalable Image Recognition
-    url: https://papperswithcode.com//paper/learning-transferable-architectures-for
+    url: https://paperswithcode.com//paper/learning-transferable-architectures-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/nasnet.md
+++ b/modelindex/models/nasnet.md
@@ -1,0 +1,126 @@
+# Summary
+
+**NASNet** is a type of convolutional neural network discovered through neural architecture search. The building blocks consist of normal and reduction cells.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('nasnetalarge', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `nasnetalarge`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('nasnetalarge', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{zoph2018learning,
+      title={Learning Transferable Architectures for Scalable Image Recognition}, 
+      author={Barret Zoph and Vijay Vasudevan and Jonathon Shlens and Quoc V. Le},
+      year={2018},
+      eprint={1707.07012},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: nasnetalarge
+  Metadata:
+    FLOPs: 30242402862
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 50x Tesla K40 GPUs
+    Architecture:
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - ReLU
+    File Size: 356056626
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: nasnetalarge
+    Dropout: 0.5
+    Crop Pct: '0.911'
+    Momentum: 0.9
+    Image Size: '331'
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+    RMSProp $\epsilon$: 1.0
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/nasnet.py#L562
+  Config: ''
+  In Collection: NASNet
+Collections:
+- Name: NASNet
+  Paper:
+    title: Learning Transferable Architectures for Scalable Image Recognition
+    url: https://papperswithcode.com//paper/learning-transferable-architectures-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/noisy-student.md
+++ b/modelindex/models/noisy-student.md
@@ -16,7 +16,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('tf_efficientnet_b3_ns', pretrained=True)
+model = timm.create_model('tf_efficientnet_b0_ns', pretrained=True)
 model.eval()
 ```
 
@@ -62,14 +62,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `tf_efficientnet_b3_ns`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_b0_ns`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('tf_efficientnet_b3_ns', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('tf_efficientnet_b0_ns', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -92,162 +92,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Noisy Student
+  Paper:
+    Title: Self-training with Noisy Student improves ImageNet classification
+    URL: https://paperswithcode.com/paper/self-training-with-noisy-student-improves
 Models:
-- Name: tf_efficientnet_b3_ns
-  Metadata:
-    FLOPs: 2275247568
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49385734
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b3_ns
-    LR: 0.128
-    Dropout: 0.5
-    Crop Pct: '0.904'
-    Momentum: 0.9
-    Image Size: '300'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-    Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1457
-  Config: ''
-  In Collection: Noisy Student
-- Name: tf_efficientnet_b1_ns
-  Metadata:
-    FLOPs: 883633200
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 31516408
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b1_ns
-    LR: 0.128
-    Dropout: 0.5
-    Crop Pct: '0.882'
-    Momentum: 0.9
-    Image Size: '240'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-    Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1437
-  Config: ''
-  In Collection: Noisy Student
-- Name: tf_efficientnet_l2_ns
-  Metadata:
-    FLOPs: 611646113804
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 1925950424
-    Tasks:
-    - Image Classification
-    Training Time: 6 days
-    ID: tf_efficientnet_l2_ns
-    LR: 0.128
-    Dropout: 0.5
-    Crop Pct: '0.96'
-    Momentum: 0.9
-    Image Size: '800'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-    Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1520
-  Config: ''
-  In Collection: Noisy Student
 - Name: tf_efficientnet_b0_ns
+  In Collection: Noisy Student
   Metadata:
     FLOPs: 488688572
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    Parameters: 5290000
+    File Size: 21386709
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -258,15 +115,27 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 21386709
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
     ID: tf_efficientnet_b0_ns
     LR: 0.128
+    Epochs: 700
     Dropout: 0.5
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -275,25 +144,19 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1427
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b0_ns-c0e6a31c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.66%
+      Top 5 Accuracy: 94.37%
+- Name: tf_efficientnet_b1_ns
   In Collection: Noisy Student
-- Name: tf_efficientnet_b2_ns
   Metadata:
-    FLOPs: 1234321170
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    FLOPs: 883633200
+    Parameters: 7790000
+    File Size: 31516408
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -304,15 +167,79 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 36801803
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
+    ID: tf_efficientnet_b1_ns
+    LR: 0.128
+    Epochs: 700
+    Dropout: 0.5
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1437
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b1_ns-99dd0c41.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.39%
+      Top 5 Accuracy: 95.74%
+- Name: tf_efficientnet_b2_ns
+  In Collection: Noisy Student
+  Metadata:
+    FLOPs: 1234321170
+    Parameters: 9110000
+    File Size: 36801803
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
     ID: tf_efficientnet_b2_ns
     LR: 0.128
+    Epochs: 700
     Dropout: 0.5
     Crop Pct: '0.89'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '260'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -321,25 +248,19 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1447
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b2_ns-00306e48.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.39%
+      Top 5 Accuracy: 96.24%
+- Name: tf_efficientnet_b3_ns
   In Collection: Noisy Student
-- Name: tf_efficientnet_b5_ns
   Metadata:
-    FLOPs: 13176501888
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    FLOPs: 2275247568
+    Parameters: 12230000
+    File Size: 49385734
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -350,33 +271,8 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 122404944
     Tasks:
     - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b5_ns
-    LR: 0.128
-    Dropout: 0.5
-    Crop Pct: '0.934'
-    Momentum: 0.9
-    Image Size: '456'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-    Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1477
-  Config: ''
-  In Collection: Noisy Student
-- Name: tf_efficientnet_b6_ns
-  Metadata:
-    FLOPs: 24180518488
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
     Training Techniques:
     - AutoAugment
     - FixRes
@@ -385,53 +281,38 @@ Models:
     - RMSProp
     - RandAugment
     - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
     Training Resources: Cloud TPU v3 Pod
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 173239537
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b6_ns
+    ID: tf_efficientnet_b3_ns
     LR: 0.128
+    Epochs: 700
     Dropout: 0.5
-    Crop Pct: '0.942'
+    Crop Pct: '0.904'
     Momentum: 0.9
-    Image Size: '528'
+    Batch Size: 2048
+    Image Size: '300'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     RMSProp Decay: 0.9
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1487
-  Config: ''
-  In Collection: Noisy Student
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1457
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b3_ns-9d44bf68.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.04%
+      Top 5 Accuracy: 96.91%
 - Name: tf_efficientnet_b4_ns
+  In Collection: Noisy Student
   Metadata:
     FLOPs: 5749638672
-    Epochs: 700
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    Parameters: 19340000
+    File Size: 77995057
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -442,15 +323,27 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 77995057
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
     ID: tf_efficientnet_b4_ns
     LR: 0.128
+    Epochs: 700
     Dropout: 0.5
     Crop Pct: '0.922'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '380'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -459,25 +352,19 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1467
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b4_ns-d6313a46.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.15%
+      Top 5 Accuracy: 97.47%
+- Name: tf_efficientnet_b5_ns
   In Collection: Noisy Student
-- Name: tf_efficientnet_b7_ns
   Metadata:
-    FLOPs: 48205304880
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - AutoAugment
-    - FixRes
-    - Label Smoothing
-    - Noisy Student
-    - RMSProp
-    - RandAugment
-    - Weight Decay
-    Training Resources: Cloud TPU v3 Pod
+    FLOPs: 13176501888
+    Parameters: 30390000
+    File Size: 122404944
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -488,15 +375,131 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 266853140
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
+    ID: tf_efficientnet_b5_ns
+    LR: 0.128
+    Epochs: 350
+    Dropout: 0.5
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1477
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_ns-6f26d0cf.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 86.08%
+      Top 5 Accuracy: 97.75%
+- Name: tf_efficientnet_b6_ns
+  In Collection: Noisy Student
+  Metadata:
+    FLOPs: 24180518488
+    Parameters: 43040000
+    File Size: 173239537
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
+    ID: tf_efficientnet_b6_ns
+    LR: 0.128
+    Epochs: 350
+    Dropout: 0.5
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1487
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b6_ns-51548356.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 86.45%
+      Top 5 Accuracy: 97.88%
+- Name: tf_efficientnet_b7_ns
+  In Collection: Noisy Student
+  Metadata:
+    FLOPs: 48205304880
+    Parameters: 66349999
+    File Size: 266853140
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
     ID: tf_efficientnet_b7_ns
     LR: 0.128
+    Epochs: 350
     Dropout: 0.5
     Crop Pct: '0.949'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '600'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -505,13 +508,64 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1498
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b7_ns-1dbc32de.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 86.83%
+      Top 5 Accuracy: 98.08%
+- Name: tf_efficientnet_l2_ns
   In Collection: Noisy Student
-Collections:
-- Name: Noisy Student
-  Paper:
-    title: Self-training with Noisy Student improves ImageNet classification
-    url: https://paperswithcode.com//paper/self-training-with-noisy-student-improves
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 611646113804
+    Parameters: 480310000
+    File Size: 1925950424
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: Cloud TPU v3 Pod
+    Training Time: 6 days
+    ID: tf_efficientnet_l2_ns
+    LR: 0.128
+    Epochs: 350
+    Dropout: 0.5
+    Crop Pct: '0.96'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '800'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1520
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_l2_ns-df73bb44.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 88.35%
+      Top 5 Accuracy: 98.66%
 -->

--- a/modelindex/models/noisy-student.md
+++ b/modelindex/models/noisy-student.md
@@ -511,7 +511,7 @@ Collections:
 - Name: Noisy Student
   Paper:
     title: Self-training with Noisy Student improves ImageNet classification
-    url: https://papperswithcode.com//paper/self-training-with-noisy-student-improves
+    url: https://paperswithcode.com//paper/self-training-with-noisy-student-improves
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/noisy-student.md
+++ b/modelindex/models/noisy-student.md
@@ -1,0 +1,517 @@
+# Summary
+
+**Noisy Student Training** is a semi-supervised learning approach. It extends the idea of self-training
+and distillation with the use of equal-or-larger student models and noise added to the student during learning. It has three main steps: 
+
+1. train a teacher model on labeled images
+2. use the teacher to generate pseudo labels on unlabeled images
+3. train a student model on the combination of labeled images and pseudo labeled images. 
+
+The algorithm is iterated a few times by treating the student as a teacher to relabel the unlabeled data and training a new student.
+
+Noisy Student Training seeks to improve on self-training and distillation in two ways. First, it makes the student larger than, or at least equal to, the teacher so the student can better learn from a larger dataset. Second, it adds noise to the student so the noised student is forced to learn harder from the pseudo labels. To noise the student, it uses input noise such as RandAugment data augmentation, and model noise such as dropout and stochastic depth during training.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('tf_efficientnet_b3_ns', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_b3_ns`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('tf_efficientnet_b3_ns', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{xie2020selftraining,
+      title={Self-training with Noisy Student improves ImageNet classification}, 
+      author={Qizhe Xie and Minh-Thang Luong and Eduard Hovy and Quoc V. Le},
+      year={2020},
+      eprint={1911.04252},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_b3_ns
+  Metadata:
+    FLOPs: 2275247568
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49385734
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b3_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1457
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b1_ns
+  Metadata:
+    FLOPs: 883633200
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 31516408
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b1_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1437
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_l2_ns
+  Metadata:
+    FLOPs: 611646113804
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 1925950424
+    Tasks:
+    - Image Classification
+    Training Time: 6 days
+    ID: tf_efficientnet_l2_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.96'
+    Momentum: 0.9
+    Image Size: '800'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1520
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b0_ns
+  Metadata:
+    FLOPs: 488688572
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 21386709
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b0_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1427
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b2_ns
+  Metadata:
+    FLOPs: 1234321170
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 36801803
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b2_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1447
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b5_ns
+  Metadata:
+    FLOPs: 13176501888
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 122404944
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b5_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1477
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b6_ns
+  Metadata:
+    FLOPs: 24180518488
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 173239537
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b6_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1487
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b4_ns
+  Metadata:
+    FLOPs: 5749638672
+    Epochs: 700
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 77995057
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b4_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1467
+  Config: ''
+  In Collection: Noisy Student
+- Name: tf_efficientnet_b7_ns
+  Metadata:
+    FLOPs: 48205304880
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: Cloud TPU v3 Pod
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 266853140
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b7_ns
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.949'
+    Momentum: 0.9
+    Image Size: '600'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1498
+  Config: ''
+  In Collection: Noisy Student
+Collections:
+- Name: Noisy Student
+  Paper:
+    title: Self-training with Noisy Student improves ImageNet classification
+    url: https://papperswithcode.com//paper/self-training-with-noisy-student-improves
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/pnasnet.md
+++ b/modelindex/models/pnasnet.md
@@ -83,18 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: PNASNet
+  Paper:
+    Title: Progressive Neural Architecture Search
+    URL: https://paperswithcode.com/paper/progressive-neural-architecture-search
 Models:
 - Name: pnasnet5large
+  In Collection: PNASNet
   Metadata:
     FLOPs: 31458865950
-    Batch Size: 1600
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 100x NVIDIA P100 GPUs
+    Parameters: 86060000
+    File Size: 345153926
     Architecture:
     - Average Pooling
     - Batch Normalization
@@ -102,24 +103,30 @@ Models:
     - Depthwise Separable Convolution
     - Dropout
     - ReLU
-    File Size: 345153926
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 100x NVIDIA P100 GPUs
     ID: pnasnet5large
     LR: 0.015
     Dropout: 0.5
     Crop Pct: '0.911'
     Momentum: 0.9
+    Batch Size: 1600
     Image Size: '331'
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/pnasnet.py#L343
-  In Collection: PNASNet
-Collections:
-- Name: PNASNet
-  Paper:
-    title: Progressive Neural Architecture Search
-    url: https://paperswithcode.com//paper/progressive-neural-architecture-search
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/pnasnet5large-bf079911.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 0.98%
+      Top 5 Accuracy: 18.58%
 -->

--- a/modelindex/models/pnasnet.md
+++ b/modelindex/models/pnasnet.md
@@ -119,7 +119,7 @@ Collections:
 - Name: PNASNet
   Paper:
     title: Progressive Neural Architecture Search
-    url: https://papperswithcode.com//paper/progressive-neural-architecture-search
+    url: https://paperswithcode.com//paper/progressive-neural-architecture-search
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/pnasnet.md
+++ b/modelindex/models/pnasnet.md
@@ -1,0 +1,125 @@
+# Summary
+
+**Progressive Neural Architecture Search**, or **PNAS**, is a method for learning the structure of convolutional neural networks (CNNs). It uses a sequential model-based optimization (SMBO) strategy, where we search the space of cell structures, starting with simple (shallow) models and progressing to complex ones, pruning out unpromising structures as we go. 
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('pnasnet5large', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `pnasnet5large`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('pnasnet5large', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{liu2018progressive,
+      title={Progressive Neural Architecture Search}, 
+      author={Chenxi Liu and Barret Zoph and Maxim Neumann and Jonathon Shlens and Wei Hua and Li-Jia Li and Li Fei-Fei and Alan Yuille and Jonathan Huang and Kevin Murphy},
+      year={2018},
+      eprint={1712.00559},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: pnasnet5large
+  Metadata:
+    FLOPs: 31458865950
+    Batch Size: 1600
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 100x NVIDIA P100 GPUs
+    Architecture:
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - ReLU
+    File Size: 345153926
+    Tasks:
+    - Image Classification
+    ID: pnasnet5large
+    LR: 0.015
+    Dropout: 0.5
+    Crop Pct: '0.911'
+    Momentum: 0.9
+    Image Size: '331'
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/pnasnet.py#L343
+  In Collection: PNASNet
+Collections:
+- Name: PNASNet
+  Paper:
+    title: Progressive Neural Architecture Search
+    url: https://papperswithcode.com//paper/progressive-neural-architecture-search
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/regnetx.md
+++ b/modelindex/models/regnetx.md
@@ -452,7 +452,7 @@ Collections:
 - Name: RegNetX
   Paper:
     title: Designing Network Design Spaces
-    url: https://papperswithcode.com//paper/designing-network-design-spaces
+    url: https://paperswithcode.com//paper/designing-network-design-spaces
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/regnetx.md
+++ b/modelindex/models/regnetx.md
@@ -1,0 +1,458 @@
+# Summary
+
+**RegNetX** is a convolutional network design space with simple, regular models with parameters: depth $d$, initial width $w\_{0} > 0$, and slope $w\_{a} > 0$, and generates a different block width $u\_{j}$ for each block $j < d$. The key restriction for the RegNet types of model is that there is a linear parameterisation of block widths (the design space only contains models with this linear structure):
+
+$$ u\_{j} = w\_{0} + w\_{a}\cdot{j} $$
+
+For **RegNetX** we have additional restrictions: we set $b = 1$ (the bottleneck ratio), $12 \leq d \leq 28$, and $w\_{m} \geq 2$ (the width multiplier).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('regnetx_040', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `regnetx_040`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('regnetx_040', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{radosavovic2020designing,
+      title={Designing Network Design Spaces}, 
+      author={Ilija Radosavovic and Raj Prateek Kosaraju and Ross Girshick and Kaiming He and Piotr Dollár},
+      year={2020},
+      eprint={2003.13678},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: regnetx_040
+  Metadata:
+    FLOPs: 5095167744
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 88844824
+    Tasks:
+    - Image Classification
+    ID: regnetx_040
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L373
+  In Collection: RegNetX
+- Name: regnetx_004
+  Metadata:
+    FLOPs: 510619136
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 20841309
+    Tasks:
+    - Image Classification
+    ID: regnetx_004
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L343
+  In Collection: RegNetX
+- Name: regnetx_006
+  Metadata:
+    FLOPs: 771659136
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 24965172
+    Tasks:
+    - Image Classification
+    ID: regnetx_006
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L349
+  In Collection: RegNetX
+- Name: regnetx_002
+  Metadata:
+    FLOPs: 255276032
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 10862199
+    Tasks:
+    - Image Classification
+    ID: regnetx_002
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L337
+  In Collection: RegNetX
+- Name: regnetx_008
+  Metadata:
+    FLOPs: 1027038208
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 29235944
+    Tasks:
+    - Image Classification
+    ID: regnetx_008
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L355
+  In Collection: RegNetX
+- Name: regnetx_016
+  Metadata:
+    FLOPs: 2059337856
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 36988158
+    Tasks:
+    - Image Classification
+    ID: regnetx_016
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L361
+  In Collection: RegNetX
+- Name: regnetx_032
+  Metadata:
+    FLOPs: 4082555904
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 61509573
+    Tasks:
+    - Image Classification
+    ID: regnetx_032
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L367
+  In Collection: RegNetX
+- Name: regnetx_064
+  Metadata:
+    FLOPs: 8303405824
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 105184854
+    Tasks:
+    - Image Classification
+    ID: regnetx_064
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L379
+  In Collection: RegNetX
+- Name: regnetx_080
+  Metadata:
+    FLOPs: 10276726784
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 158720042
+    Tasks:
+    - Image Classification
+    ID: regnetx_080
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L385
+  In Collection: RegNetX
+- Name: regnetx_120
+  Metadata:
+    FLOPs: 15536378368
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 184866342
+    Tasks:
+    - Image Classification
+    ID: regnetx_120
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L391
+  In Collection: RegNetX
+- Name: regnetx_160
+  Metadata:
+    FLOPs: 20491740672
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 217623862
+    Tasks:
+    - Image Classification
+    ID: regnetx_160
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L397
+  In Collection: RegNetX
+- Name: regnetx_320
+  Metadata:
+    FLOPs: 40798958592
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    File Size: 431962133
+    Tasks:
+    - Image Classification
+    ID: regnetx_320
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L403
+  In Collection: RegNetX
+Collections:
+- Name: RegNetX
+  Paper:
+    title: Designing Network Design Spaces
+    url: https://papperswithcode.com//paper/designing-network-design-spaces
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/regnetx.md
+++ b/modelindex/models/regnetx.md
@@ -11,7 +11,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('regnetx_040', pretrained=True)
+model = timm.create_model('regnetx_002', pretrained=True)
 model.eval()
 ```
 
@@ -57,14 +57,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `regnetx_040`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `regnetx_002`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('regnetx_040', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('regnetx_002', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -87,108 +87,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: RegNetX
+  Paper:
+    Title: Designing Network Design Spaces
+    URL: https://paperswithcode.com/paper/designing-network-design-spaces
 Models:
-- Name: regnetx_040
-  Metadata:
-    FLOPs: 5095167744
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    File Size: 88844824
-    Tasks:
-    - Image Classification
-    ID: regnetx_040
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L373
-  In Collection: RegNetX
-- Name: regnetx_004
-  Metadata:
-    FLOPs: 510619136
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    File Size: 20841309
-    Tasks:
-    - Image Classification
-    ID: regnetx_004
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L343
-  In Collection: RegNetX
-- Name: regnetx_006
-  Metadata:
-    FLOPs: 771659136
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    File Size: 24965172
-    Tasks:
-    - Image Classification
-    ID: regnetx_006
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L349
-  In Collection: RegNetX
 - Name: regnetx_002
+  In Collection: RegNetX
   Metadata:
     FLOPs: 255276032
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 2680000
+    File Size: 10862199
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -197,28 +108,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 10862199
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_002
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L337
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_002-e7e85e5c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 68.75%
+      Top 5 Accuracy: 88.56%
+- Name: regnetx_004
   In Collection: RegNetX
-- Name: regnetx_008
   Metadata:
-    FLOPs: 1027038208
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    FLOPs: 510619136
+    Parameters: 5160000
+    File Size: 20841309
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -227,28 +146,112 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 29235944
     Tasks:
     - Image Classification
-    ID: regnetx_008
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_004
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L343
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_004-7d0e9424.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.39%
+      Top 5 Accuracy: 90.82%
+- Name: regnetx_006
+  In Collection: RegNetX
+  Metadata:
+    FLOPs: 771659136
+    Parameters: 6200000
+    File Size: 24965172
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_006
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 1024
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L349
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_006-85ec1baa.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.84%
+      Top 5 Accuracy: 91.68%
+- Name: regnetx_008
+  In Collection: RegNetX
+  Metadata:
+    FLOPs: 1027038208
+    Parameters: 7260000
+    File Size: 29235944
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_008
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L355
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_008-d8b470eb.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.05%
+      Top 5 Accuracy: 92.34%
 - Name: regnetx_016
+  In Collection: RegNetX
   Metadata:
     FLOPs: 2059337856
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 9190000
+    File Size: 36988158
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -257,28 +260,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 36988158
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_016
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L361
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_016-65ca972a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.95%
+      Top 5 Accuracy: 93.43%
 - Name: regnetx_032
+  In Collection: RegNetX
   Metadata:
     FLOPs: 4082555904
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 15300000
+    File Size: 61509573
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -287,28 +298,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 61509573
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_032
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L367
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_032-ed0c7f7e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.15%
+      Top 5 Accuracy: 94.09%
+- Name: regnetx_040
   In Collection: RegNetX
-- Name: regnetx_064
   Metadata:
-    FLOPs: 8303405824
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    FLOPs: 5095167744
+    Parameters: 22120000
+    File Size: 88844824
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -317,28 +336,74 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 105184854
     Tasks:
     - Image Classification
-    ID: regnetx_064
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_040
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L373
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_040-73c2a654.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.48%
+      Top 5 Accuracy: 94.25%
+- Name: regnetx_064
+  In Collection: RegNetX
+  Metadata:
+    FLOPs: 8303405824
+    Parameters: 26210000
+    File Size: 105184854
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnetx_064
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L379
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_064-29278baa.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.06%
+      Top 5 Accuracy: 94.47%
 - Name: regnetx_080
+  In Collection: RegNetX
   Metadata:
     FLOPs: 10276726784
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 39570000
+    File Size: 158720042
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -347,28 +412,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 158720042
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_080
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L385
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_080-7c7fcab1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.21%
+      Top 5 Accuracy: 94.55%
 - Name: regnetx_120
+  In Collection: RegNetX
   Metadata:
     FLOPs: 15536378368
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 46110000
+    File Size: 184866342
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -377,28 +450,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 184866342
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_120
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L391
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_120-65d5521e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.61%
+      Top 5 Accuracy: 94.73%
 - Name: regnetx_160
+  In Collection: RegNetX
   Metadata:
     FLOPs: 20491740672
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 54280000
+    File Size: 217623862
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -407,28 +488,36 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 217623862
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_160
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L397
-  In Collection: RegNetX
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_160-c98c4112.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.84%
+      Top 5 Accuracy: 94.82%
 - Name: regnetx_320
+  In Collection: RegNetX
   Metadata:
     FLOPs: 40798958592
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 107810000
+    File Size: 431962133
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -437,22 +526,28 @@ Models:
     - Global Average Pooling
     - Grouped Convolution
     - ReLU
-    File Size: 431962133
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnetx_320
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L403
-  In Collection: RegNetX
-Collections:
-- Name: RegNetX
-  Paper:
-    title: Designing Network Design Spaces
-    url: https://paperswithcode.com//paper/designing-network-design-spaces
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnetx_320-8ea38b93.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.25%
+      Top 5 Accuracy: 95.03%
 -->

--- a/modelindex/models/regnety.md
+++ b/modelindex/models/regnety.md
@@ -1,0 +1,472 @@
+# Summary
+
+**RegNetY** is a convolutional network design space with simple, regular models with parameters: depth $d$, initial width $w\_{0} > 0$, and slope $w\_{a} > 0$, and generates a different block width $u\_{j}$ for each block $j < d$. The key restriction for the RegNet types of model is that there is a linear parameterisation of block widths (the design space only contains models with this linear structure):
+
+$$ u\_{j} = w\_{0} + w\_{a}\cdot{j} $$
+
+For **RegNetX** authors have additional restrictions: we set $b = 1$ (the bottleneck ratio), $12 \leq d \leq 28$, and $w\_{m} \geq 2$ (the width multiplier).
+
+For **RegNetY** authors make one change, which is to include [Squeeze-and-Excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('regnety_002', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `regnety_002`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('regnety_002', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{radosavovic2020designing,
+      title={Designing Network Design Spaces}, 
+      author={Ilija Radosavovic and Raj Prateek Kosaraju and Ross Girshick and Kaiming He and Piotr Dollár},
+      year={2020},
+      eprint={2003.13678},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: regnety_002
+  Metadata:
+    FLOPs: 255754236
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 12782926
+    Tasks:
+    - Image Classification
+    ID: regnety_002
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L409
+  In Collection: RegNetY
+- Name: regnety_016
+  Metadata:
+    FLOPs: 2070895094
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 45115589
+    Tasks:
+    - Image Classification
+    ID: regnety_016
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L433
+  In Collection: RegNetY
+- Name: regnety_004
+  Metadata:
+    FLOPs: 515664568
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 17542753
+    Tasks:
+    - Image Classification
+    ID: regnety_004
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L415
+  In Collection: RegNetY
+- Name: regnety_006
+  Metadata:
+    FLOPs: 771746928
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 24394127
+    Tasks:
+    - Image Classification
+    ID: regnety_006
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L421
+  In Collection: RegNetY
+- Name: regnety_008
+  Metadata:
+    FLOPs: 1023448952
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 25223268
+    Tasks:
+    - Image Classification
+    ID: regnety_008
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L427
+  In Collection: RegNetY
+- Name: regnety_032
+  Metadata:
+    FLOPs: 4081118714
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 78084523
+    Tasks:
+    - Image Classification
+    ID: regnety_032
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L439
+  In Collection: RegNetY
+- Name: regnety_080
+  Metadata:
+    FLOPs: 10233621420
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 157124671
+    Tasks:
+    - Image Classification
+    ID: regnety_080
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L457
+  In Collection: RegNetY
+- Name: regnety_040
+  Metadata:
+    FLOPs: 5105933432
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 82913909
+    Tasks:
+    - Image Classification
+    ID: regnety_040
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L445
+  In Collection: RegNetY
+- Name: regnety_064
+  Metadata:
+    FLOPs: 8167730444
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 122751416
+    Tasks:
+    - Image Classification
+    ID: regnety_064
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L451
+  In Collection: RegNetY
+- Name: regnety_120
+  Metadata:
+    FLOPs: 15542094856
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 207743949
+    Tasks:
+    - Image Classification
+    ID: regnety_120
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L463
+  In Collection: RegNetY
+- Name: regnety_160
+  Metadata:
+    FLOPs: 20450196852
+    Epochs: 100
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 334916722
+    Tasks:
+    - Image Classification
+    ID: regnety_160
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L469
+  In Collection: RegNetY
+- Name: regnety_320
+  Metadata:
+    FLOPs: 41492618394
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    File Size: 580891965
+    Tasks:
+    - Image Classification
+    ID: regnety_320
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L475
+  In Collection: RegNetY
+Collections:
+- Name: RegNetY
+  Paper:
+    title: Designing Network Design Spaces
+    url: https://papperswithcode.com//paper/designing-network-design-spaces
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/regnety.md
+++ b/modelindex/models/regnety.md
@@ -89,18 +89,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: RegNetY
+  Paper:
+    Title: Designing Network Design Spaces
+    URL: https://paperswithcode.com/paper/designing-network-design-spaces
 Models:
 - Name: regnety_002
+  In Collection: RegNetY
   Metadata:
     FLOPs: 255754236
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 3160000
+    File Size: 12782926
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -110,59 +111,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 12782926
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_002
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L409
-  In Collection: RegNetY
-- Name: regnety_016
-  Metadata:
-    FLOPs: 2070895094
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    - Squeeze-and-Excitation Block
-    File Size: 45115589
-    Tasks:
-    - Image Classification
-    ID: regnety_016
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L433
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_002-e68ca334.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 70.28%
+      Top 5 Accuracy: 89.55%
 - Name: regnety_004
+  In Collection: RegNetY
   Metadata:
     FLOPs: 515664568
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 4340000
+    File Size: 17542753
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -172,28 +150,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 17542753
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_004
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L415
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_004-0db870e6.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.02%
+      Top 5 Accuracy: 91.76%
 - Name: regnety_006
+  In Collection: RegNetY
   Metadata:
     FLOPs: 771746928
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 6060000
+    File Size: 24394127
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -203,28 +189,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 24394127
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_006
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L421
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_006-c67e57ec.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.27%
+      Top 5 Accuracy: 92.53%
 - Name: regnety_008
+  In Collection: RegNetY
   Metadata:
     FLOPs: 1023448952
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 6260000
+    File Size: 25223268
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -234,28 +228,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 25223268
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_008
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L427
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_008-dc900dbe.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.32%
+      Top 5 Accuracy: 93.07%
+- Name: regnety_016
   In Collection: RegNetY
-- Name: regnety_032
   Metadata:
-    FLOPs: 4081118714
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    FLOPs: 2070895094
+    Parameters: 11200000
+    File Size: 45115589
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -265,59 +267,75 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 78084523
     Tasks:
     - Image Classification
-    ID: regnety_032
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnety_016
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L433
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_016-54367f74.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.87%
+      Top 5 Accuracy: 93.73%
+- Name: regnety_032
+  In Collection: RegNetY
+  Metadata:
+    FLOPs: 4081118714
+    Parameters: 19440000
+    File Size: 78084523
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnety_032
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L439
-  In Collection: RegNetY
-- Name: regnety_080
-  Metadata:
-    FLOPs: 10233621420
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Grouped Convolution
-    - ReLU
-    - Squeeze-and-Excitation Block
-    File Size: 157124671
-    Tasks:
-    - Image Classification
-    ID: regnety_080
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 5.0e-05
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L457
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/regnety_032_ra-7f2439f9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.01%
+      Top 5 Accuracy: 95.91%
 - Name: regnety_040
+  In Collection: RegNetY
   Metadata:
     FLOPs: 5105933432
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 20650000
+    File Size: 82913909
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -327,28 +345,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 82913909
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_040
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L445
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_040-f0d569f9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.23%
+      Top 5 Accuracy: 94.64%
 - Name: regnety_064
+  In Collection: RegNetY
   Metadata:
     FLOPs: 8167730444
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 30580000
+    File Size: 122751416
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -358,28 +384,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 122751416
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_064
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L451
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_064-0a48325c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.73%
+      Top 5 Accuracy: 94.76%
+- Name: regnety_080
   In Collection: RegNetY
-- Name: regnety_120
   Metadata:
-    FLOPs: 15542094856
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    FLOPs: 10233621420
+    Parameters: 39180000
+    File Size: 157124671
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -389,28 +423,75 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 207743949
     Tasks:
     - Image Classification
-    ID: regnety_120
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnety_080
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
+    Image Size: '224'
+    Weight Decay: 5.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L457
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_080-e7f3eb93.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.87%
+      Top 5 Accuracy: 94.83%
+- Name: regnety_120
+  In Collection: RegNetY
+  Metadata:
+    FLOPs: 15542094856
+    Parameters: 51820000
+    File Size: 207743949
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - ReLU
+    - Squeeze-and-Excitation Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
+    ID: regnety_120
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L463
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_120-721ba79a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.38%
+      Top 5 Accuracy: 95.12%
 - Name: regnety_160
+  In Collection: RegNetY
   Metadata:
     FLOPs: 20450196852
-    Epochs: 100
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 83590000
+    File Size: 334916722
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -420,28 +501,36 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 334916722
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_160
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L469
-  In Collection: RegNetY
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_160-d64013cd.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.28%
+      Top 5 Accuracy: 94.97%
 - Name: regnety_320
+  In Collection: RegNetY
   Metadata:
     FLOPs: 41492618394
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA V100 GPUs
+    Parameters: 145050000
+    File Size: 580891965
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -451,22 +540,28 @@ Models:
     - Grouped Convolution
     - ReLU
     - Squeeze-and-Excitation Block
-    File Size: 580891965
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA V100 GPUs
     ID: regnety_320
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 5.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/regnet.py#L475
-  In Collection: RegNetY
-Collections:
-- Name: RegNetY
-  Paper:
-    title: Designing Network Design Spaces
-    url: https://paperswithcode.com//paper/designing-network-design-spaces
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-regnet/regnety_320-ba464b29.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.8%
+      Top 5 Accuracy: 95.25%
 -->

--- a/modelindex/models/regnety.md
+++ b/modelindex/models/regnety.md
@@ -466,7 +466,7 @@ Collections:
 - Name: RegNetY
   Paper:
     title: Designing Network Design Spaces
-    url: https://papperswithcode.com//paper/designing-network-design-spaces
+    url: https://paperswithcode.com//paper/designing-network-design-spaces
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/res2net.md
+++ b/modelindex/models/res2net.md
@@ -1,0 +1,274 @@
+# Summary
+
+**Res2Net** is an image model that employs a variation on bottleneck residual blocks, [Res2Net Blocks](https://paperswithcode.com/method/res2net-block). The motivation is to be able to represent features at multiple scales. This is achieved through a novel building block for CNNs that constructs hierarchical residual-like connections within one single residual block. This represents multi-scale features at a granular level and increases the range of receptive fields for each network layer.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('res2net101_26w_4s', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `res2net101_26w_4s`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('res2net101_26w_4s', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{Gao_2021,
+   title={Res2Net: A New Multi-Scale Backbone Architecture},
+   volume={43},
+   ISSN={1939-3539},
+   url={http://dx.doi.org/10.1109/TPAMI.2019.2938758},
+   DOI={10.1109/tpami.2019.2938758},
+   number={2},
+   journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
+   publisher={Institute of Electrical and Electronics Engineers (IEEE)},
+   author={Gao, Shang-Hua and Cheng, Ming-Ming and Zhao, Kai and Zhang, Xin-Yu and Yang, Ming-Hsuan and Torr, Philip},
+   year={2021},
+   month={Feb},
+   pages={652–662}
+}
+```
+
+<!--
+Models:
+- Name: res2net101_26w_4s
+  Metadata:
+    FLOPs: 10415881200
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 181456059
+    Tasks:
+    - Image Classification
+    ID: res2net101_26w_4s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L152
+  In Collection: Res2Net
+- Name: res2net50_26w_6s
+  Metadata:
+    FLOPs: 8130156528
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 148603239
+    Tasks:
+    - Image Classification
+    ID: res2net50_26w_6s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L163
+  In Collection: Res2Net
+- Name: res2net50_26w_8s
+  Metadata:
+    FLOPs: 10760338992
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 194085165
+    Tasks:
+    - Image Classification
+    ID: res2net50_26w_8s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L174
+  In Collection: Res2Net
+- Name: res2net50_14w_8s
+  Metadata:
+    FLOPs: 5403546768
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 100638543
+    Tasks:
+    - Image Classification
+    ID: res2net50_14w_8s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L196
+  In Collection: Res2Net
+- Name: res2net50_26w_4s
+  Metadata:
+    FLOPs: 5499974064
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 103110087
+    Tasks:
+    - Image Classification
+    ID: res2net50_26w_4s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L141
+  In Collection: Res2Net
+- Name: res2net50_48w_2s
+  Metadata:
+    FLOPs: 5375291520
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    File Size: 101421406
+    Tasks:
+    - Image Classification
+    ID: res2net50_48w_2s
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L185
+  In Collection: Res2Net
+Collections:
+- Name: Res2Net
+  Paper:
+    title: 'Res2Net: A New Multi-scale Backbone Architecture'
+    url: https://papperswithcode.com//paper/res2net-a-new-multi-scale-backbone
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/res2net.md
+++ b/modelindex/models/res2net.md
@@ -89,186 +89,233 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Res2Net
+  Paper:
+    Title: 'Res2Net: A New Multi-scale Backbone Architecture'
+    URL: https://paperswithcode.com/paper/res2net-a-new-multi-scale-backbone
 Models:
 - Name: res2net101_26w_4s
+  In Collection: Res2Net
   Metadata:
     FLOPs: 10415881200
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    Parameters: 45210000
+    File Size: 181456059
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2Net Block
-    File Size: 181456059
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
     ID: res2net101_26w_4s
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L152
-  In Collection: Res2Net
-- Name: res2net50_26w_6s
-  Metadata:
-    FLOPs: 8130156528
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - ReLU
-    - Res2Net Block
-    File Size: 148603239
-    Tasks:
-    - Image Classification
-    ID: res2net50_26w_6s
-    LR: 0.1
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L163
-  In Collection: Res2Net
-- Name: res2net50_26w_8s
-  Metadata:
-    FLOPs: 10760338992
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
-    Architecture:
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - ReLU
-    - Res2Net Block
-    File Size: 194085165
-    Tasks:
-    - Image Classification
-    ID: res2net50_26w_8s
-    LR: 0.1
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L174
-  In Collection: Res2Net
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net101_26w_4s-02a759a1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.19%
+      Top 5 Accuracy: 94.43%
 - Name: res2net50_14w_8s
+  In Collection: Res2Net
   Metadata:
     FLOPs: 5403546768
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    Parameters: 25060000
+    File Size: 100638543
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2Net Block
-    File Size: 100638543
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
     ID: res2net50_14w_8s
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L196
-  In Collection: Res2Net
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_14w_8s-6527dddc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.14%
+      Top 5 Accuracy: 93.86%
 - Name: res2net50_26w_4s
+  In Collection: Res2Net
   Metadata:
     FLOPs: 5499974064
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    Parameters: 25700000
+    File Size: 103110087
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2Net Block
-    File Size: 103110087
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
     ID: res2net50_26w_4s
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L141
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_26w_4s-06e79181.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.99%
+      Top 5 Accuracy: 93.85%
+- Name: res2net50_26w_6s
   In Collection: Res2Net
-- Name: res2net50_48w_2s
   Metadata:
-    FLOPs: 5375291520
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    FLOPs: 8130156528
+    Parameters: 37050000
+    File Size: 148603239
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2Net Block
-    File Size: 101421406
     Tasks:
     - Image Classification
-    ID: res2net50_48w_2s
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
+    ID: res2net50_26w_6s
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L163
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_26w_6s-19041792.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.57%
+      Top 5 Accuracy: 94.12%
+- Name: res2net50_26w_8s
+  In Collection: Res2Net
+  Metadata:
+    FLOPs: 10760338992
+    Parameters: 48400000
+    File Size: 194085165
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
+    ID: res2net50_26w_8s
+    LR: 0.1
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L174
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_26w_8s-2c7c9f12.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.19%
+      Top 5 Accuracy: 94.37%
+- Name: res2net50_48w_2s
+  In Collection: Res2Net
+  Metadata:
+    FLOPs: 5375291520
+    Parameters: 25290000
+    File Size: 101421406
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2Net Block
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
+    ID: res2net50_48w_2s
+    LR: 0.1
+    Epochs: 100
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L185
-  In Collection: Res2Net
-Collections:
-- Name: Res2Net
-  Paper:
-    title: 'Res2Net: A New Multi-scale Backbone Architecture'
-    url: https://paperswithcode.com//paper/res2net-a-new-multi-scale-backbone
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2net50_48w_2s-afed724a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.53%
+      Top 5 Accuracy: 93.56%
 -->

--- a/modelindex/models/res2net.md
+++ b/modelindex/models/res2net.md
@@ -268,7 +268,7 @@ Collections:
 - Name: Res2Net
   Paper:
     title: 'Res2Net: A New Multi-scale Backbone Architecture'
-    url: https://papperswithcode.com//paper/res2net-a-new-multi-scale-backbone
+    url: https://paperswithcode.com//paper/res2net-a-new-multi-scale-backbone
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/res2next.md
+++ b/modelindex/models/res2next.md
@@ -1,0 +1,129 @@
+# Summary
+
+**Res2Net** is an image model that employs a variation on [ResNeXt](https://paperswithcode.com/method/resnext) bottleneck residual blocks. The motivation is to be able to represent features at multiple scales. This is achieved through a novel building block for CNNs that constructs hierarchical residual-like connections within one single residual block. This represents multi-scale features at a granular level and increases the range of receptive fields for each network layer.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('res2next50', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `res2next50`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('res2next50', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{Gao_2021,
+   title={Res2Net: A New Multi-Scale Backbone Architecture},
+   volume={43},
+   ISSN={1939-3539},
+   url={http://dx.doi.org/10.1109/TPAMI.2019.2938758},
+   DOI={10.1109/tpami.2019.2938758},
+   number={2},
+   journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
+   publisher={Institute of Electrical and Electronics Engineers (IEEE)},
+   author={Gao, Shang-Hua and Cheng, Ming-Ming and Zhao, Kai and Zhang, Xin-Yu and Yang, Ming-Hsuan and Torr, Philip},
+   year={2021},
+   month={Feb},
+   pages={652–662}
+}
+```
+
+<!--
+Models:
+- Name: res2next50
+  Metadata:
+    FLOPs: 5396798208
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 4x Titan Xp GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - ReLU
+    - Res2NeXt Block
+    File Size: 99019592
+    Tasks:
+    - Image Classification
+    ID: res2next50
+    LR: 0.1
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L207
+  In Collection: Res2NeXt
+Collections:
+- Name: Res2NeXt
+  Paper:
+    title: 'Res2Net: A New Multi-scale Backbone Architecture'
+    url: https://papperswithcode.com//paper/res2net-a-new-multi-scale-backbone
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/res2next.md
+++ b/modelindex/models/res2next.md
@@ -123,7 +123,7 @@ Collections:
 - Name: Res2NeXt
   Paper:
     title: 'Res2Net: A New Multi-scale Backbone Architecture'
-    url: https://papperswithcode.com//paper/res2net-a-new-multi-scale-backbone
+    url: https://paperswithcode.com//paper/res2net-a-new-multi-scale-backbone
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/res2next.md
+++ b/modelindex/models/res2next.md
@@ -89,41 +89,48 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Res2NeXt
+  Paper:
+    Title: 'Res2Net: A New Multi-scale Backbone Architecture'
+    URL: https://paperswithcode.com/paper/res2net-a-new-multi-scale-backbone
 Models:
 - Name: res2next50
+  In Collection: Res2NeXt
   Metadata:
     FLOPs: 5396798208
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 4x Titan Xp GPUs
+    Parameters: 24670000
+    File Size: 99019592
     Architecture:
     - Batch Normalization
     - Convolution
     - Global Average Pooling
     - ReLU
     - Res2NeXt Block
-    File Size: 99019592
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x Titan Xp GPUs
     ID: res2next50
     LR: 0.1
+    Epochs: 100
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/res2net.py#L207
-  In Collection: Res2NeXt
-Collections:
-- Name: Res2NeXt
-  Paper:
-    title: 'Res2Net: A New Multi-scale Backbone Architecture'
-    url: https://paperswithcode.com//paper/res2net-a-new-multi-scale-backbone
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-res2net/res2next50_4s-6ef7e7bf.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.24%
+      Top 5 Accuracy: 93.91%
 -->

--- a/modelindex/models/resnest.md
+++ b/modelindex/models/resnest.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('resnest50d_4s2x40d', pretrained=True)
+model = timm.create_model('resnest101e', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `resnest50d_4s2x40d`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `resnest101e`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('resnest50d_4s2x40d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('resnest101e', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -83,145 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ResNeSt
+  Paper:
+    Title: 'ResNeSt: Split-Attention Networks'
+    URL: https://paperswithcode.com/paper/resnest-split-attention-networks
 Models:
-- Name: resnest50d_4s2x40d
-  Metadata:
-    FLOPs: 5657064720
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Connection
-    - Softmax
-    - Split Attention
-    File Size: 122133282
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnest50d_4s2x40d
-    LR: 0.1
-    Layers: 50
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L218
-  Config: ''
-  In Collection: ResNeSt
-- Name: resnest200e
-  Metadata:
-    FLOPs: 45954387872
-    Epochs: 270
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Connection
-    - Softmax
-    - Split Attention
-    File Size: 193782911
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnest200e
-    LR: 0.1
-    Layers: 200
-    Dropout: 0.2
-    Crop Pct: '0.909'
-    Momentum: 0.9
-    Image Size: '320'
-    Weight Decay: 0.0001
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L194
-  Config: ''
-  In Collection: ResNeSt
-- Name: resnest14d
-  Metadata:
-    FLOPs: 3548594464
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Convolution
-    - Dense Connections
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Connection
-    - Softmax
-    - Split Attention
-    File Size: 42562639
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: resnest14d
-    LR: 0.1
-    Layers: 14
-    Dropout: 0.2
-    Crop Pct: '0.875'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L148
-  Config: ''
-  In Collection: ResNeSt
 - Name: resnest101e
+  In Collection: ResNeSt
   Metadata:
     FLOPs: 17423183648
-    Epochs: 270
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    Parameters: 48280000
+    File Size: 193782911
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -232,37 +106,43 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 193782911
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest101e
     LR: 0.1
+    Epochs: 270
     Layers: 101
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '256'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L182
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest101-22405ba7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.88%
+      Top 5 Accuracy: 96.31%
+- Name: resnest14d
   In Collection: ResNeSt
-- Name: resnest269e
   Metadata:
-    FLOPs: 100830307104
-    Epochs: 270
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    FLOPs: 3548594464
+    Parameters: 10610000
+    File Size: 42562639
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -273,37 +153,137 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 445402691
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
+    ID: resnest14d
+    LR: 0.1
+    Epochs: 270
+    Layers: 14
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 8192
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L148
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/gluon_resnest14-9c8fe254.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.51%
+      Top 5 Accuracy: 92.52%
+- Name: resnest200e
+  In Collection: ResNeSt
+  Metadata:
+    FLOPs: 45954387872
+    Parameters: 70200000
+    File Size: 193782911
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
+    ID: resnest200e
+    LR: 0.1
+    Epochs: 270
+    Layers: 200
+    Dropout: 0.2
+    Crop Pct: '0.909'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '320'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L194
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest101-22405ba7.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.85%
+      Top 5 Accuracy: 96.89%
+- Name: resnest269e
+  In Collection: ResNeSt
+  Metadata:
+    FLOPs: 100830307104
+    Parameters: 110930000
+    File Size: 445402691
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest269e
     LR: 0.1
+    Epochs: 270
     Layers: 269
     Dropout: 0.2
     Crop Pct: '0.928'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '416'
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L206
-  Config: ''
-  In Collection: ResNeSt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest269-0cc87c48.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.53%
+      Top 5 Accuracy: 96.99%
 - Name: resnest26d
+  In Collection: ResNeSt
   Metadata:
     FLOPs: 4678918720
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    Parameters: 17070000
+    File Size: 68470242
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -314,37 +294,43 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 68470242
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest26d
     LR: 0.1
+    Epochs: 270
     Layers: 26
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8192
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L159
-  Config: ''
-  In Collection: ResNeSt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/gluon_resnest26-50eb607c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.48%
+      Top 5 Accuracy: 94.3%
 - Name: resnest50d
+  In Collection: ResNeSt
   Metadata:
     FLOPs: 6937106336
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    Parameters: 27480000
+    File Size: 110273258
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -355,37 +341,43 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 110273258
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest50d
     LR: 0.1
+    Epochs: 270
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8192
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L170
-  Config: ''
-  In Collection: ResNeSt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest50-528c19ca.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.96%
+      Top 5 Accuracy: 95.38%
 - Name: resnest50d_1s4x24d
+  In Collection: ResNeSt
   Metadata:
     FLOPs: 5686764544
-    Epochs: 270
-    Batch Size: 8192
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - DropBlock
-    - Label Smoothing
-    - Mixup
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x NVIDIA V100 GPUs
+    Parameters: 25680000
+    File Size: 103045531
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -396,25 +388,82 @@ Models:
     - Residual Connection
     - Softmax
     - Split Attention
-    File Size: 103045531
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
     ID: resnest50d_1s4x24d
     LR: 0.1
+    Epochs: 270
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 8192
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L229
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest50_fast_1s4x24d-d4a4f76f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.0%
+      Top 5 Accuracy: 95.33%
+- Name: resnest50d_4s2x40d
   In Collection: ResNeSt
-Collections:
-- Name: ResNeSt
-  Paper:
-    title: 'ResNeSt: Split-Attention Networks'
-    url: https://paperswithcode.com//paper/resnest-split-attention-networks
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5657064720
+    Parameters: 30420000
+    File Size: 122133282
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 64x NVIDIA V100 GPUs
+    ID: resnest50d_4s2x40d
+    LR: 0.1
+    Epochs: 270
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Batch Size: 8192
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L218
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-resnest/resnest50_fast_4s2x40d-41d14ed0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.11%
+      Top 5 Accuracy: 95.55%
 -->

--- a/modelindex/models/resnest.md
+++ b/modelindex/models/resnest.md
@@ -1,0 +1,420 @@
+# Summary
+
+A **ResNest** is a variant on a [ResNet](https://paperswithcode.com/method/resnet), which instead stacks [Split-Attention blocks](https://paperswithcode.com/method/split-attention). The cardinal group representations are then concatenated along the channel dimension: $V = \text{Concat}${$V^{1},V^{2},\cdots{V}^{K}$}. As in standard residual blocks, the final output $Y$ of otheur Split-Attention block is produced using a shortcut connection: $Y=V+X$, if the input and output feature-map share the same shape.  For blocks with a stride, an appropriate transformation $\mathcal{T}$ is applied to the shortcut connection to align the output shapes:  $Y=V+\mathcal{T}(X)$. For example, $\mathcal{T}$ can be strided convolution or combined convolution-with-pooling.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('resnest50d_4s2x40d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `resnest50d_4s2x40d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('resnest50d_4s2x40d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{zhang2020resnest,
+      title={ResNeSt: Split-Attention Networks}, 
+      author={Hang Zhang and Chongruo Wu and Zhongyue Zhang and Yi Zhu and Haibin Lin and Zhi Zhang and Yue Sun and Tong He and Jonas Mueller and R. Manmatha and Mu Li and Alexander Smola},
+      year={2020},
+      eprint={2004.08955},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: resnest50d_4s2x40d
+  Metadata:
+    FLOPs: 5657064720
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 122133282
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest50d_4s2x40d
+    LR: 0.1
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L218
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest200e
+  Metadata:
+    FLOPs: 45954387872
+    Epochs: 270
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 193782911
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest200e
+    LR: 0.1
+    Layers: 200
+    Dropout: 0.2
+    Crop Pct: '0.909'
+    Momentum: 0.9
+    Image Size: '320'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L194
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest14d
+  Metadata:
+    FLOPs: 3548594464
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 42562639
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest14d
+    LR: 0.1
+    Layers: 14
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L148
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest101e
+  Metadata:
+    FLOPs: 17423183648
+    Epochs: 270
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 193782911
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest101e
+    LR: 0.1
+    Layers: 101
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '256'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L182
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest269e
+  Metadata:
+    FLOPs: 100830307104
+    Epochs: 270
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 445402691
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest269e
+    LR: 0.1
+    Layers: 269
+    Dropout: 0.2
+    Crop Pct: '0.928'
+    Momentum: 0.9
+    Image Size: '416'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L206
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest26d
+  Metadata:
+    FLOPs: 4678918720
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 68470242
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest26d
+    LR: 0.1
+    Layers: 26
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L159
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest50d
+  Metadata:
+    FLOPs: 6937106336
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 110273258
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: resnest50d
+    LR: 0.1
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L170
+  Config: ''
+  In Collection: ResNeSt
+- Name: resnest50d_1s4x24d
+  Metadata:
+    FLOPs: 5686764544
+    Epochs: 270
+    Batch Size: 8192
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - DropBlock
+    - Label Smoothing
+    - Mixup
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x NVIDIA V100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Split Attention
+    File Size: 103045531
+    Tasks:
+    - Image Classification
+    ID: resnest50d_1s4x24d
+    LR: 0.1
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnest.py#L229
+  In Collection: ResNeSt
+Collections:
+- Name: ResNeSt
+  Paper:
+    title: 'ResNeSt: Split-Attention Networks'
+    url: https://papperswithcode.com//paper/resnest-split-attention-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/resnest.md
+++ b/modelindex/models/resnest.md
@@ -414,7 +414,7 @@ Collections:
 - Name: ResNeSt
   Paper:
     title: 'ResNeSt: Split-Attention Networks'
-    url: https://papperswithcode.com//paper/resnest-split-attention-networks
+    url: https://paperswithcode.com//paper/resnest-split-attention-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/resnet-d.md
+++ b/modelindex/models/resnet-d.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('resnet50d', pretrained=True)
+model = timm.create_model('resnet101d', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `resnet50d`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `resnet101d`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('resnet50d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('resnet101d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -83,137 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ResNet-D
+  Paper:
+    Title: Bag of Tricks for Image Classification with Convolutional Neural Networks
+    URL: https://paperswithcode.com/paper/bag-of-tricks-for-image-classification-with
 Models:
-- Name: resnet50d
-  Metadata:
-    FLOPs: 5591002624
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 102567109
-    Tasks:
-    - Image Classification
-    ID: resnet50d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L699
-  In Collection: ResNet-D
-- Name: resnet26d
-  Metadata:
-    FLOPs: 3335276032
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 64209122
-    Tasks:
-    - Image Classification
-    ID: resnet26d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L683
-  In Collection: ResNet-D
-- Name: resnet18d
-  Metadata:
-    FLOPs: 2645205760
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 46893231
-    Tasks:
-    - Image Classification
-    ID: resnet18d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L649
-  In Collection: ResNet-D
-- Name: resnet34d
-  Metadata:
-    FLOPs: 5026601728
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 87369807
-    Tasks:
-    - Image Classification
-    ID: resnet34d
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L666
-  In Collection: ResNet-D
-- Name: resnet200d
-  Metadata:
-    FLOPs: 26034378752
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 259662933
-    Tasks:
-    - Image Classification
-    ID: resnet200d
-    Crop Pct: '0.94'
-    Image Size: '256'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L749
-  In Collection: ResNet-D
 - Name: resnet101d
+  In Collection: ResNet-D
   Metadata:
     FLOPs: 13805639680
-    Training Data:
-    - ImageNet
+    Parameters: 44570000
+    File Size: 178791263
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -225,20 +107,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178791263
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnet101d
     Crop Pct: '0.94'
     Image Size: '256'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L716
-  In Collection: ResNet-D
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet101d_ra2-2803ffab.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.31%
+      Top 5 Accuracy: 96.06%
 - Name: resnet152d
+  In Collection: ResNet-D
   Metadata:
     FLOPs: 20155275264
-    Training Data:
-    - ImageNet
+    Parameters: 60210000
+    File Size: 241596837
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -250,20 +140,185 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 241596837
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnet152d
     Crop Pct: '0.94'
     Image Size: '256'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L724
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet152d_ra2-5cac0439.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.13%
+      Top 5 Accuracy: 96.35%
+- Name: resnet18d
   In Collection: ResNet-D
-Collections:
-- Name: ResNet-D
-  Paper:
-    title: Bag of Tricks for Image Classification with Convolutional Neural Networks
-    url: https://paperswithcode.com//paper/bag-of-tricks-for-image-classification-with
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 2645205760
+    Parameters: 11710000
+    File Size: 46893231
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet18d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L649
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet18d_ra2-48a79e06.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.27%
+      Top 5 Accuracy: 90.69%
+- Name: resnet200d
+  In Collection: ResNet-D
+  Metadata:
+    FLOPs: 26034378752
+    Parameters: 64690000
+    File Size: 259662933
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet200d
+    Crop Pct: '0.94'
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L749
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet200d_ra2-bdba9bf9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.24%
+      Top 5 Accuracy: 96.49%
+- Name: resnet26d
+  In Collection: ResNet-D
+  Metadata:
+    FLOPs: 3335276032
+    Parameters: 16010000
+    File Size: 64209122
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet26d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L683
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet26d-69e92c46.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.69%
+      Top 5 Accuracy: 93.15%
+- Name: resnet34d
+  In Collection: ResNet-D
+  Metadata:
+    FLOPs: 5026601728
+    Parameters: 21820000
+    File Size: 87369807
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet34d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L666
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet34d_ra2-f8dcfcaf.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.11%
+      Top 5 Accuracy: 93.38%
+- Name: resnet50d
+  In Collection: ResNet-D
+  Metadata:
+    FLOPs: 5591002624
+    Parameters: 25580000
+    File Size: 102567109
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: resnet50d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L699
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet50d_ra2-464e36ba.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.55%
+      Top 5 Accuracy: 95.16%
 -->

--- a/modelindex/models/resnet-d.md
+++ b/modelindex/models/resnet-d.md
@@ -1,0 +1,269 @@
+# Summary
+
+**ResNet-D** is a modification on the [ResNet](https://paperswithcode.com/method/resnet) architecture that utilises an [average pooling](https://paperswithcode.com/method/average-pooling) tweak for downsampling. The motivation is that in the unmodified ResNet, the [1×1 convolution](https://paperswithcode.com/method/1x1-convolution) for the downsampling block ignores 3/4 of input feature maps, so this is modified so no information will be ignored
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('resnet50d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `resnet50d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('resnet50d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{he2018bag,
+      title={Bag of Tricks for Image Classification with Convolutional Neural Networks}, 
+      author={Tong He and Zhi Zhang and Hang Zhang and Zhongyue Zhang and Junyuan Xie and Mu Li},
+      year={2018},
+      eprint={1812.01187},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: resnet50d
+  Metadata:
+    FLOPs: 5591002624
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102567109
+    Tasks:
+    - Image Classification
+    ID: resnet50d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L699
+  In Collection: ResNet-D
+- Name: resnet26d
+  Metadata:
+    FLOPs: 3335276032
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 64209122
+    Tasks:
+    - Image Classification
+    ID: resnet26d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L683
+  In Collection: ResNet-D
+- Name: resnet18d
+  Metadata:
+    FLOPs: 2645205760
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46893231
+    Tasks:
+    - Image Classification
+    ID: resnet18d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L649
+  In Collection: ResNet-D
+- Name: resnet34d
+  Metadata:
+    FLOPs: 5026601728
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 87369807
+    Tasks:
+    - Image Classification
+    ID: resnet34d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L666
+  In Collection: ResNet-D
+- Name: resnet200d
+  Metadata:
+    FLOPs: 26034378752
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 259662933
+    Tasks:
+    - Image Classification
+    ID: resnet200d
+    Crop Pct: '0.94'
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L749
+  In Collection: ResNet-D
+- Name: resnet101d
+  Metadata:
+    FLOPs: 13805639680
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178791263
+    Tasks:
+    - Image Classification
+    ID: resnet101d
+    Crop Pct: '0.94'
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L716
+  In Collection: ResNet-D
+- Name: resnet152d
+  Metadata:
+    FLOPs: 20155275264
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241596837
+    Tasks:
+    - Image Classification
+    ID: resnet152d
+    Crop Pct: '0.94'
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L724
+  In Collection: ResNet-D
+Collections:
+- Name: ResNet-D
+  Paper:
+    title: Bag of Tricks for Image Classification with Convolutional Neural Networks
+    url: https://papperswithcode.com//paper/bag-of-tricks-for-image-classification-with
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/resnet-d.md
+++ b/modelindex/models/resnet-d.md
@@ -263,7 +263,7 @@ Collections:
 - Name: ResNet-D
   Paper:
     title: Bag of Tricks for Image Classification with Convolutional Neural Networks
-    url: https://papperswithcode.com//paper/bag-of-tricks-for-image-classification-with
+    url: https://paperswithcode.com//paper/bag-of-tricks-for-image-classification-with
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/resnet.md
+++ b/modelindex/models/resnet.md
@@ -1,0 +1,368 @@
+# Summary
+
+**Residual Networks**, or **ResNets**, learn residual functions with reference to the layer inputs, instead of learning unreferenced functions. Instead of hoping each few stacked layers directly fit a desired underlying mapping, residual nets let these layers fit a residual mapping. They stack [residual blocks](https://paperswithcode.com/method/residual-block) ontop of each other to form network: e.g. a ResNet-50 has fifty layers using these blocks. 
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('resnet26', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `resnet26`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('resnet26', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/HeZRS15,
+  author    = {Kaiming He and
+               Xiangyu Zhang and
+               Shaoqing Ren and
+               Jian Sun},
+  title     = {Deep Residual Learning for Image Recognition},
+  journal   = {CoRR},
+  volume    = {abs/1512.03385},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.03385},
+  archivePrefix = {arXiv},
+  eprint    = {1512.03385},
+  timestamp = {Wed, 17 Apr 2019 17:23:45 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/HeZRS15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: resnet26
+  Metadata:
+    FLOPs: 3026804736
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 64129972
+    Tasks:
+    - Image Classification
+    ID: resnet26
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L675
+  In Collection: ResNet
+- Name: tv_resnet152
+  Metadata:
+    FLOPs: 14857660416
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 241530880
+    Tasks:
+    - Image Classification
+    ID: tv_resnet152
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L769
+  In Collection: ResNet
+- Name: resnet18
+  Metadata:
+    FLOPs: 2337073152
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46827520
+    Tasks:
+    - Image Classification
+    ID: resnet18
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L641
+  In Collection: ResNet
+- Name: resnet50
+  Metadata:
+    FLOPs: 5282531328
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102488165
+    Tasks:
+    - Image Classification
+    ID: resnet50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L691
+  In Collection: ResNet
+- Name: resnet34
+  Metadata:
+    FLOPs: 4718469120
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 87290831
+    Tasks:
+    - Image Classification
+    ID: resnet34
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L658
+  In Collection: ResNet
+- Name: resnetblur50
+  Metadata:
+    FLOPs: 6621606912
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Blur Pooling
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102488165
+    Tasks:
+    - Image Classification
+    ID: resnetblur50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L1160
+  In Collection: ResNet
+- Name: tv_resnet34
+  Metadata:
+    FLOPs: 4718469120
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 87306240
+    Tasks:
+    - Image Classification
+    ID: tv_resnet34
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L745
+  In Collection: ResNet
+- Name: tv_resnet101
+  Metadata:
+    FLOPs: 10068547584
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 178728960
+    Tasks:
+    - Image Classification
+    ID: tv_resnet101
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L761
+  In Collection: ResNet
+- Name: tv_resnet50
+  Metadata:
+    FLOPs: 5282531328
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102502400
+    Tasks:
+    - Image Classification
+    ID: tv_resnet50
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L753
+  In Collection: ResNet
+Collections:
+- Name: ResNet
+  Paper:
+    title: Deep Residual Learning for Image Recognition
+    url: https://papperswithcode.com//paper/deep-residual-learning-for-image-recognition
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/resnet.md
+++ b/modelindex/models/resnet.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('resnet26', pretrained=True)
+model = timm.create_model('resnet18', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `resnet26`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `resnet18`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('resnet26', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('resnet18', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -91,72 +91,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ResNet
+  Paper:
+    Title: Deep Residual Learning for Image Recognition
+    URL: https://paperswithcode.com/paper/deep-residual-learning-for-image-recognition
 Models:
-- Name: resnet26
-  Metadata:
-    FLOPs: 3026804736
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 64129972
-    Tasks:
-    - Image Classification
-    ID: resnet26
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L675
-  In Collection: ResNet
-- Name: tv_resnet152
-  Metadata:
-    FLOPs: 14857660416
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 241530880
-    Tasks:
-    - Image Classification
-    ID: tv_resnet152
-    LR: 0.1
-    Crop Pct: '0.875'
-    LR Gamma: 0.1
-    Momentum: 0.9
-    Image Size: '224'
-    LR Step Size: 30
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L769
-  In Collection: ResNet
 - Name: resnet18
+  In Collection: ResNet
   Metadata:
     FLOPs: 2337073152
-    Training Data:
-    - ImageNet
+    Parameters: 11690000
+    File Size: 46827520
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -168,20 +115,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 46827520
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnet18
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L641
+  Weights: https://download.pytorch.org/models/resnet18-5c106cde.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 69.74%
+      Top 5 Accuracy: 89.09%
+- Name: resnet26
   In Collection: ResNet
-- Name: resnet50
   Metadata:
-    FLOPs: 5282531328
-    Training Data:
-    - ImageNet
+    FLOPs: 3026804736
+    Parameters: 16000000
+    File Size: 64129972
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -193,20 +148,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102488165
     Tasks:
     - Image Classification
-    ID: resnet50
+    Training Data:
+    - ImageNet
+    ID: resnet26
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L691
-  In Collection: ResNet
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L675
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet26-9aa10e23.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.29%
+      Top 5 Accuracy: 92.57%
 - Name: resnet34
+  In Collection: ResNet
   Metadata:
     FLOPs: 4718469120
-    Training Data:
-    - ImageNet
+    Parameters: 21800000
+    File Size: 87290831
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -218,20 +181,61 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 87290831
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnet34
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L658
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet34-43635321.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.11%
+      Top 5 Accuracy: 92.28%
+- Name: resnet50
   In Collection: ResNet
-- Name: resnetblur50
   Metadata:
-    FLOPs: 6621606912
+    FLOPs: 5282531328
+    Parameters: 25560000
+    File Size: 102488165
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
     Training Data:
     - ImageNet
+    ID: resnet50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L691
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet50_ram-a26f946b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.04%
+      Top 5 Accuracy: 94.39%
+- Name: resnetblur50
+  In Collection: ResNet
+  Metadata:
+    FLOPs: 6621606912
+    Parameters: 25560000
+    File Size: 102488165
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -244,60 +248,28 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102488165
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnetblur50
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/resnet.py#L1160
-  In Collection: ResNet
-- Name: tv_resnet34
-  Metadata:
-    FLOPs: 4718469120
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 87306240
-    Tasks:
-    - Image Classification
-    ID: tv_resnet34
-    LR: 0.1
-    Crop Pct: '0.875'
-    LR Gamma: 0.1
-    Momentum: 0.9
-    Image Size: '224'
-    LR Step Size: 30
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L745
-  In Collection: ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnetblur50-84f4748f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.29%
+      Top 5 Accuracy: 94.64%
 - Name: tv_resnet101
+  In Collection: ResNet
   Metadata:
     FLOPs: 10068547584
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    Parameters: 44550000
+    File Size: 178728960
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -309,30 +281,38 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 178728960
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tv_resnet101
     LR: 0.1
+    Epochs: 90
     Crop Pct: '0.875'
     LR Gamma: 0.1
     Momentum: 0.9
+    Batch Size: 32
     Image Size: '224'
     LR Step Size: 30
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L761
+  Weights: https://download.pytorch.org/models/resnet101-5d3b4d8f.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.37%
+      Top 5 Accuracy: 93.56%
+- Name: tv_resnet152
   In Collection: ResNet
-- Name: tv_resnet50
   Metadata:
-    FLOPs: 5282531328
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
+    FLOPs: 14857660416
+    Parameters: 60190000
+    File Size: 241530880
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -344,25 +324,116 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102502400
     Tasks:
     - Image Classification
-    ID: tv_resnet50
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tv_resnet152
     LR: 0.1
+    Epochs: 90
     Crop Pct: '0.875'
     LR Gamma: 0.1
     Momentum: 0.9
+    Batch Size: 32
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L769
+  Weights: https://download.pytorch.org/models/resnet152-b121ed2d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.32%
+      Top 5 Accuracy: 94.05%
+- Name: tv_resnet34
+  In Collection: ResNet
+  Metadata:
+    FLOPs: 4718469120
+    Parameters: 21800000
+    File Size: 87306240
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tv_resnet34
+    LR: 0.1
+    Epochs: 90
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Batch Size: 32
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L745
+  Weights: https://download.pytorch.org/models/resnet34-333f7ec4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.3%
+      Top 5 Accuracy: 91.42%
+- Name: tv_resnet50
+  In Collection: ResNet
+  Metadata:
+    FLOPs: 5282531328
+    Parameters: 25560000
+    File Size: 102502400
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tv_resnet50
+    LR: 0.1
+    Epochs: 90
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Batch Size: 32
     Image Size: '224'
     LR Step Size: 30
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L753
-  In Collection: ResNet
-Collections:
-- Name: ResNet
-  Paper:
-    title: Deep Residual Learning for Image Recognition
-    url: https://paperswithcode.com//paper/deep-residual-learning-for-image-recognition
-  type: model-index
-Type: model-index
+  Weights: https://download.pytorch.org/models/resnet50-19c8e357.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.16%
+      Top 5 Accuracy: 92.88%
 -->

--- a/modelindex/models/resnet.md
+++ b/modelindex/models/resnet.md
@@ -362,7 +362,7 @@ Collections:
 - Name: ResNet
   Paper:
     title: Deep Residual Learning for Image Recognition
-    url: https://papperswithcode.com//paper/deep-residual-learning-for-image-recognition
+    url: https://paperswithcode.com//paper/deep-residual-learning-for-image-recognition
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/resnext.md
+++ b/modelindex/models/resnext.md
@@ -207,7 +207,7 @@ Collections:
 - Name: ResNeXt
   Paper:
     title: Aggregated Residual Transformations for Deep Neural Networks
-    url: https://papperswithcode.com//paper/aggregated-residual-transformations-for-deep
+    url: https://paperswithcode.com//paper/aggregated-residual-transformations-for-deep
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/resnext.md
+++ b/modelindex/models/resnext.md
@@ -92,12 +92,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: ResNeXt
+  Paper:
+    Title: Aggregated Residual Transformations for Deep Neural Networks
+    URL: https://paperswithcode.com/paper/aggregated-residual-transformations-for-deep
 Models:
 - Name: resnext101_32x8d
+  In Collection: ResNeXt
   Metadata:
     FLOPs: 21180417024
-    Training Data:
-    - ImageNet
+    Parameters: 88790000
+    File Size: 356082095
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -109,20 +116,28 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 356082095
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnext101_32x8d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L877
-  In Collection: ResNeXt
+  Weights: https://download.pytorch.org/models/resnext101_32x8d-8ba56ff5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.3%
+      Top 5 Accuracy: 94.53%
 - Name: resnext50_32x4d
+  In Collection: ResNeXt
   Metadata:
     FLOPs: 5472648192
-    Training Data:
-    - ImageNet
+    Parameters: 25030000
+    File Size: 100435887
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -134,55 +149,28 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 100435887
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnext50_32x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L851
-  In Collection: ResNeXt
-- Name: tv_resnext50_32x4d
-  Metadata:
-    FLOPs: 5472648192
-    Epochs: 90
-    Batch Size: 32
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 100441675
-    Tasks:
-    - Image Classification
-    ID: tv_resnext50_32x4d
-    LR: 0.1
-    Crop Pct: '0.875'
-    LR Gamma: 0.1
-    Momentum: 0.9
-    Image Size: '224'
-    LR Step Size: 30
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L842
-  In Collection: ResNeXt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnext50_32x4d_ra-d733960d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.79%
+      Top 5 Accuracy: 94.61%
 - Name: resnext50d_32x4d
+  In Collection: ResNeXt
   Metadata:
     FLOPs: 5781119488
-    Training Data:
-    - ImageNet
+    Parameters: 25050000
+    File Size: 100515304
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -194,20 +182,63 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 100515304
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: resnext50d_32x4d
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L869
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnext50d_32x4d-103e99f8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.67%
+      Top 5 Accuracy: 94.87%
+- Name: tv_resnext50_32x4d
   In Collection: ResNeXt
-Collections:
-- Name: ResNeXt
-  Paper:
-    title: Aggregated Residual Transformations for Deep Neural Networks
-    url: https://paperswithcode.com//paper/aggregated-residual-transformations-for-deep
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5472648192
+    Parameters: 25030000
+    File Size: 100441675
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tv_resnext50_32x4d
+    LR: 0.1
+    Epochs: 90
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Batch Size: 32
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L842
+  Weights: https://download.pytorch.org/models/resnext50_32x4d-7cdf4587.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.61%
+      Top 5 Accuracy: 93.68%
 -->

--- a/modelindex/models/resnext.md
+++ b/modelindex/models/resnext.md
@@ -1,0 +1,213 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('resnext101_32x8d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `resnext101_32x8d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('resnext101_32x8d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/XieGDTH16,
+  author    = {Saining Xie and
+               Ross B. Girshick and
+               Piotr Doll{\'{a}}r and
+               Zhuowen Tu and
+               Kaiming He},
+  title     = {Aggregated Residual Transformations for Deep Neural Networks},
+  journal   = {CoRR},
+  volume    = {abs/1611.05431},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1611.05431},
+  archivePrefix = {arXiv},
+  eprint    = {1611.05431},
+  timestamp = {Mon, 13 Aug 2018 16:45:58 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/XieGDTH16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: resnext101_32x8d
+  Metadata:
+    FLOPs: 21180417024
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 356082095
+    Tasks:
+    - Image Classification
+    ID: resnext101_32x8d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L877
+  In Collection: ResNeXt
+- Name: resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100435887
+    Tasks:
+    - Image Classification
+    ID: resnext50_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L851
+  In Collection: ResNeXt
+- Name: tv_resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Epochs: 90
+    Batch Size: 32
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100441675
+    Tasks:
+    - Image Classification
+    ID: tv_resnext50_32x4d
+    LR: 0.1
+    Crop Pct: '0.875'
+    LR Gamma: 0.1
+    Momentum: 0.9
+    Image Size: '224'
+    LR Step Size: 30
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L842
+  In Collection: ResNeXt
+- Name: resnext50d_32x4d
+  Metadata:
+    FLOPs: 5781119488
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100515304
+    Tasks:
+    - Image Classification
+    ID: resnext50d_32x4d
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/resnet.py#L869
+  In Collection: ResNeXt
+Collections:
+- Name: ResNeXt
+  Paper:
+    title: Aggregated Residual Transformations for Deep Neural Networks
+    url: https://papperswithcode.com//paper/aggregated-residual-transformations-for-deep
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/rexnet.md
+++ b/modelindex/models/rexnet.md
@@ -1,0 +1,235 @@
+# Summary
+
+**Rank Expansion Networks** (ReXNets) follow a set of new design principles for designing bottlenecks in image classification models. Authors refine each layer by 1) expanding the input channel size of the convolution layer and 2) replacing the [ReLU6s](https://www.paperswithcode.com/method/relu6).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('rexnet_100', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `rexnet_100`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('rexnet_100', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{han2020rexnet,
+      title={ReXNet: Diminishing Representational Bottleneck on Convolutional Neural Network}, 
+      author={Dongyoon Han and Sangdoo Yun and Byeongho Heo and YoungJoon Yoo},
+      year={2020},
+      eprint={2007.00992},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: rexnet_100
+  Metadata:
+    FLOPs: 509989377
+    Epochs: 400
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dropout
+    - ReLU6
+    - Residual Connection
+    File Size: 19417552
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: rexnet_100
+    LR: 0.5
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L212
+  Config: ''
+  In Collection: RexNet
+- Name: rexnet_130
+  Metadata:
+    FLOPs: 848364461
+    Epochs: 400
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dropout
+    - ReLU6
+    - Residual Connection
+    File Size: 30508197
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: rexnet_130
+    LR: 0.5
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L218
+  Config: ''
+  In Collection: RexNet
+- Name: rexnet_150
+  Metadata:
+    FLOPs: 1122374469
+    Epochs: 400
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dropout
+    - ReLU6
+    - Residual Connection
+    File Size: 39227315
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: rexnet_150
+    LR: 0.5
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L224
+  Config: ''
+  In Collection: RexNet
+- Name: rexnet_200
+  Metadata:
+    FLOPs: 1960224938
+    Epochs: 400
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Resources: 4x NVIDIA V100 GPUs
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dropout
+    - ReLU6
+    - Residual Connection
+    File Size: 65862221
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: rexnet_200
+    LR: 0.5
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    Label Smoothing: 0.1
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L230
+  Config: ''
+  In Collection: RexNet
+Collections:
+- Name: RexNet
+  Paper:
+    title: 'ReXNet: Diminishing Representational Bottleneck on Convolutional Neural
+      Network'
+    url: https://papperswithcode.com//paper/rexnet-diminishing-representational
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/rexnet.md
+++ b/modelindex/models/rexnet.md
@@ -229,7 +229,7 @@ Collections:
   Paper:
     title: 'ReXNet: Diminishing Representational Bottleneck on Convolutional Neural
       Network'
-    url: https://papperswithcode.com//paper/rexnet-diminishing-representational
+    url: https://paperswithcode.com//paper/rexnet-diminishing-representational
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/rexnet.md
+++ b/modelindex/models/rexnet.md
@@ -83,153 +83,176 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: RexNet
+  Paper:
+    Title: 'ReXNet: Diminishing Representational Bottleneck on Convolutional Neural
+      Network'
+    URL: https://paperswithcode.com/paper/rexnet-diminishing-representational
 Models:
 - Name: rexnet_100
+  In Collection: RexNet
   Metadata:
     FLOPs: 509989377
-    Epochs: 400
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Linear Warmup With Cosine Annealing
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 4800000
+    File Size: 19417552
     Architecture:
     - Batch Normalization
     - Convolution
     - Dropout
     - ReLU6
     - Residual Connection
-    File Size: 19417552
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: rexnet_100
     LR: 0.5
+    Epochs: 400
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L212
-  Config: ''
-  In Collection: RexNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-rexnet/rexnetv1_100-1b4dddf4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.86%
+      Top 5 Accuracy: 93.88%
 - Name: rexnet_130
+  In Collection: RexNet
   Metadata:
     FLOPs: 848364461
-    Epochs: 400
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Linear Warmup With Cosine Annealing
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 7560000
+    File Size: 30508197
     Architecture:
     - Batch Normalization
     - Convolution
     - Dropout
     - ReLU6
     - Residual Connection
-    File Size: 30508197
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: rexnet_130
     LR: 0.5
+    Epochs: 400
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L218
-  Config: ''
-  In Collection: RexNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-rexnet/rexnetv1_130-590d768e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.49%
+      Top 5 Accuracy: 94.67%
 - Name: rexnet_150
+  In Collection: RexNet
   Metadata:
     FLOPs: 1122374469
-    Epochs: 400
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Linear Warmup With Cosine Annealing
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 9730000
+    File Size: 39227315
     Architecture:
     - Batch Normalization
     - Convolution
     - Dropout
     - ReLU6
     - Residual Connection
-    File Size: 39227315
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: rexnet_150
     LR: 0.5
+    Epochs: 400
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L224
-  Config: ''
-  In Collection: RexNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-rexnet/rexnetv1_150-bd1a6aa8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.31%
+      Top 5 Accuracy: 95.16%
 - Name: rexnet_200
+  In Collection: RexNet
   Metadata:
     FLOPs: 1960224938
-    Epochs: 400
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - Linear Warmup With Cosine Annealing
-    - Nesterov Accelerated Gradient
-    - Weight Decay
-    Training Resources: 4x NVIDIA V100 GPUs
+    Parameters: 16370000
+    File Size: 65862221
     Architecture:
     - Batch Normalization
     - Convolution
     - Dropout
     - ReLU6
     - Residual Connection
-    File Size: 65862221
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Label Smoothing
+    - Linear Warmup With Cosine Annealing
+    - Nesterov Accelerated Gradient
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x NVIDIA V100 GPUs
     ID: rexnet_200
     LR: 0.5
+    Epochs: 400
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
     Label Smoothing: 0.1
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/rexnet.py#L230
-  Config: ''
-  In Collection: RexNet
-Collections:
-- Name: RexNet
-  Paper:
-    title: 'ReXNet: Diminishing Representational Bottleneck on Convolutional Neural
-      Network'
-    url: https://paperswithcode.com//paper/rexnet-diminishing-representational
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-rexnet/rexnetv1_200-8c0b7f2d.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.63%
+      Top 5 Accuracy: 95.67%
 -->

--- a/modelindex/models/se-resnet.md
+++ b/modelindex/models/se-resnet.md
@@ -162,7 +162,7 @@ Collections:
 - Name: SE ResNet
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/se-resnet.md
+++ b/modelindex/models/se-resnet.md
@@ -83,19 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SE ResNet
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: seresnet152d
+  In Collection: SE ResNet
   Metadata:
     FLOPs: 20161904304
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 66840000
+    File Size: 268144497
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -108,31 +108,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 268144497
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnet152d
     LR: 0.6
+    Epochs: 100
     Layers: 152
     Dropout: 0.2
     Crop Pct: '0.94'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '256'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1206
-  In Collection: SE ResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnet152d_ra2-04464dd2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.74%
+      Top 5 Accuracy: 96.77%
 - Name: seresnet50
+  In Collection: SE ResNet
   Metadata:
     FLOPs: 5285062320
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 28090000
+    File Size: 112621903
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -145,24 +153,31 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 112621903
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnet50
     LR: 0.6
+    Epochs: 100
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1180
-  In Collection: SE ResNet
-Collections:
-- Name: SE ResNet
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnet50_ra_224-8efdb4bb.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.26%
+      Top 5 Accuracy: 95.07%
 -->

--- a/modelindex/models/se-resnet.md
+++ b/modelindex/models/se-resnet.md
@@ -1,0 +1,168 @@
+# Summary
+
+**SE ResNet** is a variant of a [ResNet](https://www.paperswithcode.com/method/resnet) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('seresnet152d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `seresnet152d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('seresnet152d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: seresnet152d
+  Metadata:
+    FLOPs: 20161904304
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 268144497
+    Tasks:
+    - Image Classification
+    ID: seresnet152d
+    LR: 0.6
+    Layers: 152
+    Dropout: 0.2
+    Crop Pct: '0.94'
+    Momentum: 0.9
+    Image Size: '256'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1206
+  In Collection: SE ResNet
+- Name: seresnet50
+  Metadata:
+    FLOPs: 5285062320
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 112621903
+    Tasks:
+    - Image Classification
+    ID: seresnet50
+    LR: 0.6
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1180
+  In Collection: SE ResNet
+Collections:
+- Name: SE ResNet
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/selecsls.md
+++ b/modelindex/models/selecsls.md
@@ -168,7 +168,7 @@ Collections:
 - Name: SelecSLS
   Paper:
     title: 'XNect: Real-time Multi-Person 3D Motion Capture with a Single RGB Camera'
-    url: https://papperswithcode.com//paper/xnect-real-time-multi-person-3d-human-pose
+    url: https://paperswithcode.com//paper/xnect-real-time-multi-person-3d-human-pose
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/selecsls.md
+++ b/modelindex/models/selecsls.md
@@ -1,0 +1,174 @@
+# Summary
+
+**SelecSLS** uses novel selective long and short range skip connections to improve the information flow allowing for a drastically faster network without compromising accuracy.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('selecsls42b', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `selecsls42b`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('selecsls42b', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{Mehta_2020,
+   title={XNect},
+   volume={39},
+   ISSN={1557-7368},
+   url={http://dx.doi.org/10.1145/3386569.3392410},
+   DOI={10.1145/3386569.3392410},
+   number={4},
+   journal={ACM Transactions on Graphics},
+   publisher={Association for Computing Machinery (ACM)},
+   author={Mehta, Dushyant and Sotnychenko, Oleksandr and Mueller, Franziska and Xu, Weipeng and Elgharib, Mohamed and Fua, Pascal and Seidel, Hans-Peter and Rhodin, Helge and Pons-Moll, Gerard and Theobalt, Christian},
+   year={2020},
+   month={Jul}
+}
+```
+
+<!--
+Models:
+- Name: selecsls42b
+  Metadata:
+    FLOPs: 3824022528
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - ReLU
+    - SelecSLS Block
+    File Size: 129948954
+    Tasks:
+    - Image Classification
+    ID: selecsls42b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L335
+  In Collection: SelecSLS
+- Name: selecsls60
+  Metadata:
+    FLOPs: 4610472600
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - ReLU
+    - SelecSLS Block
+    File Size: 122839714
+    Tasks:
+    - Image Classification
+    ID: selecsls60
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L342
+  In Collection: SelecSLS
+- Name: selecsls60b
+  Metadata:
+    FLOPs: 4657653144
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Architecture:
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - ReLU
+    - SelecSLS Block
+    File Size: 131252898
+    Tasks:
+    - Image Classification
+    ID: selecsls60b
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L349
+  In Collection: SelecSLS
+Collections:
+- Name: SelecSLS
+  Paper:
+    title: 'XNect: Real-time Multi-Person 3D Motion Capture with a Single RGB Camera'
+    url: https://papperswithcode.com//paper/xnect-real-time-multi-person-3d-human-pose
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/selecsls.md
+++ b/modelindex/models/selecsls.md
@@ -88,15 +88,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SelecSLS
+  Paper:
+    Title: 'XNect: Real-time Multi-Person 3D Motion Capture with a Single RGB Camera'
+    URL: https://paperswithcode.com/paper/xnect-real-time-multi-person-3d-human-pose
 Models:
 - Name: selecsls42b
+  In Collection: SelecSLS
   Metadata:
     FLOPs: 3824022528
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Cosine Annealing
-    - Random Erasing
+    Parameters: 32460000
+    File Size: 129948954
     Architecture:
     - Batch Normalization
     - Convolution
@@ -105,23 +109,31 @@ Models:
     - Global Average Pooling
     - ReLU
     - SelecSLS Block
-    File Size: 129948954
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Training Data:
+    - ImageNet
     ID: selecsls42b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L335
-  In Collection: SelecSLS
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-selecsls/selecsls42b-8af30141.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.18%
+      Top 5 Accuracy: 93.39%
 - Name: selecsls60
+  In Collection: SelecSLS
   Metadata:
     FLOPs: 4610472600
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Cosine Annealing
-    - Random Erasing
+    Parameters: 30670000
+    File Size: 122839714
     Architecture:
     - Batch Normalization
     - Convolution
@@ -130,23 +142,31 @@ Models:
     - Global Average Pooling
     - ReLU
     - SelecSLS Block
-    File Size: 122839714
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Training Data:
+    - ImageNet
     ID: selecsls60
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L342
-  In Collection: SelecSLS
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-selecsls/selecsls60-bbf87526.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.99%
+      Top 5 Accuracy: 93.83%
 - Name: selecsls60b
+  In Collection: SelecSLS
   Metadata:
     FLOPs: 4657653144
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Cosine Annealing
-    - Random Erasing
+    Parameters: 32770000
+    File Size: 131252898
     Architecture:
     - Batch Normalization
     - Convolution
@@ -155,20 +175,23 @@ Models:
     - Global Average Pooling
     - ReLU
     - SelecSLS Block
-    File Size: 131252898
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Random Erasing
+    Training Data:
+    - ImageNet
     ID: selecsls60b
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/b9843f954b0457af2db4f9dea41a8538f51f5d78/timm/models/selecsls.py#L349
-  In Collection: SelecSLS
-Collections:
-- Name: SelecSLS
-  Paper:
-    title: 'XNect: Real-time Multi-Person 3D Motion Capture with a Single RGB Camera'
-    url: https://paperswithcode.com//paper/xnect-real-time-multi-person-3d-human-pose
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-selecsls/selecsls60b-94e619b5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.41%
+      Top 5 Accuracy: 94.18%
 -->

--- a/modelindex/models/seresnext.md
+++ b/modelindex/models/seresnext.md
@@ -199,7 +199,7 @@ Collections:
 - Name: SEResNeXt
   Paper:
     title: Squeeze-and-Excitation Networks
-    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/seresnext.md
+++ b/modelindex/models/seresnext.md
@@ -1,0 +1,205 @@
+# Summary
+
+**SE ResNeXt** is a variant of a [ResNext](https://www.paperswithcode.com/method/resneXt) that employs [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block) to enable the network to perform dynamic channel-wise feature recalibration.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('seresnext26d_32x4d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `seresnext26d_32x4d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('seresnext26d_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{hu2019squeezeandexcitation,
+      title={Squeeze-and-Excitation Networks}, 
+      author={Jie Hu and Li Shen and Samuel Albanie and Gang Sun and Enhua Wu},
+      year={2019},
+      eprint={1709.01507},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: seresnext26d_32x4d
+  Metadata:
+    FLOPs: 3507053024
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 67425193
+    Tasks:
+    - Image Classification
+    ID: seresnext26d_32x4d
+    LR: 0.6
+    Layers: 26
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1234
+  In Collection: SEResNeXt
+- Name: seresnext26t_32x4d
+  Metadata:
+    FLOPs: 3466436448
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 67414838
+    Tasks:
+    - Image Classification
+    ID: seresnext26t_32x4d
+    LR: 0.6
+    Layers: 26
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1246
+  In Collection: SEResNeXt
+- Name: seresnext50_32x4d
+  Metadata:
+    FLOPs: 5475179184
+    Epochs: 100
+    Batch Size: 1024
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA Titan X GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 110569859
+    Tasks:
+    - Image Classification
+    ID: seresnext50_32x4d
+    LR: 0.6
+    Layers: 50
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1267
+  In Collection: SEResNeXt
+Collections:
+- Name: SEResNeXt
+  Paper:
+    title: Squeeze-and-Excitation Networks
+    url: https://papperswithcode.com//paper/squeeze-and-excitation-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/seresnext.md
+++ b/modelindex/models/seresnext.md
@@ -83,19 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SEResNeXt
+  Paper:
+    Title: Squeeze-and-Excitation Networks
+    URL: https://paperswithcode.com/paper/squeeze-and-excitation-networks
 Models:
 - Name: seresnext26d_32x4d
+  In Collection: SEResNeXt
   Metadata:
     FLOPs: 3507053024
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 16810000
+    File Size: 67425193
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -108,31 +108,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 67425193
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnext26d_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 26
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1234
-  In Collection: SEResNeXt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnext26d_32x4d-80fa48a3.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.59%
+      Top 5 Accuracy: 93.61%
 - Name: seresnext26t_32x4d
+  In Collection: SEResNeXt
   Metadata:
     FLOPs: 3466436448
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 16820000
+    File Size: 67414838
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -145,31 +153,39 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 67414838
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnext26t_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 26
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1246
-  In Collection: SEResNeXt
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnext26tn_32x4d-569cb627.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.99%
+      Top 5 Accuracy: 93.73%
 - Name: seresnext50_32x4d
+  In Collection: SEResNeXt
   Metadata:
     FLOPs: 5475179184
-    Epochs: 100
-    Batch Size: 1024
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA Titan X GPUs
+    Parameters: 27560000
+    File Size: 110569859
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -182,24 +198,31 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 110569859
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA Titan X GPUs
     ID: seresnext50_32x4d
     LR: 0.6
+    Epochs: 100
     Layers: 50
     Dropout: 0.2
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 1024
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/resnet.py#L1267
-  In Collection: SEResNeXt
-Collections:
-- Name: SEResNeXt
-  Paper:
-    title: Squeeze-and-Excitation Networks
-    url: https://paperswithcode.com//paper/squeeze-and-excitation-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/seresnext50_32x4d_racm-a304a460.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.27%
+      Top 5 Accuracy: 95.62%
 -->

--- a/modelindex/models/skresnet.md
+++ b/modelindex/models/skresnet.md
@@ -83,18 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SKResNet
+  Paper:
+    Title: Selective Kernel Networks
+    URL: https://paperswithcode.com/paper/selective-kernel-networks
 Models:
 - Name: skresnet18
+  In Collection: SKResNet
   Metadata:
     FLOPs: 2333467136
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 11960000
+    File Size: 47923238
     Architecture:
     - Convolution
     - Dense Connections
@@ -103,30 +104,38 @@ Models:
     - Residual Connection
     - Selective Kernel
     - Softmax
-    File Size: 47923238
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: skresnet18
     LR: 0.1
+    Epochs: 100
     Layers: 18
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L148
-  In Collection: SKResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/skresnet18_ra-4eec2804.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.03%
+      Top 5 Accuracy: 91.17%
 - Name: skresnet34
+  In Collection: SKResNet
   Metadata:
     FLOPs: 4711849952
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x GPUs
+    Parameters: 22280000
+    File Size: 89299314
     Architecture:
     - Convolution
     - Dense Connections
@@ -135,24 +144,30 @@ Models:
     - Residual Connection
     - Selective Kernel
     - Softmax
-    File Size: 89299314
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: skresnet34
     LR: 0.1
+    Epochs: 100
     Layers: 34
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L165
-  In Collection: SKResNet
-Collections:
-- Name: SKResNet
-  Paper:
-    title: Selective Kernel Networks
-    url: https://paperswithcode.com//paper/selective-kernel-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/skresnet34_ra-bdc0ccde.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.93%
+      Top 5 Accuracy: 93.32%
 -->

--- a/modelindex/models/skresnet.md
+++ b/modelindex/models/skresnet.md
@@ -152,7 +152,7 @@ Collections:
 - Name: SKResNet
   Paper:
     title: Selective Kernel Networks
-    url: https://papperswithcode.com//paper/selective-kernel-networks
+    url: https://paperswithcode.com//paper/selective-kernel-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/skresnet.md
+++ b/modelindex/models/skresnet.md
@@ -1,0 +1,158 @@
+# Summary
+
+**SK ResNet** is a variant of a [ResNet](https://www.paperswithcode.com/method/resnet) that employs a [Selective Kernel](https://paperswithcode.com/method/selective-kernel) unit. In general, all the large kernel convolutions in the original bottleneck blocks in ResNet are replaced by the proposed [SK convolutions](https://paperswithcode.com/method/selective-kernel-convolution), enabling the network to choose appropriate receptive field sizes in an adaptive manner.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('skresnet18', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `skresnet18`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('skresnet18', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{li2019selective,
+      title={Selective Kernel Networks}, 
+      author={Xiang Li and Wenhai Wang and Xiaolin Hu and Jian Yang},
+      year={2019},
+      eprint={1903.06586},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: skresnet18
+  Metadata:
+    FLOPs: 2333467136
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Residual Connection
+    - Selective Kernel
+    - Softmax
+    File Size: 47923238
+    Tasks:
+    - Image Classification
+    ID: skresnet18
+    LR: 0.1
+    Layers: 18
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L148
+  In Collection: SKResNet
+- Name: skresnet34
+  Metadata:
+    FLOPs: 4711849952
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x GPUs
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Max Pooling
+    - Residual Connection
+    - Selective Kernel
+    - Softmax
+    File Size: 89299314
+    Tasks:
+    - Image Classification
+    ID: skresnet34
+    LR: 0.1
+    Layers: 34
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L165
+  In Collection: SKResNet
+Collections:
+- Name: SKResNet
+  Paper:
+    title: Selective Kernel Networks
+    url: https://papperswithcode.com//paper/selective-kernel-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/skresnext.md
+++ b/modelindex/models/skresnext.md
@@ -83,15 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SKResNeXt
+  Paper:
+    Title: Selective Kernel Networks
+    URL: https://paperswithcode.com/paper/selective-kernel-networks
 Models:
 - Name: skresnext50_32x4d
+  In Collection: SKResNeXt
   Metadata:
     FLOPs: 5739845824
-    Epochs: 100
-    Batch Size: 256
-    Training Data:
-    - ImageNet
-    Training Resources: 8x GPUs
+    Parameters: 27480000
+    File Size: 110340975
     Architecture:
     - Convolution
     - Dense Connections
@@ -101,24 +105,27 @@ Models:
     - Residual Connection
     - Selective Kernel
     - Softmax
-    File Size: 110340975
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
     ID: skresnext50_32x4d
     LR: 0.1
+    Epochs: 100
     Layers: 50
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 256
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L210
-  In Collection: SKResNeXt
-Collections:
-- Name: SKResNeXt
-  Paper:
-    title: Selective Kernel Networks
-    url: https://paperswithcode.com//paper/selective-kernel-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/skresnext50_ra-f40e40bf.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.15%
+      Top 5 Accuracy: 94.64%
 -->

--- a/modelindex/models/skresnext.md
+++ b/modelindex/models/skresnext.md
@@ -118,7 +118,7 @@ Collections:
 - Name: SKResNeXt
   Paper:
     title: Selective Kernel Networks
-    url: https://papperswithcode.com//paper/selective-kernel-networks
+    url: https://paperswithcode.com//paper/selective-kernel-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/skresnext.md
+++ b/modelindex/models/skresnext.md
@@ -1,0 +1,124 @@
+# Summary
+
+**SK ResNeXt** is a variant of a [ResNeXt](https://www.paperswithcode.com/method/resnext) that employs a [Selective Kernel](https://paperswithcode.com/method/selective-kernel) unit. In general, all the large kernel convolutions in the original bottleneck blocks in ResNext are replaced by the proposed [SK convolutions](https://paperswithcode.com/method/selective-kernel-convolution), enabling the network to choose appropriate receptive field sizes in an adaptive manner.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('skresnext50_32x4d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `skresnext50_32x4d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('skresnext50_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{li2019selective,
+      title={Selective Kernel Networks}, 
+      author={Xiang Li and Wenhai Wang and Xiaolin Hu and Jian Yang},
+      year={2019},
+      eprint={1903.06586},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: skresnext50_32x4d
+  Metadata:
+    FLOPs: 5739845824
+    Epochs: 100
+    Batch Size: 256
+    Training Data:
+    - ImageNet
+    Training Resources: 8x GPUs
+    Architecture:
+    - Convolution
+    - Dense Connections
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - Residual Connection
+    - Selective Kernel
+    - Softmax
+    File Size: 110340975
+    Tasks:
+    - Image Classification
+    ID: skresnext50_32x4d
+    LR: 0.1
+    Layers: 50
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/a7f95818e44b281137503bcf4b3e3e94d8ffa52f/timm/models/sknet.py#L210
+  In Collection: SKResNeXt
+Collections:
+- Name: SKResNeXt
+  Paper:
+    title: Selective Kernel Networks
+    url: https://papperswithcode.com//paper/selective-kernel-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/spnasnet.md
+++ b/modelindex/models/spnasnet.md
@@ -110,7 +110,7 @@ Collections:
   Paper:
     title: 'Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4
       Hours'
-    url: https://papperswithcode.com//paper/single-path-nas-designing-hardware-efficient
+    url: https://paperswithcode.com//paper/single-path-nas-designing-hardware-efficient
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/spnasnet.md
+++ b/modelindex/models/spnasnet.md
@@ -83,12 +83,20 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SPNASNet
+  Paper:
+    Title: 'Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4
+      Hours'
+    URL: https://paperswithcode.com/paper/single-path-nas-designing-hardware-efficient
 Models:
 - Name: spnasnet_100
+  In Collection: SPNASNet
   Metadata:
     FLOPs: 442385600
-    Training Data:
-    - ImageNet
+    Parameters: 4420000
+    File Size: 17902337
     Architecture:
     - Average Pooling
     - Batch Normalization
@@ -96,21 +104,20 @@ Models:
     - Depthwise Separable Convolution
     - Dropout
     - ReLU
-    File Size: 17902337
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: spnasnet_100
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L995
-  In Collection: SPNASNet
-Collections:
-- Name: SPNASNet
-  Paper:
-    title: 'Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4
-      Hours'
-    url: https://paperswithcode.com//paper/single-path-nas-designing-hardware-efficient
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/spnasnet_100-048bc3f4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.08%
+      Top 5 Accuracy: 91.82%
 -->

--- a/modelindex/models/spnasnet.md
+++ b/modelindex/models/spnasnet.md
@@ -1,0 +1,116 @@
+# Summary
+
+**Single-Path NAS** is a novel differentiable NAS method for designing hardware-efficient ConvNets in less than 4 hours.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('spnasnet_100', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `spnasnet_100`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('spnasnet_100', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{stamoulis2019singlepath,
+      title={Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4 Hours}, 
+      author={Dimitrios Stamoulis and Ruizhou Ding and Di Wang and Dimitrios Lymberopoulos and Bodhi Priyantha and Jie Liu and Diana Marculescu},
+      year={2019},
+      eprint={1904.02877},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: spnasnet_100
+  Metadata:
+    FLOPs: 442385600
+    Training Data:
+    - ImageNet
+    Architecture:
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Depthwise Separable Convolution
+    - Dropout
+    - ReLU
+    File Size: 17902337
+    Tasks:
+    - Image Classification
+    ID: spnasnet_100
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L995
+  In Collection: SPNASNet
+Collections:
+- Name: SPNASNet
+  Paper:
+    title: 'Single-Path NAS: Designing Hardware-Efficient ConvNets in less than 4
+      Hours'
+    url: https://papperswithcode.com//paper/single-path-nas-designing-hardware-efficient
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/ssl-resnet.md
+++ b/modelindex/models/ssl-resnet.md
@@ -1,0 +1,177 @@
+# Summary
+
+**Residual Networks**, or **ResNets**, learn residual functions with reference to the layer inputs, instead of learning unreferenced functions. Instead of hoping each few stacked layers directly fit a desired underlying mapping, residual nets let these layers fit a residual mapping. They stack [residual blocks](https://paperswithcode.com/method/residual-block) ontop of each other to form network: e.g. a ResNet-50 has fifty layers using these blocks. 
+
+The model in this collection utilises semi-supervised learning to improve the performance of the model. The approach brings important gains to standard architectures for image, video and fine-grained classification. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('ssl_resnet50', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `ssl_resnet50`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('ssl_resnet50', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-00546,
+  author    = {I. Zeki Yalniz and
+               Herv{\'{e}} J{\'{e}}gou and
+               Kan Chen and
+               Manohar Paluri and
+               Dhruv Mahajan},
+  title     = {Billion-scale semi-supervised learning for image classification},
+  journal   = {CoRR},
+  volume    = {abs/1905.00546},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.00546},
+  archivePrefix = {arXiv},
+  eprint    = {1905.00546},
+  timestamp = {Mon, 28 Sep 2020 08:19:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-00546.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: ssl_resnet50
+  Metadata:
+    FLOPs: 5282531328
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102480594
+    Tasks:
+    - Image Classification
+    ID: ssl_resnet50
+    LR: 0.0015
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L904
+  In Collection: SSL ResNet
+- Name: ssl_resnet18
+  Metadata:
+    FLOPs: 2337073152
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46811375
+    Tasks:
+    - Image Classification
+    ID: ssl_resnet18
+    LR: 0.0015
+    Layers: 18
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L894
+  In Collection: SSL ResNet
+Collections:
+- Name: SSL ResNet
+  Paper:
+    title: Billion-scale semi-supervised learning for image classification
+    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/ssl-resnet.md
+++ b/modelindex/models/ssl-resnet.md
@@ -11,7 +11,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('ssl_resnet50', pretrained=True)
+model = timm.create_model('ssl_resnet18', pretrained=True)
 model.eval()
 ```
 
@@ -57,14 +57,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `ssl_resnet50`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `ssl_resnet18`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('ssl_resnet50', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('ssl_resnet18', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -96,54 +96,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SSL ResNet
+  Paper:
+    Title: Billion-scale semi-supervised learning for image classification
+    URL: https://paperswithcode.com/paper/billion-scale-semi-supervised-learning-for
 Models:
-- Name: ssl_resnet50
-  Metadata:
-    FLOPs: 5282531328
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Bottleneck Residual Block
-    - Convolution
-    - Global Average Pooling
-    - Max Pooling
-    - ReLU
-    - Residual Block
-    - Residual Connection
-    - Softmax
-    File Size: 102480594
-    Tasks:
-    - Image Classification
-    ID: ssl_resnet50
-    LR: 0.0015
-    Layers: 50
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L904
-  In Collection: SSL ResNet
 - Name: ssl_resnet18
+  In Collection: SSL ResNet
   Metadata:
     FLOPs: 2337073152
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 11690000
+    File Size: 46811375
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -155,23 +120,73 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 46811375
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
     ID: ssl_resnet18
     LR: 0.0015
+    Epochs: 30
     Layers: 18
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L894
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnet18-d92f0530.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.62%
+      Top 5 Accuracy: 91.42%
+- Name: ssl_resnet50
   In Collection: SSL ResNet
-Collections:
-- Name: SSL ResNet
-  Paper:
-    title: Billion-scale semi-supervised learning for image classification
-    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5282531328
+    Parameters: 25560000
+    File Size: 102480594
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
+    ID: ssl_resnet50
+    LR: 0.0015
+    Epochs: 30
+    Layers: 50
+    Crop Pct: '0.875'
+    Batch Size: 1536
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L904
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnet50-08389792.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.24%
+      Top 5 Accuracy: 94.83%
 -->

--- a/modelindex/models/ssl-resnet.md
+++ b/modelindex/models/ssl-resnet.md
@@ -171,7 +171,7 @@ Collections:
 - Name: SSL ResNet
   Paper:
     title: Billion-scale semi-supervised learning for image classification
-    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/ssl-resnext.md
+++ b/modelindex/models/ssl-resnext.md
@@ -1,0 +1,247 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+The model in this collection utilises semi-supervised learning to improve the performance of the model. The approach brings important gains to standard architectures for image, video and fine-grained classification. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('ssl_resnext101_32x16d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `ssl_resnext101_32x16d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('ssl_resnext101_32x16d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-00546,
+  author    = {I. Zeki Yalniz and
+               Herv{\'{e}} J{\'{e}}gou and
+               Kan Chen and
+               Manohar Paluri and
+               Dhruv Mahajan},
+  title     = {Billion-scale semi-supervised learning for image classification},
+  journal   = {CoRR},
+  volume    = {abs/1905.00546},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.00546},
+  archivePrefix = {arXiv},
+  eprint    = {1905.00546},
+  timestamp = {Mon, 28 Sep 2020 08:19:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-00546.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: ssl_resnext101_32x16d
+  Metadata:
+    FLOPs: 46623691776
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 777518664
+    Tasks:
+    - Image Classification
+    ID: ssl_resnext101_32x16d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L944
+  In Collection: SSL ResNext
+- Name: ssl_resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100428550
+    Tasks:
+    - Image Classification
+    ID: ssl_resnext50_32x4d
+    LR: 0.0015
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L914
+  In Collection: SSL ResNext
+- Name: ssl_resnext101_32x4d
+  Metadata:
+    FLOPs: 10298145792
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 177341913
+    Tasks:
+    - Image Classification
+    ID: ssl_resnext101_32x4d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L924
+  In Collection: SSL ResNext
+- Name: ssl_resnext101_32x8d
+  Metadata:
+    FLOPs: 21180417024
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 356056638
+    Tasks:
+    - Image Classification
+    ID: ssl_resnext101_32x8d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L934
+  In Collection: SSL ResNext
+Collections:
+- Name: SSL ResNext
+  Paper:
+    title: Billion-scale semi-supervised learning for image classification
+    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/ssl-resnext.md
+++ b/modelindex/models/ssl-resnext.md
@@ -241,7 +241,7 @@ Collections:
 - Name: SSL ResNext
   Paper:
     title: Billion-scale semi-supervised learning for image classification
-    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/ssl-resnext.md
+++ b/modelindex/models/ssl-resnext.md
@@ -96,19 +96,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SSL ResNext
+  Paper:
+    Title: Billion-scale semi-supervised learning for image classification
+    URL: https://paperswithcode.com/paper/billion-scale-semi-supervised-learning-for
 Models:
 - Name: ssl_resnext101_32x16d
+  In Collection: SSL ResNext
   Metadata:
     FLOPs: 46623691776
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 194030000
+    File Size: 777518664
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -120,65 +120,38 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 777518664
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
     ID: ssl_resnext101_32x16d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L944
-  In Collection: SSL ResNext
-- Name: ssl_resnext50_32x4d
-  Metadata:
-    FLOPs: 5472648192
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 100428550
-    Tasks:
-    - Image Classification
-    ID: ssl_resnext50_32x4d
-    LR: 0.0015
-    Layers: 50
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L914
-  In Collection: SSL ResNext
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnext101_32x16-15fffa57.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.84%
+      Top 5 Accuracy: 96.09%
 - Name: ssl_resnext101_32x4d
+  In Collection: SSL ResNext
   Metadata:
     FLOPs: 10298145792
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 44180000
+    File Size: 177341913
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -190,30 +163,38 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 177341913
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
     ID: ssl_resnext101_32x4d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L924
-  In Collection: SSL ResNext
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnext101_32x4-dc43570a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.91%
+      Top 5 Accuracy: 95.73%
 - Name: ssl_resnext101_32x8d
+  In Collection: SSL ResNext
   Metadata:
     FLOPs: 21180417024
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - ImageNet
-    - YFCC-100M
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 88790000
+    File Size: 356056638
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -225,23 +206,73 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 356056638
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
     ID: ssl_resnext101_32x8d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L934
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnext101_32x8-2cfe2f8b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.61%
+      Top 5 Accuracy: 96.04%
+- Name: ssl_resnext50_32x4d
   In Collection: SSL ResNext
-Collections:
-- Name: SSL ResNext
-  Paper:
-    title: Billion-scale semi-supervised learning for image classification
-    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5472648192
+    Parameters: 25030000
+    File Size: 100428550
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    - YFCC-100M
+    Training Resources: 64x GPUs
+    ID: ssl_resnext50_32x4d
+    LR: 0.0015
+    Epochs: 30
+    Layers: 50
+    Crop Pct: '0.875'
+    Batch Size: 1536
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L914
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnext50_32x4-ddb3e555.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.3%
+      Top 5 Accuracy: 95.41%
 -->

--- a/modelindex/models/swsl-resnet.md
+++ b/modelindex/models/swsl-resnet.md
@@ -96,19 +96,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SWSL ResNet
+  Paper:
+    Title: Billion-scale semi-supervised learning for image classification
+    URL: https://paperswithcode.com/paper/billion-scale-semi-supervised-learning-for
 Models:
 - Name: swsl_resnet18
+  In Collection: SWSL ResNet
   Metadata:
     FLOPs: 2337073152
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 11690000
+    File Size: 46811375
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -120,30 +120,38 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 46811375
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
     ID: swsl_resnet18
     LR: 0.0015
+    Epochs: 30
     Layers: 18
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L954
-  In Collection: SWSL ResNet
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnet18-118f1556.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.28%
+      Top 5 Accuracy: 91.76%
 - Name: swsl_resnet50
+  In Collection: SWSL ResNet
   Metadata:
     FLOPs: 5282531328
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 25560000
+    File Size: 102480594
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -155,23 +163,30 @@ Models:
     - Residual Block
     - Residual Connection
     - Softmax
-    File Size: 102480594
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
     ID: swsl_resnet50
     LR: 0.0015
+    Epochs: 30
     Layers: 50
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L965
-  In Collection: SWSL ResNet
-Collections:
-- Name: SWSL ResNet
-  Paper:
-    title: Billion-scale semi-supervised learning for image classification
-    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
-  type: model-index
-Type: model-index
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnet50-16a12f1b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.14%
+      Top 5 Accuracy: 95.97%
 -->

--- a/modelindex/models/swsl-resnet.md
+++ b/modelindex/models/swsl-resnet.md
@@ -171,7 +171,7 @@ Collections:
 - Name: SWSL ResNet
   Paper:
     title: Billion-scale semi-supervised learning for image classification
-    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/swsl-resnet.md
+++ b/modelindex/models/swsl-resnet.md
@@ -1,0 +1,177 @@
+# Summary
+
+**Residual Networks**, or **ResNets**, learn residual functions with reference to the layer inputs, instead of learning unreferenced functions. Instead of hoping each few stacked layers directly fit a desired underlying mapping, residual nets let these layers fit a residual mapping. They stack [residual blocks](https://paperswithcode.com/method/residual-block) ontop of each other to form network: e.g. a ResNet-50 has fifty layers using these blocks. 
+
+The models in this collection utilise semi-weakly supervised learning to improve the performance of the model. The approach brings important gains to standard architectures for image, video and fine-grained classification. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('swsl_resnet18', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `swsl_resnet18`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('swsl_resnet18', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-00546,
+  author    = {I. Zeki Yalniz and
+               Herv{\'{e}} J{\'{e}}gou and
+               Kan Chen and
+               Manohar Paluri and
+               Dhruv Mahajan},
+  title     = {Billion-scale semi-supervised learning for image classification},
+  journal   = {CoRR},
+  volume    = {abs/1905.00546},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.00546},
+  archivePrefix = {arXiv},
+  eprint    = {1905.00546},
+  timestamp = {Mon, 28 Sep 2020 08:19:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-00546.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: swsl_resnet18
+  Metadata:
+    FLOPs: 2337073152
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 46811375
+    Tasks:
+    - Image Classification
+    ID: swsl_resnet18
+    LR: 0.0015
+    Layers: 18
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L954
+  In Collection: SWSL ResNet
+- Name: swsl_resnet50
+  Metadata:
+    FLOPs: 5282531328
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Bottleneck Residual Block
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Block
+    - Residual Connection
+    - Softmax
+    File Size: 102480594
+    Tasks:
+    - Image Classification
+    ID: swsl_resnet50
+    LR: 0.0015
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L965
+  In Collection: SWSL ResNet
+Collections:
+- Name: SWSL ResNet
+  Paper:
+    title: Billion-scale semi-supervised learning for image classification
+    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/swsl-resnext.md
+++ b/modelindex/models/swsl-resnext.md
@@ -1,0 +1,247 @@
+# Summary
+
+A **ResNeXt** repeats a [building block](https://paperswithcode.com/method/resnext-block) that aggregates a set of transformations with the same topology. Compared to a [ResNet](https://paperswithcode.com/method/resnet), it exposes a new dimension,  *cardinality* (the size of the set of transformations) $C$, as an essential factor in addition to the dimensions of depth and width. 
+
+The models in this collection utilise semi-weakly supervised learning to improve the performance of the model. The approach brings important gains to standard architectures for image, video and fine-grained classification. 
+
+Please note the CC-BY-NC 4.0 license on theses weights, non-commercial use only.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('swsl_resnext101_32x4d', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `swsl_resnext101_32x4d`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('swsl_resnext101_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-00546,
+  author    = {I. Zeki Yalniz and
+               Herv{\'{e}} J{\'{e}}gou and
+               Kan Chen and
+               Manohar Paluri and
+               Dhruv Mahajan},
+  title     = {Billion-scale semi-supervised learning for image classification},
+  journal   = {CoRR},
+  volume    = {abs/1905.00546},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.00546},
+  archivePrefix = {arXiv},
+  eprint    = {1905.00546},
+  timestamp = {Mon, 28 Sep 2020 08:19:37 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-00546.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: swsl_resnext101_32x4d
+  Metadata:
+    FLOPs: 10298145792
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 177341913
+    Tasks:
+    - Image Classification
+    ID: swsl_resnext101_32x4d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L987
+  In Collection: SWSL ResNext
+- Name: swsl_resnext50_32x4d
+  Metadata:
+    FLOPs: 5472648192
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 100428550
+    Tasks:
+    - Image Classification
+    ID: swsl_resnext50_32x4d
+    LR: 0.0015
+    Layers: 50
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L976
+  In Collection: SWSL ResNext
+- Name: swsl_resnext101_32x16d
+  Metadata:
+    FLOPs: 46623691776
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 777518664
+    Tasks:
+    - Image Classification
+    ID: swsl_resnext101_32x16d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L1009
+  In Collection: SWSL ResNext
+- Name: swsl_resnext101_32x8d
+  Metadata:
+    FLOPs: 21180417024
+    Epochs: 30
+    Batch Size: 1536
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 64x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    File Size: 356056638
+    Tasks:
+    - Image Classification
+    ID: swsl_resnext101_32x8d
+    LR: 0.0015
+    Layers: 101
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L998
+  In Collection: SWSL ResNext
+Collections:
+- Name: SWSL ResNext
+  Paper:
+    title: Billion-scale semi-supervised learning for image classification
+    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/swsl-resnext.md
+++ b/modelindex/models/swsl-resnext.md
@@ -241,7 +241,7 @@ Collections:
 - Name: SWSL ResNext
   Paper:
     title: Billion-scale semi-supervised learning for image classification
-    url: https://papperswithcode.com//paper/billion-scale-semi-supervised-learning-for
+    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/swsl-resnext.md
+++ b/modelindex/models/swsl-resnext.md
@@ -11,7 +11,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('swsl_resnext101_32x4d', pretrained=True)
+model = timm.create_model('swsl_resnext101_32x16d', pretrained=True)
 model.eval()
 ```
 
@@ -57,14 +57,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `swsl_resnext101_32x4d`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `swsl_resnext101_32x16d`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('swsl_resnext101_32x4d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('swsl_resnext101_32x16d', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -96,89 +96,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: SWSL ResNext
+  Paper:
+    Title: Billion-scale semi-supervised learning for image classification
+    URL: https://paperswithcode.com/paper/billion-scale-semi-supervised-learning-for
 Models:
-- Name: swsl_resnext101_32x4d
-  Metadata:
-    FLOPs: 10298145792
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 177341913
-    Tasks:
-    - Image Classification
-    ID: swsl_resnext101_32x4d
-    LR: 0.0015
-    Layers: 101
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L987
-  In Collection: SWSL ResNext
-- Name: swsl_resnext50_32x4d
-  Metadata:
-    FLOPs: 5472648192
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
-    Architecture:
-    - 1x1 Convolution
-    - Batch Normalization
-    - Convolution
-    - Global Average Pooling
-    - Grouped Convolution
-    - Max Pooling
-    - ReLU
-    - ResNeXt Block
-    - Residual Connection
-    - Softmax
-    File Size: 100428550
-    Tasks:
-    - Image Classification
-    ID: swsl_resnext50_32x4d
-    LR: 0.0015
-    Layers: 50
-    Crop Pct: '0.875'
-    Image Size: '224'
-    Weight Decay: 0.0001
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L976
-  In Collection: SWSL ResNext
 - Name: swsl_resnext101_32x16d
+  In Collection: SWSL ResNext
   Metadata:
     FLOPs: 46623691776
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    Parameters: 194030000
+    File Size: 777518664
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -190,30 +120,38 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 777518664
     Tasks:
     - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
     ID: swsl_resnext101_32x16d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L1009
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnext101_32x16-f3559a9c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.34%
+      Top 5 Accuracy: 96.84%
+- Name: swsl_resnext101_32x4d
   In Collection: SWSL ResNext
-- Name: swsl_resnext101_32x8d
   Metadata:
-    FLOPs: 21180417024
-    Epochs: 30
-    Batch Size: 1536
-    Training Data:
-    - IG-1B-Targeted
-    - ImageNet
-    Training Techniques:
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 64x GPUs
+    FLOPs: 10298145792
+    Parameters: 44180000
+    File Size: 177341913
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -225,23 +163,116 @@ Models:
     - ResNeXt Block
     - Residual Connection
     - Softmax
-    File Size: 356056638
     Tasks:
     - Image Classification
-    ID: swsl_resnext101_32x8d
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
+    ID: swsl_resnext101_32x4d
     LR: 0.0015
+    Epochs: 30
     Layers: 101
     Crop Pct: '0.875'
+    Batch Size: 1536
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L987
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnext101_32x4-3f87e46b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.22%
+      Top 5 Accuracy: 96.77%
+- Name: swsl_resnext101_32x8d
+  In Collection: SWSL ResNext
+  Metadata:
+    FLOPs: 21180417024
+    Parameters: 88790000
+    File Size: 356056638
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
+    ID: swsl_resnext101_32x8d
+    LR: 0.0015
+    Epochs: 30
+    Layers: 101
+    Crop Pct: '0.875'
+    Batch Size: 1536
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L998
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnext101_32x8-b4712904.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.27%
+      Top 5 Accuracy: 97.17%
+- Name: swsl_resnext50_32x4d
   In Collection: SWSL ResNext
-Collections:
-- Name: SWSL ResNext
-  Paper:
-    title: Billion-scale semi-supervised learning for image classification
-    url: https://paperswithcode.com//paper/billion-scale-semi-supervised-learning-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 5472648192
+    Parameters: 25030000
+    File Size: 100428550
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Grouped Convolution
+    - Max Pooling
+    - ReLU
+    - ResNeXt Block
+    - Residual Connection
+    - Softmax
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - IG-1B-Targeted
+    - ImageNet
+    Training Resources: 64x GPUs
+    ID: swsl_resnext50_32x4d
+    LR: 0.0015
+    Epochs: 30
+    Layers: 50
+    Crop Pct: '0.875'
+    Batch Size: 1536
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/resnet.py#L976
+  Weights: https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_weakly_supervised_resnext50_32x4-72679e44.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.17%
+      Top 5 Accuracy: 96.23%
 -->

--- a/modelindex/models/tf-efficientnet-condconv.md
+++ b/modelindex/models/tf-efficientnet-condconv.md
@@ -13,7 +13,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('tf_efficientnet_cc_b1_8e', pretrained=True)
+model = timm.create_model('tf_efficientnet_cc_b0_4e', pretrained=True)
 model.eval()
 ```
 
@@ -59,14 +59,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `tf_efficientnet_cc_b1_8e`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_cc_b0_4e`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('tf_efficientnet_cc_b1_8e', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('tf_efficientnet_cc_b0_4e', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -97,59 +97,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF EfficientNet CondConv
+  Paper:
+    Title: 'CondConv: Conditionally Parameterized Convolutions for Efficient Inference'
+    URL: https://paperswithcode.com/paper/soft-conditional-computation
 Models:
-- Name: tf_efficientnet_cc_b1_8e
-  Metadata:
-    FLOPs: 370427824
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - CondConv
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 159206198
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_cc_b1_8e
-    LR: 0.256
-    Crop Pct: '0.882'
-    Momentum: 0.9
-    Image Size: '240'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1584
-  In Collection: TF EfficientNet CondConv
 - Name: tf_efficientnet_cc_b0_4e
+  In Collection: TF EfficientNet CondConv
   Metadata:
     FLOPs: 224153788
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 13310000
+    File Size: 53490940
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -161,13 +121,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 53490940
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_cc_b0_4e
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -175,20 +144,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1561
-  In Collection: TF EfficientNet CondConv
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_cc_b0_4e-4362b6b2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.32%
+      Top 5 Accuracy: 93.32%
 - Name: tf_efficientnet_cc_b0_8e
+  In Collection: TF EfficientNet CondConv
   Metadata:
     FLOPs: 224158524
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 24010000
+    File Size: 96287616
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -200,13 +168,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 96287616
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_cc_b0_8e
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -214,12 +191,58 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1572
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_cc_b0_8e-66184a25.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.91%
+      Top 5 Accuracy: 93.65%
+- Name: tf_efficientnet_cc_b1_8e
   In Collection: TF EfficientNet CondConv
-Collections:
-- Name: TF EfficientNet CondConv
-  Paper:
-    title: 'CondConv: Conditionally Parameterized Convolutions for Efficient Inference'
-    url: https://paperswithcode.com//paper/soft-conditional-computation
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 370427824
+    Parameters: 39720000
+    File Size: 159206198
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - CondConv
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_cc_b1_8e
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1584
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_cc_b1_8e-f7c79ae1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.33%
+      Top 5 Accuracy: 94.37%
 -->

--- a/modelindex/models/tf-efficientnet-condconv.md
+++ b/modelindex/models/tf-efficientnet-condconv.md
@@ -219,7 +219,7 @@ Collections:
 - Name: TF EfficientNet CondConv
   Paper:
     title: 'CondConv: Conditionally Parameterized Convolutions for Efficient Inference'
-    url: https://papperswithcode.com//paper/soft-conditional-computation
+    url: https://paperswithcode.com//paper/soft-conditional-computation
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/tf-efficientnet-condconv.md
+++ b/modelindex/models/tf-efficientnet-condconv.md
@@ -1,0 +1,225 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2), in addition to squeeze-and-excitation blocks.
+
+This collection of models amends EfficientNet by adding [CondConv](https://paperswithcode.com/method/condconv) convolutions.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('tf_efficientnet_cc_b1_8e', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_cc_b1_8e`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('tf_efficientnet_cc_b1_8e', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1904-04971,
+  author    = {Brandon Yang and
+               Gabriel Bender and
+               Quoc V. Le and
+               Jiquan Ngiam},
+  title     = {Soft Conditional Computation},
+  journal   = {CoRR},
+  volume    = {abs/1904.04971},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1904.04971},
+  archivePrefix = {arXiv},
+  eprint    = {1904.04971},
+  timestamp = {Thu, 25 Apr 2019 13:55:01 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1904-04971.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_cc_b1_8e
+  Metadata:
+    FLOPs: 370427824
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - CondConv
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 159206198
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_cc_b1_8e
+    LR: 0.256
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1584
+  In Collection: TF EfficientNet CondConv
+- Name: tf_efficientnet_cc_b0_4e
+  Metadata:
+    FLOPs: 224153788
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - CondConv
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 53490940
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_cc_b0_4e
+    LR: 0.256
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1561
+  In Collection: TF EfficientNet CondConv
+- Name: tf_efficientnet_cc_b0_8e
+  Metadata:
+    FLOPs: 224158524
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - CondConv
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 96287616
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_cc_b0_8e
+    LR: 0.256
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1572
+  In Collection: TF EfficientNet CondConv
+Collections:
+- Name: TF EfficientNet CondConv
+  Paper:
+    title: 'CondConv: Conditionally Parameterized Convolutions for Efficient Inference'
+    url: https://papperswithcode.com//paper/soft-conditional-computation
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/tf-efficientnet-lite.md
+++ b/modelindex/models/tf-efficientnet-lite.md
@@ -209,7 +209,7 @@ Collections:
 - Name: TF EfficientNet Lite
   Paper:
     title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/tf-efficientnet-lite.md
+++ b/modelindex/models/tf-efficientnet-lite.md
@@ -1,0 +1,215 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2).
+
+EfficientNet-Lite makes EfficientNet more suitable for mobile devices by introducing [ReLU6](https://paperswithcode.com/method/relu6) activation functions and removing [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('tf_efficientnet_lite3', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_lite3`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('tf_efficientnet_lite3', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2020efficientnet,
+      title={EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2020},
+      eprint={1905.11946},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_lite3
+  Metadata:
+    FLOPs: 2011534304
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 33161413
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite3
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1629
+  In Collection: TF EfficientNet Lite
+- Name: tf_efficientnet_lite4
+  Metadata:
+    FLOPs: 5164802912
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 52558819
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite4
+    Crop Pct: '0.92'
+    Image Size: '380'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1640
+  In Collection: TF EfficientNet Lite
+- Name: tf_efficientnet_lite2
+  Metadata:
+    FLOPs: 1068494432
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 24658687
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite2
+    Crop Pct: '0.89'
+    Image Size: '260'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1618
+  In Collection: TF EfficientNet Lite
+- Name: tf_efficientnet_lite1
+  Metadata:
+    FLOPs: 773639520
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 21939331
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite1
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1607
+  In Collection: TF EfficientNet Lite
+- Name: tf_efficientnet_lite0
+  Metadata:
+    FLOPs: 488052032
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    File Size: 18820223
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_lite0
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1596
+  In Collection: TF EfficientNet Lite
+Collections:
+- Name: TF EfficientNet Lite
+  Paper:
+    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/tf-efficientnet-lite.md
+++ b/modelindex/models/tf-efficientnet-lite.md
@@ -13,7 +13,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('tf_efficientnet_lite3', pretrained=True)
+model = timm.create_model('tf_efficientnet_lite0', pretrained=True)
 model.eval()
 ```
 
@@ -59,14 +59,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `tf_efficientnet_lite3`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_lite0`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('tf_efficientnet_lite3', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('tf_efficientnet_lite0', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -89,104 +89,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF EfficientNet Lite
+  Paper:
+    Title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    URL: https://paperswithcode.com/paper/efficientnet-rethinking-model-scaling-for
 Models:
-- Name: tf_efficientnet_lite3
-  Metadata:
-    FLOPs: 2011534304
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - RELU6
-    File Size: 33161413
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_lite3
-    Crop Pct: '0.904'
-    Image Size: '300'
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1629
-  In Collection: TF EfficientNet Lite
-- Name: tf_efficientnet_lite4
-  Metadata:
-    FLOPs: 5164802912
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - RELU6
-    File Size: 52558819
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_lite4
-    Crop Pct: '0.92'
-    Image Size: '380'
-    Interpolation: bilinear
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1640
-  In Collection: TF EfficientNet Lite
-- Name: tf_efficientnet_lite2
-  Metadata:
-    FLOPs: 1068494432
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - RELU6
-    File Size: 24658687
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_lite2
-    Crop Pct: '0.89'
-    Image Size: '260'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1618
-  In Collection: TF EfficientNet Lite
-- Name: tf_efficientnet_lite1
-  Metadata:
-    FLOPs: 773639520
-    Training Data:
-    - ImageNet
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - RELU6
-    File Size: 21939331
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_lite1
-    Crop Pct: '0.882'
-    Image Size: '240'
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1607
-  In Collection: TF EfficientNet Lite
 - Name: tf_efficientnet_lite0
+  In Collection: TF EfficientNet Lite
   Metadata:
     FLOPs: 488052032
-    Training Data:
-    - ImageNet
+    Parameters: 4650000
+    File Size: 18820223
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -196,20 +111,144 @@ Models:
     - Dropout
     - Inverted Residual Block
     - RELU6
-    File Size: 18820223
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_lite0
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1596
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite0-0aa007d2.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 74.83%
+      Top 5 Accuracy: 92.17%
+- Name: tf_efficientnet_lite1
   In Collection: TF EfficientNet Lite
-Collections:
-- Name: TF EfficientNet Lite
-  Paper:
-    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
-  type: model-index
-Type: model-index
+  Metadata:
+    FLOPs: 773639520
+    Parameters: 5420000
+    File Size: 21939331
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_lite1
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1607
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite1-bde8b488.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.67%
+      Top 5 Accuracy: 93.24%
+- Name: tf_efficientnet_lite2
+  In Collection: TF EfficientNet Lite
+  Metadata:
+    FLOPs: 1068494432
+    Parameters: 6090000
+    File Size: 24658687
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_lite2
+    Crop Pct: '0.89'
+    Image Size: '260'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1618
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite2-dcccb7df.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.48%
+      Top 5 Accuracy: 93.75%
+- Name: tf_efficientnet_lite3
+  In Collection: TF EfficientNet Lite
+  Metadata:
+    FLOPs: 2011534304
+    Parameters: 8199999
+    File Size: 33161413
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_lite3
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1629
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite3-b733e338.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.83%
+      Top 5 Accuracy: 94.91%
+- Name: tf_efficientnet_lite4
+  In Collection: TF EfficientNet Lite
+  Metadata:
+    FLOPs: 5164802912
+    Parameters: 13010000
+    File Size: 52558819
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - RELU6
+    Tasks:
+    - Image Classification
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_lite4
+    Crop Pct: '0.92'
+    Image Size: '380'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1640
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_lite4-741542c3.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.54%
+      Top 5 Accuracy: 95.66%
 -->

--- a/modelindex/models/tf-efficientnet.md
+++ b/modelindex/models/tf-efficientnet.md
@@ -11,7 +11,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('tf_efficientnet_b1', pretrained=True)
+model = timm.create_model('tf_efficientnet_b0', pretrained=True)
 model.eval()
 ```
 
@@ -57,14 +57,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `tf_efficientnet_b1`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_b0`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('tf_efficientnet_b1', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('tf_efficientnet_b0', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -87,176 +87,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF EfficientNet
+  Paper:
+    Title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    URL: https://paperswithcode.com/paper/efficientnet-rethinking-model-scaling-for
 Models:
-- Name: tf_efficientnet_b1
-  Metadata:
-    FLOPs: 883633200
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 31512534
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b1
-    LR: 0.256
-    Crop Pct: '0.882'
-    Momentum: 0.9
-    Image Size: '240'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1251
-  In Collection: TF EfficientNet
-- Name: tf_efficientnet_b4
-  Metadata:
-    FLOPs: 5749638672
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Training Resources: TPUv3 Cloud TPU
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 77989689
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: tf_efficientnet_b4
-    LR: 0.256
-    Crop Pct: '0.922'
-    Momentum: 0.9
-    Image Size: '380'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1281
-  Config: ''
-  In Collection: TF EfficientNet
-- Name: tf_efficientnet_b2
-  Metadata:
-    FLOPs: 1234321170
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 36797929
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b2
-    LR: 0.256
-    Crop Pct: '0.89'
-    Momentum: 0.9
-    Image Size: '260'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1261
-  In Collection: TF EfficientNet
-- Name: tf_efficientnet_b3
-  Metadata:
-    FLOPs: 2275247568
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 49381362
-    Tasks:
-    - Image Classification
-    ID: tf_efficientnet_b3
-    LR: 0.256
-    Crop Pct: '0.904'
-    Momentum: 0.9
-    Image Size: '300'
-    Weight Decay: 1.0e-05
-    Interpolation: bicubic
-    RMSProp Decay: 0.9
-    Label Smoothing: 0.1
-    BatchNorm Momentum: 0.99
-  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1271
-  In Collection: TF EfficientNet
 - Name: tf_efficientnet_b0
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 488688572
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
-    Training Resources: TPUv3 Cloud TPU
+    Parameters: 5290000
+    File Size: 21383997
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -267,14 +110,23 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 21383997
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: TPUv3 Cloud TPU
     ID: tf_efficientnet_b0
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -282,21 +134,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1241
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b0_aa-827b6e33.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.85%
+      Top 5 Accuracy: 93.23%
+- Name: tf_efficientnet_b1
   In Collection: TF EfficientNet
-- Name: tf_efficientnet_b5
   Metadata:
-    FLOPs: 13176501888
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    FLOPs: 883633200
+    Parameters: 7790000
+    File Size: 31512534
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -307,13 +157,207 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 122403150
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b1
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1251
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b1_aa-ea7a6ee0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.84%
+      Top 5 Accuracy: 94.2%
+- Name: tf_efficientnet_b2
+  In Collection: TF EfficientNet
+  Metadata:
+    FLOPs: 1234321170
+    Parameters: 9110000
+    File Size: 36797929
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b2
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1261
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b2_aa-60c94f97.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.07%
+      Top 5 Accuracy: 94.9%
+- Name: tf_efficientnet_b3
+  In Collection: TF EfficientNet
+  Metadata:
+    FLOPs: 2275247568
+    Parameters: 12230000
+    File Size: 49381362
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    ID: tf_efficientnet_b3
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1271
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b3_aa-84b4657e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.65%
+      Top 5 Accuracy: 95.72%
+- Name: tf_efficientnet_b4
+  In Collection: TF EfficientNet
+  Metadata:
+    FLOPs: 5749638672
+    Parameters: 19340000
+    File Size: 77989689
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: TPUv3 Cloud TPU
+    ID: tf_efficientnet_b4
+    LR: 0.256
+    Epochs: 350
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Batch Size: 2048
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1281
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b4_aa-818f208c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.03%
+      Top 5 Accuracy: 96.3%
+- Name: tf_efficientnet_b5
+  In Collection: TF EfficientNet
+  Metadata:
+    FLOPs: 13176501888
+    Parameters: 30390000
+    File Size: 122403150
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b5
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.934'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '456'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -321,20 +365,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1291
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_ra-9a3e5369.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.81%
+      Top 5 Accuracy: 96.75%
 - Name: tf_efficientnet_b6
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 24180518488
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 43040000
+    File Size: 173232007
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -345,13 +388,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 173232007
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b6
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.942'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '528'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -359,20 +411,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1301
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b6_aa-80ba17e4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.11%
+      Top 5 Accuracy: 96.89%
 - Name: tf_efficientnet_b7
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 48205304880
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 66349999
+    File Size: 266850607
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -383,13 +434,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 266850607
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b7
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.949'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '600'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -397,20 +457,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1312
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b7_ra-6c08e654.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.93%
+      Top 5 Accuracy: 97.2%
 - Name: tf_efficientnet_b8
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 80962956270
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Label Smoothing
-    - RMSProp
-    - Stochastic Depth
-    - Weight Decay
+    Parameters: 87410000
+    File Size: 351379853
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -421,13 +480,22 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 351379853
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_b8
     LR: 0.256
+    Epochs: 350
     Crop Pct: '0.954'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '672'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -435,12 +503,19 @@ Models:
     Label Smoothing: 0.1
     BatchNorm Momentum: 0.99
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1323
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b8_ra-572d5dd9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.35%
+      Top 5 Accuracy: 97.39%
 - Name: tf_efficientnet_el
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 9356616096
-    Training Data:
-    - ImageNet
+    Parameters: 10590000
+    File Size: 42800271
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -451,20 +526,28 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 42800271
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_el
     Crop Pct: '0.904'
     Image Size: '300'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1551
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_el-5143854e.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.45%
+      Top 5 Accuracy: 95.17%
 - Name: tf_efficientnet_em
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 3636607040
-    Training Data:
-    - ImageNet
+    Parameters: 6900000
+    File Size: 27933644
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -475,20 +558,28 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 27933644
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_em
     Crop Pct: '0.882'
     Image Size: '240'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1541
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_em-e78cfe58.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.71%
+      Top 5 Accuracy: 94.33%
 - Name: tf_efficientnet_es
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 2057577472
-    Training Data:
-    - ImageNet
+    Parameters: 5440000
+    File Size: 22008479
     Architecture:
     - 1x1 Convolution
     - Average Pooling
@@ -499,23 +590,40 @@ Models:
     - Inverted Residual Block
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 22008479
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: tf_efficientnet_es
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1531
-  In Collection: TF EfficientNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_es-ca1afbfe.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.28%
+      Top 5 Accuracy: 93.6%
 - Name: tf_efficientnet_l2_ns_475
+  In Collection: TF EfficientNet
   Metadata:
     FLOPs: 217795669644
-    Epochs: 350
-    Batch Size: 2048
-    Training Data:
-    - ImageNet
-    - JFT-300M
+    Parameters: 480310000
+    File Size: 1925950424
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    Tasks:
+    - Image Classification
     Training Techniques:
     - AutoAugment
     - FixRes
@@ -524,26 +632,17 @@ Models:
     - RMSProp
     - RandAugment
     - Weight Decay
+    Training Data:
+    - ImageNet
+    - JFT-300M
     Training Resources: TPUv3 Cloud TPU
-    Architecture:
-    - 1x1 Convolution
-    - Average Pooling
-    - Batch Normalization
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - Inverted Residual Block
-    - Squeeze-and-Excitation Block
-    - Swish
-    File Size: 1925950424
-    Tasks:
-    - Image Classification
-    Training Time: ''
     ID: tf_efficientnet_l2_ns_475
     LR: 0.128
+    Epochs: 350
     Dropout: 0.5
     Crop Pct: '0.936'
     Momentum: 0.9
+    Batch Size: 2048
     Image Size: '475'
     Weight Decay: 1.0e-05
     Interpolation: bicubic
@@ -552,13 +651,11 @@ Models:
     BatchNorm Momentum: 0.99
     Stochastic Depth Survival: 0.8
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1509
-  Config: ''
-  In Collection: TF EfficientNet
-Collections:
-- Name: TF EfficientNet
-  Paper:
-    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_l2_ns_475-bebbd00a.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 88.24%
+      Top 5 Accuracy: 98.55%
 -->

--- a/modelindex/models/tf-efficientnet.md
+++ b/modelindex/models/tf-efficientnet.md
@@ -558,7 +558,7 @@ Collections:
 - Name: TF EfficientNet
   Paper:
     title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
-    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+    url: https://paperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/tf-efficientnet.md
+++ b/modelindex/models/tf-efficientnet.md
@@ -1,0 +1,564 @@
+# Summary
+
+**EfficientNet** is a convolutional neural network architecture and scaling method that uniformly scales all dimensions of depth/width/resolution using a *compound coefficient*. Unlike conventional practice that arbitrary scales  these factors, the EfficientNet scaling method uniformly scales network width, depth, and resolution with a set of fixed scaling coefficients. For example, if we want to use $2^N$ times more computational resources, then we can simply increase the network depth by $\alpha ^ N$,  width by $\beta ^ N$, and image size by $\gamma ^ N$, where $\alpha, \beta, \gamma$ are constant coefficients determined by a small grid search on the original small model. EfficientNet uses a compound coefficient $\phi$ to uniformly scales network width, depth, and resolution in a  principled way.
+
+The compound scaling method is justified by the intuition that if the input image is bigger, then the network needs more layers to increase the receptive field and more channels to capture more fine-grained patterns on the bigger image.
+
+The base EfficientNet-B0 network is based on the inverted bottleneck residual blocks of [MobileNetV2](https://paperswithcode.com/method/mobilenetv2), in addition to [squeeze-and-excitation blocks](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('tf_efficientnet_b1', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `tf_efficientnet_b1`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('tf_efficientnet_b1', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2020efficientnet,
+      title={EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2020},
+      eprint={1905.11946},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+```
+
+<!--
+Models:
+- Name: tf_efficientnet_b1
+  Metadata:
+    FLOPs: 883633200
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 31512534
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b1
+    LR: 0.256
+    Crop Pct: '0.882'
+    Momentum: 0.9
+    Image Size: '240'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1251
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b4
+  Metadata:
+    FLOPs: 5749638672
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Resources: TPUv3 Cloud TPU
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 77989689
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b4
+    LR: 0.256
+    Crop Pct: '0.922'
+    Momentum: 0.9
+    Image Size: '380'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1281
+  Config: ''
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b2
+  Metadata:
+    FLOPs: 1234321170
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 36797929
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b2
+    LR: 0.256
+    Crop Pct: '0.89'
+    Momentum: 0.9
+    Image Size: '260'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1261
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b3
+  Metadata:
+    FLOPs: 2275247568
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 49381362
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b3
+    LR: 0.256
+    Crop Pct: '0.904'
+    Momentum: 0.9
+    Image Size: '300'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1271
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b0
+  Metadata:
+    FLOPs: 488688572
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Training Resources: TPUv3 Cloud TPU
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 21383997
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_b0
+    LR: 0.256
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1241
+  Config: ''
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b5
+  Metadata:
+    FLOPs: 13176501888
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 122403150
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b5
+    LR: 0.256
+    Crop Pct: '0.934'
+    Momentum: 0.9
+    Image Size: '456'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1291
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b6
+  Metadata:
+    FLOPs: 24180518488
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 173232007
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b6
+    LR: 0.256
+    Crop Pct: '0.942'
+    Momentum: 0.9
+    Image Size: '528'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1301
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b7
+  Metadata:
+    FLOPs: 48205304880
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 266850607
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b7
+    LR: 0.256
+    Crop Pct: '0.949'
+    Momentum: 0.9
+    Image Size: '600'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1312
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_b8
+  Metadata:
+    FLOPs: 80962956270
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Label Smoothing
+    - RMSProp
+    - Stochastic Depth
+    - Weight Decay
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 351379853
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_b8
+    LR: 0.256
+    Crop Pct: '0.954'
+    Momentum: 0.9
+    Image Size: '672'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1323
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_el
+  Metadata:
+    FLOPs: 9356616096
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 42800271
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_el
+    Crop Pct: '0.904'
+    Image Size: '300'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1551
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_em
+  Metadata:
+    FLOPs: 3636607040
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 27933644
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_em
+    Crop Pct: '0.882'
+    Image Size: '240'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1541
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_es
+  Metadata:
+    FLOPs: 2057577472
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 22008479
+    Tasks:
+    - Image Classification
+    ID: tf_efficientnet_es
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1531
+  In Collection: TF EfficientNet
+- Name: tf_efficientnet_l2_ns_475
+  Metadata:
+    FLOPs: 217795669644
+    Epochs: 350
+    Batch Size: 2048
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - AutoAugment
+    - FixRes
+    - Label Smoothing
+    - Noisy Student
+    - RMSProp
+    - RandAugment
+    - Weight Decay
+    Training Resources: TPUv3 Cloud TPU
+    Architecture:
+    - 1x1 Convolution
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inverted Residual Block
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 1925950424
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tf_efficientnet_l2_ns_475
+    LR: 0.128
+    Dropout: 0.5
+    Crop Pct: '0.936'
+    Momentum: 0.9
+    Image Size: '475'
+    Weight Decay: 1.0e-05
+    Interpolation: bicubic
+    RMSProp Decay: 0.9
+    Label Smoothing: 0.1
+    BatchNorm Momentum: 0.99
+    Stochastic Depth Survival: 0.8
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1509
+  Config: ''
+  In Collection: TF EfficientNet
+Collections:
+- Name: TF EfficientNet
+  Paper:
+    title: 'EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks'
+    url: https://papperswithcode.com//paper/efficientnet-rethinking-model-scaling-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/tf-inception-v3.md
+++ b/modelindex/models/tf-inception-v3.md
@@ -1,0 +1,139 @@
+# Summary
+
+**Inception v3** is a convolutional neural network architecture from the Inception family that makes several improvements including using [Label Smoothing](https://paperswithcode.com/method/label-smoothing), Factorized 7 x 7 convolutions, and the use of an [auxiliary classifer](https://paperswithcode.com/method/auxiliary-classifier) to propagate label information lower down the network (along with the use of batch normalization for layers in the sidehead). The key building block is an [Inception Module](https://paperswithcode.com/method/inception-v3-module).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('tf_inception_v3', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `tf_inception_v3`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('tf_inception_v3', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/SzegedyVISW15,
+  author    = {Christian Szegedy and
+               Vincent Vanhoucke and
+               Sergey Ioffe and
+               Jonathon Shlens and
+               Zbigniew Wojna},
+  title     = {Rethinking the Inception Architecture for Computer Vision},
+  journal   = {CoRR},
+  volume    = {abs/1512.00567},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.00567},
+  archivePrefix = {arXiv},
+  eprint    = {1512.00567},
+  timestamp = {Mon, 13 Aug 2018 16:49:07 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/SzegedyVISW15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: tf_inception_v3
+  Metadata:
+    FLOPs: 7352418880
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - Gradient Clipping
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Resources: 50x NVIDIA Kepler GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Auxiliary Classifier
+    - Average Pooling
+    - Average Pooling
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - Inception-v3 Module
+    - Max Pooling
+    - ReLU
+    - Softmax
+    File Size: 95549439
+    Tasks:
+    - Image Classification
+    ID: tf_inception_v3
+    LR: 0.045
+    Dropout: 0.2
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L449
+  In Collection: TF Inception v3
+Collections:
+- Name: TF Inception v3
+  Paper:
+    title: Rethinking the Inception Architecture for Computer Vision
+    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/tf-inception-v3.md
+++ b/modelindex/models/tf-inception-v3.md
@@ -133,7 +133,7 @@ Collections:
 - Name: TF Inception v3
   Paper:
     title: Rethinking the Inception Architecture for Computer Vision
-    url: https://papperswithcode.com//paper/rethinking-the-inception-architecture-for
+    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/tf-inception-v3.md
+++ b/modelindex/models/tf-inception-v3.md
@@ -92,18 +92,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF Inception v3
+  Paper:
+    Title: Rethinking the Inception Architecture for Computer Vision
+    URL: https://paperswithcode.com/paper/rethinking-the-inception-architecture-for
 Models:
 - Name: tf_inception_v3
+  In Collection: TF Inception v3
   Metadata:
     FLOPs: 7352418880
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - Gradient Clipping
-    - Label Smoothing
-    - RMSProp
-    - Weight Decay
-    Training Resources: 50x NVIDIA Kepler GPUs
+    Parameters: 23830000
+    File Size: 95549439
     Architecture:
     - 1x1 Convolution
     - Auxiliary Classifier
@@ -117,9 +118,16 @@ Models:
     - Max Pooling
     - ReLU
     - Softmax
-    File Size: 95549439
     Tasks:
     - Image Classification
+    Training Techniques:
+    - Gradient Clipping
+    - Label Smoothing
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 50x NVIDIA Kepler GPUs
     ID: tf_inception_v3
     LR: 0.045
     Dropout: 0.2
@@ -128,12 +136,11 @@ Models:
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/inception_v3.py#L449
-  In Collection: TF Inception v3
-Collections:
-- Name: TF Inception v3
-  Paper:
-    title: Rethinking the Inception Architecture for Computer Vision
-    url: https://paperswithcode.com//paper/rethinking-the-inception-architecture-for
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_inception_v3-e0069de4.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.87%
+      Top 5 Accuracy: 93.65%
 -->

--- a/modelindex/models/tf-mixnet.md
+++ b/modelindex/models/tf-mixnet.md
@@ -1,0 +1,169 @@
+# Summary
+
+**MixNet** is a type of convolutional neural network discovered via AutoML that utilises [MixConvs](https://paperswithcode.com/method/mixconv) instead of regular [depthwise convolutions](https://paperswithcode.com/method/depthwise-convolution).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('tf_mixnet_l', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `tf_mixnet_l`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('tf_mixnet_l', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{tan2019mixconv,
+      title={MixConv: Mixed Depthwise Convolutional Kernels}, 
+      author={Mingxing Tan and Quoc V. Le},
+      year={2019},
+      eprint={1907.09595},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: tf_mixnet_l
+  Metadata:
+    FLOPs: 688674516
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 29620756
+    Tasks:
+    - Image Classification
+    ID: tf_mixnet_l
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1720
+  In Collection: TF MixNet
+- Name: tf_mixnet_m
+  Metadata:
+    FLOPs: 416633502
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 20310871
+    Tasks:
+    - Image Classification
+    ID: tf_mixnet_m
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1709
+  In Collection: TF MixNet
+- Name: tf_mixnet_s
+  Metadata:
+    FLOPs: 302587678
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - MNAS
+    Architecture:
+    - Batch Normalization
+    - Dense Connections
+    - Dropout
+    - Global Average Pooling
+    - Grouped Convolution
+    - MixConv
+    - Squeeze-and-Excitation Block
+    - Swish
+    File Size: 16738218
+    Tasks:
+    - Image Classification
+    ID: tf_mixnet_s
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1698
+  In Collection: TF MixNet
+Collections:
+- Name: TF MixNet
+  Paper:
+    title: 'MixConv: Mixed Depthwise Convolutional Kernels'
+    url: https://papperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/tf-mixnet.md
+++ b/modelindex/models/tf-mixnet.md
@@ -163,7 +163,7 @@ Collections:
 - Name: TF MixNet
   Paper:
     title: 'MixConv: Mixed Depthwise Convolutional Kernels'
-    url: https://papperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
+    url: https://paperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/tf-mixnet.md
+++ b/modelindex/models/tf-mixnet.md
@@ -83,14 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF MixNet
+  Paper:
+    Title: 'MixConv: Mixed Depthwise Convolutional Kernels'
+    URL: https://paperswithcode.com/paper/mixnet-mixed-depthwise-convolutional-kernels
 Models:
 - Name: tf_mixnet_l
+  In Collection: TF MixNet
   Metadata:
     FLOPs: 688674516
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
+    Parameters: 7330000
+    File Size: 29620756
     Architecture:
     - Batch Normalization
     - Dense Connections
@@ -100,22 +105,30 @@ Models:
     - MixConv
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 29620756
     Tasks:
     - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
     ID: tf_mixnet_l
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1720
-  In Collection: TF MixNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mixnet_l-6c92e0c8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.78%
+      Top 5 Accuracy: 94.0%
 - Name: tf_mixnet_m
+  In Collection: TF MixNet
   Metadata:
     FLOPs: 416633502
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
+    Parameters: 5010000
+    File Size: 20310871
     Architecture:
     - Batch Normalization
     - Dense Connections
@@ -125,22 +138,30 @@ Models:
     - MixConv
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 20310871
     Tasks:
     - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
     ID: tf_mixnet_m
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1709
-  In Collection: TF MixNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mixnet_m-0f4d8805.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 76.96%
+      Top 5 Accuracy: 93.16%
 - Name: tf_mixnet_s
+  In Collection: TF MixNet
   Metadata:
     FLOPs: 302587678
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - MNAS
+    Parameters: 4130000
+    File Size: 16738218
     Architecture:
     - Batch Normalization
     - Dense Connections
@@ -150,20 +171,22 @@ Models:
     - MixConv
     - Squeeze-and-Excitation Block
     - Swish
-    File Size: 16738218
     Tasks:
     - Image Classification
+    Training Techniques:
+    - MNAS
+    Training Data:
+    - ImageNet
     ID: tf_mixnet_s
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/efficientnet.py#L1698
-  In Collection: TF MixNet
-Collections:
-- Name: TF MixNet
-  Paper:
-    title: 'MixConv: Mixed Depthwise Convolutional Kernels'
-    url: https://paperswithcode.com//paper/mixnet-mixed-depthwise-convolutional-kernels
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mixnet_s-89d3354b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.68%
+      Top 5 Accuracy: 92.64%
 -->

--- a/modelindex/models/tf-mobilenet-v3.md
+++ b/modelindex/models/tf-mobilenet-v3.md
@@ -326,7 +326,7 @@ Collections:
 - Name: TF MobileNet V3
   Paper:
     title: Searching for MobileNetV3
-    url: https://papperswithcode.com//paper/searching-for-mobilenetv3
+    url: https://paperswithcode.com//paper/searching-for-mobilenetv3
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/tf-mobilenet-v3.md
+++ b/modelindex/models/tf-mobilenet-v3.md
@@ -1,0 +1,332 @@
+# Summary
+
+**MobileNetV3** is a convolutional neural network that is designed for mobile phone CPUs. The network design includes the use of a [hard swish activation](https://paperswithcode.com/method/hard-swish) and [squeeze-and-excitation](https://paperswithcode.com/method/squeeze-and-excitation-block) modules in the [MBConv blocks](https://paperswithcode.com/method/inverted-residual-block).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('tf_mobilenetv3_large_075', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `tf_mobilenetv3_large_075`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('tf_mobilenetv3_large_075', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/abs-1905-02244,
+  author    = {Andrew Howard and
+               Mark Sandler and
+               Grace Chu and
+               Liang{-}Chieh Chen and
+               Bo Chen and
+               Mingxing Tan and
+               Weijun Wang and
+               Yukun Zhu and
+               Ruoming Pang and
+               Vijay Vasudevan and
+               Quoc V. Le and
+               Hartwig Adam},
+  title     = {Searching for MobileNetV3},
+  journal   = {CoRR},
+  volume    = {abs/1905.02244},
+  year      = {2019},
+  url       = {http://arxiv.org/abs/1905.02244},
+  archivePrefix = {arXiv},
+  eprint    = {1905.02244},
+  timestamp = {Tue, 12 Jan 2021 15:30:06 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-1905-02244.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: tf_mobilenetv3_large_075
+  Metadata:
+    FLOPs: 194323712
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 16097377
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_large_075
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L394
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_large_100
+  Metadata:
+    FLOPs: 274535288
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 22076649
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_large_100
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L403
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_large_minimal_100
+  Metadata:
+    FLOPs: 267216928
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 4x4 TPU Pod
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 15836368
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_large_minimal_100
+    LR: 0.1
+    Dropout: 0.8
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 1.0e-05
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L412
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_small_075
+  Metadata:
+    FLOPs: 48457664
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 8242701
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_small_075
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bilinear
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L421
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_small_100
+  Metadata:
+    FLOPs: 65450600
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 10256398
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_small_100
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bilinear
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L430
+  In Collection: TF MobileNet V3
+- Name: tf_mobilenetv3_small_minimal_100
+  Metadata:
+    FLOPs: 60827936
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Resources: 16x GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Dropout
+    - Global Average Pooling
+    - Hard Swish
+    - Inverted Residual Block
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Squeeze-and-Excitation Block
+    File Size: 8258083
+    Tasks:
+    - Image Classification
+    ID: tf_mobilenetv3_small_minimal_100
+    LR: 0.045
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 4.0e-05
+    Interpolation: bilinear
+    RMSProp Decay: 0.9
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L439
+  In Collection: TF MobileNet V3
+Collections:
+- Name: TF MobileNet V3
+  Paper:
+    title: Searching for MobileNetV3
+    url: https://papperswithcode.com//paper/searching-for-mobilenetv3
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/tf-mobilenet-v3.md
+++ b/modelindex/models/tf-mobilenet-v3.md
@@ -99,17 +99,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TF MobileNet V3
+  Paper:
+    Title: Searching for MobileNetV3
+    URL: https://paperswithcode.com/paper/searching-for-mobilenetv3
 Models:
 - Name: tf_mobilenetv3_large_075
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 194323712
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
+    Parameters: 3990000
+    File Size: 16097377
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -124,29 +126,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 16097377
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
     ID: tf_mobilenetv3_large_075
     LR: 0.1
     Dropout: 0.8
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L394
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_large_075-150ee8b0.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 73.45%
+      Top 5 Accuracy: 91.34%
 - Name: tf_mobilenetv3_large_100
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 274535288
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
+    Parameters: 5480000
+    File Size: 22076649
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -161,29 +171,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 22076649
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
     ID: tf_mobilenetv3_large_100
     LR: 0.1
     Dropout: 0.8
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L403
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_large_100-427764d5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 75.51%
+      Top 5 Accuracy: 92.61%
 - Name: tf_mobilenetv3_large_minimal_100
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 267216928
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 4x4 TPU Pod
+    Parameters: 3920000
+    File Size: 15836368
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -198,29 +216,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 15836368
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 4x4 TPU Pod
     ID: tf_mobilenetv3_large_minimal_100
     LR: 0.1
     Dropout: 0.8
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 1.0e-05
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L412
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_large_minimal_100-8596ae28.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 72.24%
+      Top 5 Accuracy: 90.64%
 - Name: tf_mobilenetv3_small_075
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 48457664
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 2040000
+    File Size: 8242701
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -235,29 +261,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 8242701
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: tf_mobilenetv3_small_075
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bilinear
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L421
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_small_075-da427f52.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 65.72%
+      Top 5 Accuracy: 86.13%
 - Name: tf_mobilenetv3_small_100
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 65450600
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 2540000
+    File Size: 10256398
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -272,29 +306,37 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 10256398
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: tf_mobilenetv3_small_100
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bilinear
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L430
-  In Collection: TF MobileNet V3
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_small_100-37f49e2b.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 67.92%
+      Top 5 Accuracy: 87.68%
 - Name: tf_mobilenetv3_small_minimal_100
+  In Collection: TF MobileNet V3
   Metadata:
     FLOPs: 60827936
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - RMSProp
-    - Weight Decay
-    Training Resources: 16x GPUs
+    Parameters: 2040000
+    File Size: 8258083
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -309,24 +351,29 @@ Models:
     - Residual Connection
     - Softmax
     - Squeeze-and-Excitation Block
-    File Size: 8258083
     Tasks:
     - Image Classification
+    Training Techniques:
+    - RMSProp
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 16x GPUs
     ID: tf_mobilenetv3_small_minimal_100
     LR: 0.045
     Crop Pct: '0.875'
     Momentum: 0.9
+    Batch Size: 4096
     Image Size: '224'
     Weight Decay: 4.0e-05
     Interpolation: bilinear
     RMSProp Decay: 0.9
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/mobilenetv3.py#L439
-  In Collection: TF MobileNet V3
-Collections:
-- Name: TF MobileNet V3
-  Paper:
-    title: Searching for MobileNetV3
-    url: https://paperswithcode.com//paper/searching-for-mobilenetv3
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_mobilenetv3_small_minimal_100-922a7843.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 62.91%
+      Top 5 Accuracy: 84.24%
 -->

--- a/modelindex/models/tresnet.md
+++ b/modelindex/models/tresnet.md
@@ -1,0 +1,316 @@
+# Summary
+
+A **TResNet** is a variant on a [ResNet](https://paperswithcode.com/method/resnet) that aim to boost accuracy while maintaining GPU training and inference efficiency.  They contain several design tricks including a SpaceToDepth stem, [Anti-Alias downsampling](https://paperswithcode.com/method/anti-alias-downsampling), In-Place Activated BatchNorm, Blocks selection and [squeeze-and-excitation layers](https://paperswithcode.com/method/squeeze-and-excitation-block).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('tresnet_l', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `tresnet_l`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('tresnet_l', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{ridnik2020tresnet,
+      title={TResNet: High Performance GPU-Dedicated Architecture}, 
+      author={Tal Ridnik and Hussam Lawen and Asaf Noy and Emanuel Ben Baruch and Gilad Sharir and Itamar Friedman},
+      year={2020},
+      eprint={2003.13630},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: tresnet_l
+  Metadata:
+    FLOPs: 10873416792
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 224440219
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_l
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L267
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_l_448
+  Metadata:
+    FLOPs: 43488238584
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 224440219
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_l_448
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '448'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L285
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_m
+  Metadata:
+    FLOPs: 5733048064
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 125861314
+    Tasks:
+    - Image Classification
+    Training Time: < 24 hours
+    ID: tresnet_m
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L261
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_m_448
+  Metadata:
+    FLOPs: 22929743104
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 125861314
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_m_448
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '448'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L279
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_xl
+  Metadata:
+    FLOPs: 15162534034
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 314378965
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_xl
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L273
+  Config: ''
+  In Collection: TResNet
+- Name: tresnet_xl_448
+  Metadata:
+    FLOPs: 60641712730
+    Epochs: 300
+    Training Data:
+    - ImageNet
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Resources: 8x NVIDIA 100 GPUs
+    Architecture:
+    - 1x1 Convolution
+    - Anti-Alias Downsampling
+    - Convolution
+    - Global Average Pooling
+    - InPlace-ABN
+    - Leaky ReLU
+    - ReLU
+    - Residual Connection
+    - Squeeze-and-Excitation Block
+    File Size: 224440219
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: tresnet_xl_448
+    LR: 0.01
+    Crop Pct: '0.875'
+    Momentum: 0.9
+    Image Size: '448'
+    Weight Decay: 0.0001
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L291
+  Config: ''
+  In Collection: TResNet
+Collections:
+- Name: TResNet
+  Paper:
+    title: 'TResNet: High Performance GPU-Dedicated Architecture'
+    url: https://papperswithcode.com//paper/tresnet-high-performance-gpu-dedicated
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/tresnet.md
+++ b/modelindex/models/tresnet.md
@@ -310,7 +310,7 @@ Collections:
 - Name: TResNet
   Paper:
     title: 'TResNet: High Performance GPU-Dedicated Architecture'
-    url: https://papperswithcode.com//paper/tresnet-high-performance-gpu-dedicated
+    url: https://paperswithcode.com//paper/tresnet-high-performance-gpu-dedicated
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/tresnet.md
+++ b/modelindex/models/tresnet.md
@@ -83,20 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: TResNet
+  Paper:
+    Title: 'TResNet: High Performance GPU-Dedicated Architecture'
+    URL: https://paperswithcode.com/paper/tresnet-high-performance-gpu-dedicated
 Models:
 - Name: tresnet_l
+  In Collection: TResNet
   Metadata:
     FLOPs: 10873416792
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 53456696
+    File Size: 224440219
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -107,33 +106,39 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 224440219
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_l
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L267
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_l_81_5-235b486c.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.49%
+      Top 5 Accuracy: 95.62%
 - Name: tresnet_l_448
+  In Collection: TResNet
   Metadata:
     FLOPs: 43488238584
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 53456696
+    File Size: 224440219
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -144,33 +149,39 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 224440219
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_l_448
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '448'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L285
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_l_448-940d0cd1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.26%
+      Top 5 Accuracy: 95.98%
 - Name: tresnet_m
+  In Collection: TResNet
   Metadata:
     FLOPs: 5733048064
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 41282200
+    File Size: 125861314
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -181,33 +192,40 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 125861314
     Tasks:
     - Image Classification
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     Training Time: < 24 hours
     ID: tresnet_m
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L261
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_m_80_8-dbc13962.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 80.8%
+      Top 5 Accuracy: 94.86%
 - Name: tresnet_m_448
+  In Collection: TResNet
   Metadata:
     FLOPs: 22929743104
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 29278464
+    File Size: 125861314
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -218,33 +236,39 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 125861314
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_m_448
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '448'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L279
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_m_448-bc359d10.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.72%
+      Top 5 Accuracy: 95.57%
 - Name: tresnet_xl
+  In Collection: TResNet
   Metadata:
     FLOPs: 15162534034
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 75646610
+    File Size: 314378965
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -255,33 +279,39 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 314378965
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_xl
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '224'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L273
-  Config: ''
-  In Collection: TResNet
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_xl_82_0-a2d51b00.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 82.05%
+      Top 5 Accuracy: 95.93%
 - Name: tresnet_xl_448
+  In Collection: TResNet
   Metadata:
     FLOPs: 60641712730
-    Epochs: 300
-    Training Data:
-    - ImageNet
-    Training Techniques:
-    - AutoAugment
-    - Cutout
-    - Label Smoothing
-    - SGD with Momentum
-    - Weight Decay
-    Training Resources: 8x NVIDIA 100 GPUs
+    Parameters: 75646610
+    File Size: 224440219
     Architecture:
     - 1x1 Convolution
     - Anti-Alias Downsampling
@@ -292,25 +322,31 @@ Models:
     - ReLU
     - Residual Connection
     - Squeeze-and-Excitation Block
-    File Size: 224440219
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - AutoAugment
+    - Cutout
+    - Label Smoothing
+    - SGD with Momentum
+    - Weight Decay
+    Training Data:
+    - ImageNet
+    Training Resources: 8x NVIDIA 100 GPUs
     ID: tresnet_xl_448
     LR: 0.01
+    Epochs: 300
     Crop Pct: '0.875'
     Momentum: 0.9
     Image Size: '448'
     Weight Decay: 0.0001
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/9a25fdf3ad0414b4d66da443fe60ae0aa14edc84/timm/models/tresnet.py#L291
-  Config: ''
-  In Collection: TResNet
-Collections:
-- Name: TResNet
-  Paper:
-    title: 'TResNet: High Performance GPU-Dedicated Architecture'
-    url: https://paperswithcode.com//paper/tresnet-high-performance-gpu-dedicated
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-tresnet/tresnet_l_448-940d0cd1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.06%
+      Top 5 Accuracy: 96.19%
 -->

--- a/modelindex/models/vision-transformer.md
+++ b/modelindex/models/vision-transformer.md
@@ -333,7 +333,7 @@ Collections:
 - Name: Vision Transformer
   Paper:
     title: 'An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale'
-    url: https://papperswithcode.com//paper/an-image-is-worth-16x16-words-transformers-1
+    url: https://paperswithcode.com//paper/an-image-is-worth-16x16-words-transformers-1
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/vision-transformer.md
+++ b/modelindex/models/vision-transformer.md
@@ -7,7 +7,7 @@ To load a pretrained model:
 
 ```python
 import timm
-model = timm.create_model('vit_large_patch16_384', pretrained=True)
+model = timm.create_model('vit_base_patch16_224', pretrained=True)
 model.eval()
 ```
 
@@ -53,14 +53,14 @@ for i in range(top5_prob.size(0)):
 # [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
 ```
 
-Replace the model name with the variant you want to use, e.g. `vit_large_patch16_384`. You can find the IDs in the model summaries at the top of this page.
+Replace the model name with the variant you want to use, e.g. `vit_base_patch16_224`. You can find the IDs in the model summaries at the top of this page.
 
 To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
 
 ## How do I finetune this model?
 You can finetune any of the pre-trained models just by changing the classifier (the last layer).
 ```python
-model = timm.create_model('vit_large_patch16_384', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+model = timm.create_model('vit_base_patch16_224', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
 ```
 To finetune on your own dataset, you have to write a training loop or adapt [timm's training
 script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
@@ -83,55 +83,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Vision Transformer
+  Paper:
+    Title: 'An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale'
+    URL: https://paperswithcode.com/paper/an-image-is-worth-16x16-words-transformers-1
 Models:
-- Name: vit_large_patch16_384
-  Metadata:
-    FLOPs: 174702764032
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
-    Architecture:
-    - Attention Dropout
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - GELU
-    - Layer Normalization
-    - Multi-Head Attention
-    - Scaled Dot-Product Attention
-    - Tanh Activation
-    File Size: 1218907013
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: vit_large_patch16_384
-    Crop Pct: '1.0'
-    Momentum: 0.9
-    Image Size: '384'
-    Weight Decay: 0.0
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L561
-  Config: ''
-  In Collection: Vision Transformer
 - Name: vit_base_patch16_224
+  In Collection: Vision Transformer
   Metadata:
     FLOPs: 67394605056
-    Epochs: 90
-    Batch Size: 4096
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    Parameters: 86570000
+    File Size: 346292833
     Architecture:
     - Attention Dropout
     - Convolution
@@ -142,33 +106,40 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 346292833
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_base_patch16_224
     LR: 0.0008
+    Epochs: 90
     Dropout: 0.0
     Crop Pct: '0.9'
+    Batch Size: 4096
     Image Size: '224'
     Warmup Steps: 10000
     Weight Decay: 0.03
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L503
-  Config: ''
-  In Collection: Vision Transformer
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_base_p16_224-80ecf9dd.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.78%
+      Top 5 Accuracy: 96.13%
 - Name: vit_base_patch16_384
+  In Collection: Vision Transformer
   Metadata:
     FLOPs: 49348245504
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    Parameters: 86860000
+    File Size: 347460194
     Architecture:
     - Attention Dropout
     - Convolution
@@ -179,66 +150,37 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 347460194
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_base_patch16_384
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '384'
     Weight Decay: 0.0
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L522
-  Config: ''
-  In Collection: Vision Transformer
-- Name: vit_large_patch16_224
-  Metadata:
-    FLOPs: 119294746624
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
-    Architecture:
-    - Attention Dropout
-    - Convolution
-    - Dense Connections
-    - Dropout
-    - GELU
-    - Layer Normalization
-    - Multi-Head Attention
-    - Scaled Dot-Product Attention
-    - Tanh Activation
-    File Size: 1217350532
-    Tasks:
-    - Image Classification
-    Training Time: ''
-    ID: vit_large_patch16_224
-    Crop Pct: '0.9'
-    Momentum: 0.9
-    Image Size: '224'
-    Weight Decay: 0.0
-    Interpolation: bicubic
-  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L542
-  Config: ''
-  In Collection: Vision Transformer
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_base_p16_384-83fb41ba.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.2%
+      Top 5 Accuracy: 97.22%
 - Name: vit_base_patch32_384
+  In Collection: Vision Transformer
   Metadata:
     FLOPs: 12656142336
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    Parameters: 88300000
+    File Size: 353210979
     Architecture:
     - Attention Dropout
     - Convolution
@@ -249,31 +191,37 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 353210979
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_base_patch32_384
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '384'
     Weight Decay: 0.0
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L532
-  Config: ''
-  In Collection: Vision Transformer
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_base_p32_384-830016f5.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.66%
+      Top 5 Accuracy: 96.13%
 - Name: vit_base_resnet50_384
+  In Collection: Vision Transformer
   Metadata:
     FLOPs: 49461491712
-    Batch Size: 512
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    Parameters: 98950000
+    File Size: 395854632
     Architecture:
     - Attention Dropout
     - Convolution
@@ -284,30 +232,37 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 395854632
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_base_resnet50_384
     Crop Pct: '1.0'
     Momentum: 0.9
+    Batch Size: 512
     Image Size: '384'
     Weight Decay: 0.0
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L653
-  Config: ''
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_base_resnet50_384-9fd3c705.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 84.99%
+      Top 5 Accuracy: 97.3%
+- Name: vit_large_patch16_224
   In Collection: Vision Transformer
-- Name: vit_small_patch16_224
   Metadata:
-    FLOPs: 28236450816
-    Training Data:
-    - ImageNet
-    - JFT-300M
-    Training Techniques:
-    - Cosine Annealing
-    - Gradient Clipping
-    - SGD with Momentum
-    Training Resources: TPUv3
+    FLOPs: 119294746624
+    Parameters: 304330000
+    File Size: 1217350532
     Architecture:
     - Attention Dropout
     - Convolution
@@ -318,22 +273,108 @@ Models:
     - Multi-Head Attention
     - Scaled Dot-Product Attention
     - Tanh Activation
-    File Size: 195031454
     Tasks:
     - Image Classification
-    Training Time: ''
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
+    ID: vit_large_patch16_224
+    Crop Pct: '0.9'
+    Momentum: 0.9
+    Batch Size: 512
+    Image Size: '224'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L542
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_large_p16_224-4ee7a4dc.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 83.06%
+      Top 5 Accuracy: 96.44%
+- Name: vit_large_patch16_384
+  In Collection: Vision Transformer
+  Metadata:
+    FLOPs: 174702764032
+    Parameters: 304720000
+    File Size: 1218907013
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
+    ID: vit_large_patch16_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Batch Size: 512
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L561
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-vitjx/jx_vit_large_p16_384-b3be5167.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 85.17%
+      Top 5 Accuracy: 97.36%
+- Name: vit_small_patch16_224
+  In Collection: Vision Transformer
+  Metadata:
+    FLOPs: 28236450816
+    Parameters: 48750000
+    File Size: 195031454
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    Tasks:
+    - Image Classification
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Resources: TPUv3
     ID: vit_small_patch16_224
     Crop Pct: '0.9'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L490
-  Config: ''
-  In Collection: Vision Transformer
-Collections:
-- Name: Vision Transformer
-  Paper:
-    title: 'An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale'
-    url: https://paperswithcode.com//paper/an-image-is-worth-16x16-words-transformers-1
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/vit_small_p16_224-15ec54c9.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 77.85%
+      Top 5 Accuracy: 93.42%
 -->

--- a/modelindex/models/vision-transformer.md
+++ b/modelindex/models/vision-transformer.md
@@ -1,0 +1,339 @@
+# Summary
+
+The **Vision Transformer** is a model for image classification that employs a Transformer-like architecture over patches of the image. This includes the use of [Multi-Head Attention](https://paperswithcode.com/method/multi-head-attention), [Scaled Dot-Product Attention](https://paperswithcode.com/method/scaled) and other architectural features seen in the [Transformer](https://paperswithcode.com/method/transformer) architecture traditionally used for NLP.
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('vit_large_patch16_384', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `vit_large_patch16_384`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('vit_large_patch16_384', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@misc{dosovitskiy2020image,
+      title={An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale}, 
+      author={Alexey Dosovitskiy and Lucas Beyer and Alexander Kolesnikov and Dirk Weissenborn and Xiaohua Zhai and Thomas Unterthiner and Mostafa Dehghani and Matthias Minderer and Georg Heigold and Sylvain Gelly and Jakob Uszkoreit and Neil Houlsby},
+      year={2020},
+      eprint={2010.11929},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: vit_large_patch16_384
+  Metadata:
+    FLOPs: 174702764032
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 1218907013
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_large_patch16_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L561
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_base_patch16_224
+  Metadata:
+    FLOPs: 67394605056
+    Epochs: 90
+    Batch Size: 4096
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 346292833
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_base_patch16_224
+    LR: 0.0008
+    Dropout: 0.0
+    Crop Pct: '0.9'
+    Image Size: '224'
+    Warmup Steps: 10000
+    Weight Decay: 0.03
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L503
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_base_patch16_384
+  Metadata:
+    FLOPs: 49348245504
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 347460194
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_base_patch16_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L522
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_large_patch16_224
+  Metadata:
+    FLOPs: 119294746624
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 1217350532
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_large_patch16_224
+    Crop Pct: '0.9'
+    Momentum: 0.9
+    Image Size: '224'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L542
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_base_patch32_384
+  Metadata:
+    FLOPs: 12656142336
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 353210979
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_base_patch32_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L532
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_base_resnet50_384
+  Metadata:
+    FLOPs: 49461491712
+    Batch Size: 512
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 395854632
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_base_resnet50_384
+    Crop Pct: '1.0'
+    Momentum: 0.9
+    Image Size: '384'
+    Weight Decay: 0.0
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L653
+  Config: ''
+  In Collection: Vision Transformer
+- Name: vit_small_patch16_224
+  Metadata:
+    FLOPs: 28236450816
+    Training Data:
+    - ImageNet
+    - JFT-300M
+    Training Techniques:
+    - Cosine Annealing
+    - Gradient Clipping
+    - SGD with Momentum
+    Training Resources: TPUv3
+    Architecture:
+    - Attention Dropout
+    - Convolution
+    - Dense Connections
+    - Dropout
+    - GELU
+    - Layer Normalization
+    - Multi-Head Attention
+    - Scaled Dot-Product Attention
+    - Tanh Activation
+    File Size: 195031454
+    Tasks:
+    - Image Classification
+    Training Time: ''
+    ID: vit_small_patch16_224
+    Crop Pct: '0.9'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/vision_transformer.py#L490
+  Config: ''
+  In Collection: Vision Transformer
+Collections:
+- Name: Vision Transformer
+  Paper:
+    title: 'An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale'
+    url: https://papperswithcode.com//paper/an-image-is-worth-16x16-words-transformers-1
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/wide-resnet.md
+++ b/modelindex/models/wide-resnet.md
@@ -89,12 +89,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Wide ResNet
+  Paper:
+    Title: Wide Residual Networks
+    URL: https://paperswithcode.com/paper/wide-residual-networks
 Models:
 - Name: wide_resnet101_2
+  In Collection: Wide ResNet
   Metadata:
     FLOPs: 29304929280
-    Training Data:
-    - ImageNet
+    Parameters: 126890000
+    File Size: 254695146
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -105,20 +112,28 @@ Models:
     - Residual Connection
     - Softmax
     - Wide Residual Block
-    File Size: 254695146
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: wide_resnet101_2
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bilinear
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/resnet.py#L802
-  In Collection: Wide ResNet
+  Weights: https://download.pytorch.org/models/wide_resnet101_2-32ee1156.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.85%
+      Top 5 Accuracy: 94.28%
 - Name: wide_resnet50_2
+  In Collection: Wide ResNet
   Metadata:
     FLOPs: 14688058368
-    Training Data:
-    - ImageNet
+    Parameters: 68880000
+    File Size: 275853271
     Architecture:
     - 1x1 Convolution
     - Batch Normalization
@@ -129,20 +144,20 @@ Models:
     - Residual Connection
     - Softmax
     - Wide Residual Block
-    File Size: 275853271
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: wide_resnet50_2
     Crop Pct: '0.875'
     Image Size: '224'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/resnet.py#L790
-  In Collection: Wide ResNet
-Collections:
-- Name: Wide ResNet
-  Paper:
-    title: Wide Residual Networks
-    url: https://paperswithcode.com//paper/wide-residual-networks
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/wide_resnet50_racm-8234f177.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 81.45%
+      Top 5 Accuracy: 95.52%
 -->

--- a/modelindex/models/wide-resnet.md
+++ b/modelindex/models/wide-resnet.md
@@ -1,0 +1,148 @@
+# Summary
+
+**Wide Residual Networks** are a variant on [ResNets](https://paperswithcode.com/method/resnet) where we decrease depth and increase the width of residual networks. This is achieved through the use of [wide residual blocks](https://paperswithcode.com/method/wide-residual-block).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('wide_resnet101_2', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `wide_resnet101_2`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('wide_resnet101_2', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/ZagoruykoK16,
+  author    = {Sergey Zagoruyko and
+               Nikos Komodakis},
+  title     = {Wide Residual Networks},
+  journal   = {CoRR},
+  volume    = {abs/1605.07146},
+  year      = {2016},
+  url       = {http://arxiv.org/abs/1605.07146},
+  archivePrefix = {arXiv},
+  eprint    = {1605.07146},
+  timestamp = {Mon, 13 Aug 2018 16:46:42 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/ZagoruykoK16.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+```
+
+<!--
+Models:
+- Name: wide_resnet101_2
+  Metadata:
+    FLOPs: 29304929280
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Wide Residual Block
+    File Size: 254695146
+    Tasks:
+    - Image Classification
+    ID: wide_resnet101_2
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bilinear
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/resnet.py#L802
+  In Collection: Wide ResNet
+- Name: wide_resnet50_2
+  Metadata:
+    FLOPs: 14688058368
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Batch Normalization
+    - Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    - Wide Residual Block
+    File Size: 275853271
+    Tasks:
+    - Image Classification
+    ID: wide_resnet50_2
+    Crop Pct: '0.875'
+    Image Size: '224'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/5f9aff395c224492e9e44248b15f44b5cc095d9c/timm/models/resnet.py#L790
+  In Collection: Wide ResNet
+Collections:
+- Name: Wide ResNet
+  Paper:
+    title: Wide Residual Networks
+    url: https://papperswithcode.com//paper/wide-residual-networks
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/wide-resnet.md
+++ b/modelindex/models/wide-resnet.md
@@ -142,7 +142,7 @@ Collections:
 - Name: Wide ResNet
   Paper:
     title: Wide Residual Networks
-    url: https://papperswithcode.com//paper/wide-residual-networks
+    url: https://paperswithcode.com//paper/wide-residual-networks
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/xception.md
+++ b/modelindex/models/xception.md
@@ -185,7 +185,7 @@ Collections:
 - Name: Xception
   Paper:
     title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
-    url: https://papperswithcode.com//paper/xception-deep-learning-with-depthwise
+    url: https://paperswithcode.com//paper/xception-deep-learning-with-depthwise
   type: model-index
 Type: model-index
 -->

--- a/modelindex/models/xception.md
+++ b/modelindex/models/xception.md
@@ -1,0 +1,191 @@
+# Summary
+
+**Xception** is a convolutional neural network architecture that relies solely on [depthwise separable convolution layers](https://paperswithcode.com/method/depthwise-separable-convolution).
+
+## How do I use this model on an image?
+To load a pretrained model:
+
+```python
+import timm
+model = timm.create_model('xception', pretrained=True)
+model.eval()
+```
+
+To load and preprocess the image:
+```python 
+import urllib
+from PIL import Image
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+config = resolve_data_config({}, model=model)
+transform = create_transform(**config)
+
+url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+urllib.request.urlretrieve(url, filename)
+img = Image.open(filename).convert('RGB')
+tensor = transform(img).unsqueeze(0) # transform and add batch dimension
+```
+
+To get the model predictions:
+```python
+import torch
+with torch.no_grad():
+    out = model(tensor)
+probabilities = torch.nn.functional.softmax(out[0], dim=0)
+print(probabilities.shape)
+# prints: torch.Size([1000])
+```
+
+To get the top-5 predictions class names:
+```python
+# Get imagenet class mappings
+url, filename = ("https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt", "imagenet_classes.txt")
+urllib.request.urlretrieve(url, filename) 
+with open("imagenet_classes.txt", "r") as f:
+    categories = [s.strip() for s in f.readlines()]
+
+# Print top categories per image
+top5_prob, top5_catid = torch.topk(probabilities, 5)
+for i in range(top5_prob.size(0)):
+    print(categories[top5_catid[i]], top5_prob[i].item())
+# prints class names and probabilities like:
+# [('Samoyed', 0.6425196528434753), ('Pomeranian', 0.04062102362513542), ('keeshond', 0.03186424449086189), ('white wolf', 0.01739676296710968), ('Eskimo dog', 0.011717947199940681)]
+```
+
+Replace the model name with the variant you want to use, e.g. `xception`. You can find the IDs in the model summaries at the top of this page.
+
+To extract image features with this model, follow the [timm feature extraction examples](https://rwightman.github.io/pytorch-image-models/feature_extraction/), just change the name of the model you want to use.
+
+## How do I finetune this model?
+You can finetune any of the pre-trained models just by changing the classifier (the last layer).
+```python
+model = timm.create_model('xception', pretrained=True).reset_classifier(NUM_FINETUNE_CLASSES)
+```
+To finetune on your own dataset, you have to write a training loop or adapt [timm's training
+script](https://github.com/rwightman/pytorch-image-models/blob/master/train.py) to use your dataset.
+
+## How do I train this model?
+
+You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-image-models/scripts/) for training a new model afresh.
+
+## Citation
+
+```BibTeX
+@article{DBLP:journals/corr/ZagoruykoK16,
+@misc{chollet2017xception,
+      title={Xception: Deep Learning with Depthwise Separable Convolutions}, 
+      author={François Chollet},
+      year={2017},
+      eprint={1610.02357},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+<!--
+Models:
+- Name: xception
+  Metadata:
+    FLOPs: 10600506792
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 91675053
+    Tasks:
+    - Image Classification
+    ID: xception
+    Crop Pct: '0.897'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception.py#L229
+  In Collection: Xception
+- Name: xception41
+  Metadata:
+    FLOPs: 11681983232
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 108422028
+    Tasks:
+    - Image Classification
+    ID: xception41
+    Crop Pct: '0.903'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L181
+  In Collection: Xception
+- Name: xception65
+  Metadata:
+    FLOPs: 17585702144
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 160536780
+    Tasks:
+    - Image Classification
+    ID: xception65
+    Crop Pct: '0.903'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L200
+  In Collection: Xception
+- Name: xception71
+  Metadata:
+    FLOPs: 22817346560
+    Training Data:
+    - ImageNet
+    Architecture:
+    - 1x1 Convolution
+    - Convolution
+    - Dense Connections
+    - Depthwise Separable Convolution
+    - Global Average Pooling
+    - Max Pooling
+    - ReLU
+    - Residual Connection
+    - Softmax
+    File Size: 170295556
+    Tasks:
+    - Image Classification
+    ID: xception71
+    Crop Pct: '0.903'
+    Image Size: '299'
+    Interpolation: bicubic
+  Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L219
+  In Collection: Xception
+Collections:
+- Name: Xception
+  Paper:
+    title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
+    url: https://papperswithcode.com//paper/xception-deep-learning-with-depthwise
+  type: model-index
+Type: model-index
+-->

--- a/modelindex/models/xception.md
+++ b/modelindex/models/xception.md
@@ -84,12 +84,19 @@ You can follow the [timm recipe scripts](https://rwightman.github.io/pytorch-ima
 ```
 
 <!--
+Type: model-index
+Collections:
+- Name: Xception
+  Paper:
+    Title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
+    URL: https://paperswithcode.com/paper/xception-deep-learning-with-depthwise
 Models:
 - Name: xception
+  In Collection: Xception
   Metadata:
     FLOPs: 10600506792
-    Training Data:
-    - ImageNet
+    Parameters: 22860000
+    File Size: 91675053
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -100,20 +107,28 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 91675053
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: xception
     Crop Pct: '0.897'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception.py#L229
-  In Collection: Xception
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-cadene/xception-43020ad28.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.05%
+      Top 5 Accuracy: 94.4%
 - Name: xception41
+  In Collection: Xception
   Metadata:
     FLOPs: 11681983232
-    Training Data:
-    - ImageNet
+    Parameters: 26970000
+    File Size: 108422028
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -124,20 +139,28 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 108422028
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: xception41
     Crop Pct: '0.903'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L181
-  In Collection: Xception
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_xception_41-e6439c97.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 78.54%
+      Top 5 Accuracy: 94.28%
 - Name: xception65
+  In Collection: Xception
   Metadata:
     FLOPs: 17585702144
-    Training Data:
-    - ImageNet
+    Parameters: 39920000
+    File Size: 160536780
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -148,20 +171,28 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 160536780
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: xception65
     Crop Pct: '0.903'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L200
-  In Collection: Xception
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_xception_65-c9ae96e8.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.55%
+      Top 5 Accuracy: 94.66%
 - Name: xception71
+  In Collection: Xception
   Metadata:
     FLOPs: 22817346560
-    Training Data:
-    - ImageNet
+    Parameters: 42340000
+    File Size: 170295556
     Architecture:
     - 1x1 Convolution
     - Convolution
@@ -172,20 +203,20 @@ Models:
     - ReLU
     - Residual Connection
     - Softmax
-    File Size: 170295556
     Tasks:
     - Image Classification
+    Training Data:
+    - ImageNet
     ID: xception71
     Crop Pct: '0.903'
     Image Size: '299'
     Interpolation: bicubic
   Code: https://github.com/rwightman/pytorch-image-models/blob/d8e69206be253892b2956341fea09fdebfaae4e3/timm/models/xception_aligned.py#L219
-  In Collection: Xception
-Collections:
-- Name: Xception
-  Paper:
-    title: 'Xception: Deep Learning with Depthwise Separable Convolutions'
-    url: https://paperswithcode.com//paper/xception-deep-learning-with-depthwise
-  type: model-index
-Type: model-index
+  Weights: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_xception_71-8eec7df1.pth
+  Results:
+  - Task: Image Classification
+    Dataset: ImageNet
+    Metrics:
+      Top 1 Accuracy: 79.88%
+      Top 5 Accuracy: 94.93%
 -->

--- a/modelindex/requirements-modelindex.txt
+++ b/modelindex/requirements-modelindex.txt
@@ -1,0 +1,2 @@
+model-index==0.1.10
+jinja2==2.11.2


### PR DESCRIPTION
This PR adds model-index files to document the models in the library.

Each model has a markdown file that provides a summary of the model, some code examples on how to use it, and the model details, that will be parsed by model-index.

The markdown files for each model are generated from model templates and the code snippets template, to make it more maintainable. This way, the code examples, which are very similar for all models, are only written once and can be easily updated for all models if the library API changes or new examples are added.

All data is stored in the `modelindex` folder which contains:
- `models`: Auto-generated full model READMEs in markdown format.
- `model-index.yml`: The root index file for the model index.
- `.templates`: A `models` folder which contains the model templates and a file `code-snippets.md` which contains the code examples.

To generate the model-index files from the templates, you just have to run:
```
python modelindex/generate_readmes.py
```
which will generate the READMEs inside `modelindex/models`.

Adding documentation for a new model can be done by creating a markdown file for the model in `modelindex/.templates/models`, like `modelindex/.templates/models/resnet.md` for example, with the summary and details of the model following the [model-index format](https://model-index.readthedocs.io/en/latest/1_quickstart/howitworks.html#storing-metadata-in-markdown-files). Additionally, adding `{% include 'code_snippets.md' %}` will automatically add the code examples when the full README is generated. 

