### PR TITLE
adding efficientnet_el, efficientnet_es_pruned and efficientnet_el_pruned pre-trained models

### DIFF
--- a/timm/models/efficientnet.py
+++ b/timm/models/efficientnet.py
@@ -117,7 +117,14 @@ default_cfgs = {
         url='https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_em_ra2-66250f76.pth',
         input_size=(3, 240, 240), pool_size=(8, 8), crop_pct=0.882),
     'efficientnet_el': _cfg(
-        url='', input_size=(3, 300, 300), pool_size=(10, 10), crop_pct=0.904),
+        url='https://github.com/DeGirum/pruned-models/releases/download/efficientnet_v1.0/efficientnet_el.pth', 
+        input_size=(3, 300, 300), pool_size=(10, 10), crop_pct=0.904),
+
+    'efficientnet_es_pruned': _cfg(
+        url='https://github.com/DeGirum/pruned-models/releases/download/efficientnet_v1.0/efficientnet_es_pruned75.pth'),
+    'efficientnet_el_pruned': _cfg(
+        url='https://github.com/DeGirum/pruned-models/releases/download/efficientnet_v1.0/efficientnet_el_pruned70.pth', 
+        input_size=(3, 300, 300), pool_size=(10, 10), crop_pct=0.904),
 
     'efficientnet_cc_b0_4e': _cfg(url=''),
     'efficientnet_cc_b0_8e': _cfg(url=''),
@@ -1113,6 +1120,12 @@ def efficientnet_es(pretrained=False, **kwargs):
         'efficientnet_es', channel_multiplier=1.0, depth_multiplier=1.0, pretrained=pretrained, **kwargs)
     return model
 
+@register_model
+def efficientnet_es_pruned(pretrained=False, **kwargs):
+    """ EfficientNet-Edge Small Pruned. For more info: https://github.com/DeGirum/pruned-models/releases/tag/efficientnet_v1.0"""
+    model = _gen_efficientnet_edge(
+        'efficientnet_es_pruned', channel_multiplier=1.0, depth_multiplier=1.0, pretrained=pretrained, **kwargs)
+    return model
 
 @register_model
 def efficientnet_em(pretrained=False, **kwargs):
@@ -1129,6 +1142,12 @@ def efficientnet_el(pretrained=False, **kwargs):
         'efficientnet_el', channel_multiplier=1.2, depth_multiplier=1.4, pretrained=pretrained, **kwargs)
     return model
 
+@register_model
+def efficientnet_el_pruned(pretrained=False, **kwargs):
+    """ EfficientNet-Edge-Large pruned. For more info: https://github.com/DeGirum/pruned-models/releases/tag/efficientnet_v1.0"""
+    model = _gen_efficientnet_edge(
+        'efficientnet_el_pruned', channel_multiplier=1.2, depth_multiplier=1.4, pretrained=pretrained, **kwargs)
+    return model
 
 @register_model
 def efficientnet_cc_b0_4e(pretrained=False, **kwargs):


### PR DESCRIPTION
## Dense Models
EfficientNet-ES (EdgeTPU-Small) and EfficientNet-EL (EdgeTPU-Large) are trained with 8 Quadro RTX 8000 using [pytorch-image-models](https://github.com/rwightman/pytorch-image-models.git) repo. 
The training scripts hyper-params are derived from [training_hparam_examples](https://github.com/rwightman/pytorch-image-models/blob/master/docs/training_hparam_examples.md).

./distributed_train.sh 8 /imagenet --model efficientnet_es -b 128 --sched step --epochs 450 --decay-epochs 2.4 --decay-rate .97 --opt rmsproptf --opt-eps .001 -j 8 --warmup-lr 1e-6 --weight-decay 1e-5 --drop 0.2 --drop-connect 0.2 --aa rand-m9-mstd0.5 --remode pixel --reprob 0.2 --amp --lr .064

./distributed_train.sh 8 /imagenet --model efficientnet_el -b 128 --sched step --epochs 450 --decay-epochs 2.4 --decay-rate .97 --opt rmsproptf --opt-eps .001 -j 8 --warmup-lr 1e-6 --weight-decay 1e-5 --drop 0.2 --drop-connect 0.2 --aa rand-m9-mstd0.5 --remode pixel --reprob 0.2 --amp --lr .064

The EfficientNet-ES accuracies are slightly lower than what is reported in [training_hparam_examples](https://github.com/rwightman/pytorch-image-models/blob/master/docs/training_hparam_examples.md) since we just took the best checkpoint, not the average of 8 best checkpoints. I kept our EfficientNet-ES results for completeness.

## Pruned Models
The pruning is done by use of the [DG_Prune submodule](https://github.com/khatami-mehrdad/DG_Prune.git). The pruning code is provided at my forked [pytorch-image-models](https://github.com/khatami-mehrdad/pytorch-image-models.git) in DG branch.
The pruning is done using the lottery ticket hypothesis (LTH) algorithm. The pruning hyperparameters are provided in the json files attached in [DeGirum/pruned-models efficientnet release](https://github.com/DeGirum/pruned-models/releases/tag/efficientnet_v1.0). 
The training hyperparameters are exactly the same as the dense training.

##  Results

| Model  | Top1 Acc | Top5 Acc |
| ------------- | ------------- | ------------- |
| EfficientNet-ES | 77.906 | 94.038 | 
| EfficientNet-ES Pruned  | 75.060  | 92.438 |
| EfficientNet-EL | 81.296 | 95.562 |
| EfficientNet-EL Pruned  | 80.318 | 95.212 |