### PR TITLE
Distribute workload across GPUs from different hardware generations (vary batch size for each GPU)

### DIFF
--- a/timm/data/distributed_sampler.py
+++ b/timm/data/distributed_sampler.py
@@ -49,3 +49,111 @@ class OrderedDistributedSampler(Sampler):
 
     def __len__(self):
         return self.num_samples
+
+
+class VariableDistributedSampler(Sampler):
+    """Sampler that distributes the dataset to each GPU according to the workload specified by the callery.
+       It adjusts the dataset slice and batch size. 
+       Note: Sampling now occurs in slices of the dataset; no longer by stepping through it.
+    .. note::
+        Dataset is assumed to be of constant size.
+    Arguments:
+        dataset: Dataset used for sampling.
+        gpu_load: GPU workload distribution list
+        batch_size: Average batch size for the overall system
+        shuffle (bool, optional): If ``True`` (default), sampler will shuffle the
+            indices.
+        seed (int, optional): random seed used to shuffle the sampler if
+            :attr:`shuffle=True`. This number should be identical across all
+            processes in the distributed group. Default: ``0``.
+    """
+            
+    def __init__(self, dataset, gpu_load, batch_size, shuffle = True, seed = 0):
+        if not dist.is_available():
+            raise RuntimeError("Requires distributed package to be available")
+            
+        world_size = dist.get_world_size()
+        rank       = dist.get_rank()
+            
+        if (len(gpu_load) != world_size):
+            raise ValueError("Number of gpu_load entries not equal to world size")
+
+        if (sum(gpu_load) != world_size):
+            raise ValueError("Total gpu_load weights not equal to world size")
+                        
+        self.dataset = dataset
+        self.num_replicas = world_size
+        self.rank = rank
+        self.epoch = 0
+
+        self.num_samples  = [None for _ in range(world_size)]
+        self.index_offset = [None for _ in range(world_size)]
+        self.batch_size   = [None for _ in range(world_size)]
+        self.num_batches  = [None for _ in range(world_size)]
+        
+        # calculate the dataset slice size for each GPU
+        for i in range(world_size):
+            self.num_samples[i] = int(math.ceil(len(self.dataset) / self.num_replicas * gpu_load[i]))
+            self.batch_size[i]  = int(math.ceil(batch_size * gpu_load[i]))
+            self.num_batches[i] = int(math.ceil(self.num_samples[i] / self.batch_size[i]))
+                        
+        for i in range(1, world_size):
+            if (self.num_batches[i] != self.num_batches[i-1]):
+                raise ValueError("Number of batches mismatch: ", self.num_batches)                
+            
+        # calculcate the dataset offset of each GPU slice
+        self.index_offset[0] = 0
+        for i in range(1, world_size):
+            self.index_offset[i] = self.index_offset[i-1] + self.num_samples[i-1]
+        
+        self.total_size = sum(self.num_samples)
+        
+        if (rank == 0):
+            print('VariableDistributedSampler: Number of samples: ', self.num_samples)
+            print('VariableDistributedSampler: Index offsets    : ', self.index_offset)
+            print('VariableDistributedSampler: Batch sizes      : ', self.batch_size)
+            print('VariableDistributedSampler: Number of batches: ', self.num_batches)
+        
+        self.shuffle = shuffle
+        self.seed = seed
+
+    def get_batch_size(self):
+        return self.batch_size[self.rank]
+    
+    def __iter__(self):
+        if self.shuffle:
+            # deterministically shuffle based on epoch and seed
+            g = torch.Generator()
+            g.manual_seed(self.seed + self.epoch)
+            indices = torch.randperm(len(self.dataset), generator=g).tolist()  # type: ignore[arg-type]
+        else:
+            indices = list(range(len(self.dataset)))  # type: ignore[arg-type]
+
+        # add extra samples to make it evenly divisible
+        padding_size = self.total_size - len(indices)
+        if padding_size <= len(indices):
+            indices += indices[:padding_size]
+        else:
+            indices += (indices * math.ceil(padding_size / len(indices)))[:padding_size]
+        assert len(indices) == self.total_size
+
+        # subsample
+        #indices = indices[self.rank:self.total_size:self.num_replicas]
+        indices = indices[self.index_offset[self.rank]:self.index_offset[self.rank] + self.num_samples[self.rank]]
+        assert len(indices) == self.num_samples[self.rank]
+
+        return iter(indices)
+
+    def __len__(self):
+        return self.num_samples[self.rank]
+
+    def set_epoch(self, epoch: int):
+        r"""
+        Sets the epoch for this sampler. When :attr:`shuffle=True`, this ensures all replicas
+        use a different random ordering for each epoch. Otherwise, the next iteration of this
+        sampler will yield the same ordering.
+        Args:
+            epoch (int): Epoch number.
+        """
+        self.epoch = epoch
+        

--- a/timm/models/efficientnet.py
+++ b/timm/models/efficientnet.py
@@ -336,7 +336,8 @@ class EfficientNet(nn.Module):
     def __init__(self, block_args, num_classes=1000, num_features=1280, in_chans=3, stem_size=32,
                  channel_multiplier=1.0, channel_divisor=8, channel_min=None,
                  output_stride=32, pad_type='', fix_stem=False, act_layer=nn.ReLU, drop_rate=0., drop_path_rate=0.,
-                 se_kwargs=None, norm_layer=nn.BatchNorm2d, norm_kwargs=None, global_pool='avg'):
+                 se_kwargs=None, norm_layer=nn.BatchNorm2d, norm_kwargs=None, global_pool='avg'):                 
+#                 se_kwargs=None, norm_layer=nn.BatchNorm2d, norm_kwargs=None, global_pool='avg'):
         super(EfficientNet, self).__init__()
         norm_kwargs = norm_kwargs or {}
 
@@ -362,6 +363,7 @@ class EfficientNet(nn.Module):
         # Head + Pooling
         self.conv_head = create_conv2d(head_chs, self.num_features, 1, padding=pad_type)
         self.bn2 = norm_layer(self.num_features, **norm_kwargs)
+        #self.bn2 = nn.LayerNorm([self.num_features, 7, 7], **norm_kwargs)
         self.act2 = act_layer(inplace=True)
         self.global_pool, self.classifier = create_classifier(
             self.num_features, self.num_classes, pool_type=global_pool)

--- a/train.py
+++ b/train.py
@@ -280,7 +280,7 @@ parser.add_argument('--torchscript', dest='torchscript', action='store_true',
 parser.add_argument('--log-wandb', action='store_true', default=False,
                     help='log training and validation metrics to wandb')
 parser.add_argument('--gpu-load', nargs="*", type=float, default=None, # None equals 1.0 1.0 1.0 1.0 for a 4 GPU system
-                    help='Distribute workload unevenly to GPUs with different performance levels. E.g. --gpu-speed 1.2 1.2 0.8 0.8 for a 4 GPU system (2xA6000 + 2x2080ti)')
+                    help='Distribute workload unevenly to GPUs with different performance levels. E.g. --gpu-load 1.2 1.2 0.8 0.8 for a 4 GPU system (2xA6000 + 2x2080ti)')
 
 def _parse_args():
     # Do we have a config file to parse?

--- a/train.py
+++ b/train.py
@@ -279,7 +279,8 @@ parser.add_argument('--torchscript', dest='torchscript', action='store_true',
                     help='convert model torchscript for inference')
 parser.add_argument('--log-wandb', action='store_true', default=False,
                     help='log training and validation metrics to wandb')
-
+parser.add_argument('--gpu-load', nargs="*", type=float, default=None, # None equals 1.0 1.0 1.0 1.0 for a 4 GPU system
+                    help='Distribute workload unevenly to GPUs with different performance levels. E.g. --gpu-speed 1.2 1.2 0.8 0.8 for a 4 GPU system (2xA6000 + 2x2080ti)')
 
 def _parse_args():
     # Do we have a config file to parse?
@@ -524,7 +525,8 @@ def main():
         distributed=args.distributed,
         collate_fn=collate_fn,
         pin_memory=args.pin_mem,
-        use_multi_epochs_loader=args.use_multi_epochs_loader
+        use_multi_epochs_loader=args.use_multi_epochs_loader,
+        gpu_load=args.gpu_load
     )
 
     loader_eval = create_loader(
@@ -540,6 +542,7 @@ def main():
         distributed=args.distributed,
         crop_pct=data_config['crop_pct'],
         pin_memory=args.pin_mem,
+        gpu_load=args.gpu_load
     )
 
     # setup loss function

--- a/train.py
+++ b/train.py
@@ -693,6 +693,11 @@ def train_one_epoch(
                 losses_m.update(reduced_loss.item(), input.size(0))
 
             if args.local_rank == 0:
+                if (args.gpu_load != None):
+                    total_input_size = input.size(0) / args.gpu_load[0] * args.world_size
+                else:
+                    total_input_size = input.size(0) * args.world_size
+                        
                 _logger.info(
                     'Train: {} [{:>4d}/{} ({:>3.0f}%)]  '
                     'Loss: {loss.val:>9.6f} ({loss.avg:>6.4f})  '
@@ -705,8 +710,8 @@ def train_one_epoch(
                         100. * batch_idx / last_idx,
                         loss=losses_m,
                         batch_time=batch_time_m,
-                        rate=input.size(0) * args.world_size / batch_time_m.val,
-                        rate_avg=input.size(0) * args.world_size / batch_time_m.avg,
+                        rate=total_input_size / batch_time_m.val,
+                        rate_avg=total_input_size / batch_time_m.avg,
                         lr=lr,
                         data_time=data_time_m))
 

--- a/train.py
+++ b/train.py
@@ -596,14 +596,14 @@ def main():
                     _logger.info("Distributing BatchNorm running means and vars")
                 distribute_bn(model, args.world_size, args.dist_bn == 'reduce')
 
-            eval_metrics = validate(model, loader_eval, validate_loss_fn, args, amp_autocast=amp_autocast)
-
             if model_ema is not None and not args.model_ema_force_cpu:
                 if args.distributed and args.dist_bn in ('broadcast', 'reduce'):
                     distribute_bn(model_ema, args.world_size, args.dist_bn == 'reduce')
                 ema_eval_metrics = validate(
                     model_ema.module, loader_eval, validate_loss_fn, args, amp_autocast=amp_autocast, log_suffix=' (EMA)')
                 eval_metrics = ema_eval_metrics
+            else:
+                eval_metrics = validate(model, loader_eval, validate_loss_fn, args, amp_autocast=amp_autocast)
 
             if lr_scheduler is not None:
                 # step LR for next epoch

--- a/validate.py
+++ b/validate.py
@@ -235,15 +235,6 @@ def validate(args):
             if real_labels is not None:
                 real_labels.add_result(output)
 
-            print(input.shape)
-            print(target.shape)
-            print(output.shape)
-            import numpy as np
-            max_idx = np.argmax(output[0].cpu().detach().numpy())
-            
-            print('Output: ', max_idx, output[0][max_idx], ' should be ', target[0])
-            print(output[0])
-            exit()
             # measure accuracy and record loss
             acc1, acc5 = accuracy(output.detach(), target, topk=(1, 5))
             losses.update(loss.item(), input.size(0))


### PR DESCRIPTION
This contribution attemps to cleanly add the option to adjust the batch size of each GPU according to its capability (performance and memory size). 

My system has two A6000 and two 2080ti GPUs. Upgrading it four A6000 GPUs is rather expensive and training with a batch size to match the 2080ti limited onboard memory doesn't fully use the additional performance/memory of the A6000.

Previously this system was capable of ~2000 images/sec when training an EfficientNet-B0 with Imagenet (batch size 200 for all).
With this patch I can increase the batch size of the A6ks to 300 and still use the 2080s with batch size 200; this increases training performance to ~2500 images/sec.

This changes the data distribution in batches, but I'm not sure if that's really a problem. (as long as the data is shuffled as it currently is by default in VariableDistributedSampler)

