### PR TITLE
Let only the _globally_ 0th rank write checkpoints in `train.py`

### DIFF
--- a/train.py
+++ b/train.py
@@ -561,7 +561,7 @@ def main():
     best_epoch = None
     saver = None
     output_dir = None
-    if args.local_rank == 0:
+    if args.rank == 0:
         if args.experiment:
             exp_name = args.experiment
         else:


### PR DESCRIPTION
Hi There,

Thank You for this project. Just today I started using your code to train EfficientNets for my own purposes. I just came across a teeny tiny bug in `train.py`, that crashes trainings on multiple nodes. It seems to happen, that multiple nodes at once write to the tmp path and then try to move it after another, yielding a 
```
FileNotFoundError: [Errno 2] No such file or directory: 'output/timm_confs/effnet_b0.txt/tmp.pth.tar' -> 'output/timm_confs/effnet_b0.txt/last.pth.tar'
```

With this fix in place it works for me, as there is no more concurrency.

Best regards,

Sam