### PR TITLE
Remove extraneous activation in SEResNetBlock

### DIFF
--- a/timm/models/senet.py
+++ b/timm/models/senet.py
@@ -212,7 +212,6 @@ class SEResNetBlock(nn.Module):
 
         out = self.conv2(out)
         out = self.bn2(out)
-        out = self.relu(out)
 
         if self.downsample is not None:
             shortcut = self.downsample(x)


### PR DESCRIPTION
There appears to be an extra activation on line 215 of the SEResNetBlock (which is functionally equivalent to the basicblock of resnet) of senet.py.
https://github.com/rwightman/pytorch-image-models/blob/d3f744065088ca9b6b3a0f968c70e90ed37de75b/timm/models/senet.py#L206-L223

If i'm not mistaken, the resnet (basic) block should only have 2 activations: 1 after the first batchnorm, and 1 after adding the residual.

Referencing resnet.py:
https://github.com/rwightman/pytorch-image-models/blob/d3f744065088ca9b6b3a0f968c70e90ed37de75b/timm/models/resnet.py#L320-L347

Ultimately this shouldn't matter too much as senet.py is deprecated.