### PR TITLE
topk bug fix for binary classification

### DIFF
--- a/train.py
+++ b/train.py
@@ -761,7 +761,7 @@ def validate(model, loader, loss_fn, args, amp_autocast=suppress, log_suffix='')
                 target = target[0:target.size(0):reduce_factor]
 
             loss = loss_fn(output, target)
-            acc1, acc5 = accuracy(output, target, topk=(1, 5))
+            acc1, acc5 = accuracy(output, target, topk=(1, min(5, model.num_classes)))
 
             if args.distributed:
                 reduced_loss = reduce_tensor(loss.data, args.world_size)


### PR DESCRIPTION
Fix for [this](https://github.com/rwightman/pytorch-image-models/issues/807) issue that I have raised.. 

It gets the job done, but logs still show 'Acc@5' which is not correct, and in fact should be completely eliminated in this case.

```
Test: [   0/110]  Time: 0.479 (0.479)  Loss:  0.4224 (0.4224)  Acc@1: 90.6250 (90.6250)  Acc@5: 100.0000 (100.0000)
Test: [  50/110]  Time: 0.044 (0.070)  Loss:  0.3271 (0.4265)  Acc@1: 100.0000 (94.9142)  Acc@5: 100.0000 (100.0000)
Test: [ 100/110]  Time: 0.105 (0.066)  Loss:  0.5649 (0.4314)  Acc@1: 90.6250 (94.8329)  Acc@5: 100.0000 (100.0000)
Test: [ 110/110]  Time: 0.349 (0.066)  Loss:  0.5874 (0.4424)  Acc@1: 92.3077 (94.6701)  Acc@5: 100.0000 (100.0000)
```

 If you can suggest the right way forward, I'll do the needful