### PR TITLE
Fix accuracy when topk > num_classes

### DIFF
--- a/timm/utils/metrics.py
+++ b/timm/utils/metrics.py
@@ -2,6 +2,7 @@
 
 Hacked together by / Copyright 2020 Ross Wightman
 """
+import torch
 
 
 class AverageMeter:
@@ -24,9 +25,12 @@ class AverageMeter:
 
 def accuracy(output, target, topk=(1,)):
     """Computes the accuracy over the k top predictions for the specified values of k"""
-    maxk = max(topk)
+    maxk = min(max(topk), output.size()[1])
     batch_size = target.size(0)
     _, pred = output.topk(maxk, 1, True, True)
     pred = pred.t()
     correct = pred.eq(target.reshape(1, -1).expand_as(pred))
-    return [correct[:k].reshape(-1).float().sum(0) * 100. / batch_size for k in topk]
+    return [
+        correct[:k].reshape(-1).float().sum(0) * 100. / batch_size
+        if k <= maxk else torch.tensor(100.) for k in topk
+    ]


### PR DESCRIPTION
In order to fix the accuracy RuntimeError from #807, I propose this simple solution. It'll avoid to had lot of changes to `train.py` file.

In case of topk > num_classes, accuracy will return 100.