### PR TITLE
Use `torch.repeat_interleave()` to generate repeated indices faster

### DIFF
--- a/timm/data/distributed_sampler.py
+++ b/timm/data/distributed_sampler.py
@@ -108,7 +108,7 @@ class RepeatAugSampler(Sampler):
             indices = torch.arange(start=0, end=len(self.dataset))
 
         # produce repeats e.g. [0, 0, 0, 1, 1, 1, 2, 2, 2....]
-        indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0)
+        indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0).tolist()
         # add extra samples to make it evenly divisible
         padding_size = self.total_size - len(indices)
         indices += indices[:padding_size]

--- a/timm/data/distributed_sampler.py
+++ b/timm/data/distributed_sampler.py
@@ -105,7 +105,7 @@ class RepeatAugSampler(Sampler):
         if self.shuffle:
             indices = torch.randperm(len(self.dataset), generator=g)
         else:
-            indices = torch.range(start=0, end=len(self.dataset))
+            indices = torch.arange(start=0, end=len(self.dataset))
 
         # produce repeats e.g. [0, 0, 0, 1, 1, 1, 2, 2, 2....]
         indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0)

--- a/timm/data/distributed_sampler.py
+++ b/timm/data/distributed_sampler.py
@@ -104,12 +104,12 @@ class RepeatAugSampler(Sampler):
         g = torch.Generator()
         g.manual_seed(self.epoch)
         if self.shuffle:
-            indices = torch.randperm(len(self.dataset), generator=g).tolist()
+            indices = torch.randperm(len(self.dataset), generator=g)
         else:
-            indices = list(range(len(self.dataset)))
+            indices = torch.range(start=0, end=len(self.dataset))
 
         # produce repeats e.g. [0, 0, 0, 1, 1, 1, 2, 2, 2....]
-        indices = np.repeat(indices, repeats=self.num_repeats, axis=0)
+        indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0)
         # add extra samples to make it evenly divisible
         padding_size = self.total_size - len(indices)
         indices += indices[:padding_size]

--- a/timm/data/distributed_sampler.py
+++ b/timm/data/distributed_sampler.py
@@ -1,6 +1,5 @@
 import math
 import torch
-import numpy as np
 from torch.utils.data import Sampler
 import torch.distributed as dist
 

--- a/timm/data/distributed_sampler.py
+++ b/timm/data/distributed_sampler.py
@@ -1,5 +1,6 @@
 import math
 import torch
+import numpy as np
 from torch.utils.data import Sampler
 import torch.distributed as dist
 
@@ -108,7 +109,7 @@ class RepeatAugSampler(Sampler):
             indices = list(range(len(self.dataset)))
 
         # produce repeats e.g. [0, 0, 0, 1, 1, 1, 2, 2, 2....]
-        indices = [x for x in indices for _ in range(self.num_repeats)]
+        indices = np.repeat(indices, repeats=self.num_repeats, axis=0)
         # add extra samples to make it evenly divisible
         padding_size = self.total_size - len(indices)
         indices += indices[:padding_size]

--- a/timm/data/distributed_sampler.py
+++ b/timm/data/distributed_sampler.py
@@ -108,10 +108,11 @@ class RepeatAugSampler(Sampler):
             indices = torch.arange(start=0, end=len(self.dataset))
 
         # produce repeats e.g. [0, 0, 0, 1, 1, 1, 2, 2, 2....]
-        indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0).tolist()
+        indices = torch.repeat_interleave(indices, repeats=self.num_repeats, dim=0)
         # add extra samples to make it evenly divisible
         padding_size = self.total_size - len(indices)
-        indices += indices[:padding_size]
+        if padding_size > 0:
+            indices = torch.cat([indices, indices[:padding_size]], dim=0)
         assert len(indices) == self.total_size
 
         # subsample per rank


### PR DESCRIPTION
## Change Log

* Use `torch.repeat_interleave()` to generate the repeated indices faster
* Add `EOF`

## Performance Benchmark

* Python 3.7
* OS : Windows 10
* CPU : i7-7700K (not overclocked)

<details>
<summary>code</summary>

```
from time import time
import numpy as np
import torch


def get_indices_v1(x, num_repeats: int = 3):
    return [i for i in x for _ in range(num_repeats)]


def get_indices_v2(x, num_repeats: int = 3):
    return np.repeat(x, repeats=num_repeats, axis=0).tolist()


def get_indices_v3(x, num_repeats: int = 3):
    return torch.repeat_interleave(x, repeats=num_repeats, dim=0).tolist()


if __name__ == '__main__':
    for num_datasets in (int(1e5), int(1e6), int(1e7)):
        indices: torch.Tensor = torch.arange(start=0, end=num_datasets)

        v1, v2, v3 = [], [], []
        for _ in range(10):
            start_time = time()
            _ = get_indices_v1(indices.tolist())
            end_time = time()
            v1.append(end_time - start_time)

            start_time = time()
            _ = get_indices_v2(indices.tolist())
            end_time = time()
            v2.append(end_time - start_time)

            start_time = time()
            _ = get_indices_v3(indices)
            end_time = time()
            v3.append(end_time - start_time)

        print(f'num_datasets {num_datasets}')
        print(f'list comprehension      : {np.mean(v1):.6f}s')
        print(f'np.repeat               : {np.mean(v2):.6f}s')
        print(f'torch.repeat_interleave : {np.mean(v3):.6f}s')
        print()

```

</details>

```
num_datasets 100000
list comprehension      : 0.031251s
np.repeat               : 0.015623s
torch.repeat_interleave : 0.009376s

num_datasets 1000000
list comprehension      : 0.292203s
np.repeat               : 0.132806s
torch.repeat_interleave : 0.129676s

num_datasets 10000000
list comprehension      : 2.788492s
np.repeat               : 1.306345s
torch.repeat_interleave : 1.042842s
```