### PR TITLE
Get rid of padding for rel_logits_1d in bot and halo attn

### DIFF
--- a/timm/models/layers/halo_attn.py
+++ b/timm/models/layers/halo_attn.py
@@ -45,9 +45,9 @@ def rel_logits_1d(q, rel_k, permute_mask: List[int]):
     x = (q @ rel_k.transpose(-1, -2))
 
     if win_size == 1:
-        out = rel_pos.reshape([-1, H, 1, W, win_size])
+        out = x.reshape([-1, H, 1, W, win_size])
     elif W == 1:
-        out = rel_pos[:, :, :, -win_size:].reshape([-1, H, 1, W, win_size])
+        out = x[:, :, :, -win_size:].reshape([-1, H, 1, W, win_size])
     else:
         full_rank_gap = win_size - W
         flat_x = x.reshape([-1, H, W * rel_size])[:, :, W - 1: -1]


### PR DESCRIPTION
Get rid of padding for `rel_logits_1d` in `bottleneck_attn.py`  and `halo_attn.py `. This is first started from the discussion in [
aravindsrinivas/botnet.py](https://gist.github.com/aravindsrinivas/56359b79f0ce4449bcb04ab4b56a57a2).
- **`rel_logits_1d` in `bottleneck_attn.py`**. If we name this new one as `rel_logits_1d_2`:
  ```py
  import torch
  import torch.nn.functional as F
  import numpy as np
  from typing import List
  from timm.models.layers.bottleneck_attn import rel_logits_1d

  q = torch.rand([4, 14, 16, 32])
  rel_k = torch.rand([2 * 16 - 1, 32])
  permute_mask = (0, 1, 3, 2, 4)

  out_1 = rel_logits_1d(q, rel_k, permute_mask)
  out_2 = rel_logits_1d_2(q, rel_k, permute_mask)
  print(f"{out_1.shape = }, {out_2.shape = }")
  # out_1.shape = torch.Size([4, 14, 16, 14, 16]), out_2.shape = torch.Size([4, 14, 16, 14, 16])
  print(f"{np.allclose(out_1.numpy(), out_2.numpy()) = }")
  # np.allclose(out_1.numpy(), out_2.numpy()) = True
  ```
- **`rel_logits_1d` in `halo_attn.py`**. If we name this new one as `rel_logits_1d_2`:
  ```py
  import torch
  import torch.nn.functional as F
  import numpy as np
  from typing import List
  from timm.models.layers.halo_attn import rel_logits_1d

  q = torch.rand([4, 14, 16, 32])
  rel_k = torch.rand([2 * 21 - 1, 32])
  permute_mask = (0, 1, 3, 2, 4)

  out_1 = rel_logits_1d(q, rel_k, permute_mask)
  out_2 = rel_logits_1d_2(q, rel_k, permute_mask)
  print(f"{out_1.shape = }, {out_2.shape = }")
  # out_1.shape = torch.Size([4, 14, 16, 21, 21]), out_2.shape = torch.Size([4, 14, 16, 21, 21])
  print(f"{np.allclose(out_1.numpy(), out_2.numpy()) = }")
  # np.allclose(out_1.numpy(), out_2.numpy()) = True
  ```
- Anyway, this is the version using in my project, and just a tiny change, that only simplify the using of `F.pad`. You may consider if accept this. :)
- The basic logic for `bottleneck_attn` is like:
  ![](https://github.com/leondgarse/keras_cv_attention_models/raw/main/keras_cv_attention_models/botnet/rel_to_abs.png)
  For `halo_attn`, just clipped some value on the left side.