### PR TITLE
Remove checking `smoothing` parameter

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -310,10 +310,7 @@ class TrainBenchmarkRunner(BenchmarkRunner):
         super().__init__(model_name=model_name, device=device, torchscript=torchscript, **kwargs)
         self.model.train()
 
-        if kwargs.pop('smoothing', 0) > 0:
-            self.loss = nn.CrossEntropyLoss().to(self.device)
-        else:
-            self.loss = nn.CrossEntropyLoss().to(self.device)
+        self.loss = nn.CrossEntropyLoss().to(self.device)
         self.target_shape = tuple()
 
         self.optimizer = create_optimizer_v2(


### PR DESCRIPTION
Currently, `smoothing` parameter for label smoothing is not used, so there's no need `if-condition` for now.

OR

From pytorch 1.10.x, starts to support `label_smoothing` parameter. So we can change to

As-is
```
self.loss = nn.CrossEntropyLoss().to(self.device)
```

To-be
```
self.loss = nn.CrossEntropyLoss(label_smoothing=kwargs.pop('smoothing', 0)).to(self.device)
```

* API : [nn.CrossEntropyLoss](https://pytorch.org/docs/1.10.1/generated/torch.nn.CrossEntropyLoss.html#crossentropyloss)