### PR TITLE
Add support for different TFDS `BuilderConfig`s

### DIFF
--- a/timm/data/parsers/parser_factory.py
+++ b/timm/data/parsers/parser_factory.py
@@ -11,7 +11,7 @@ def create_parser(name, root, split='train', **kwargs):
     prefix = ''
     if len(name) > 1:
         prefix = name[0]
-    name = name[-1]
+    name = "/".join(name[1:])
 
     # FIXME improve the selection right now just tfds prefix or fallback path, will need options to
     # explicitly select other options shortly


### PR DESCRIPTION
As of now a user can't use a TFDS `BuilderConfig` different than the default one (because the current parser assumes that the dataset is in the form `source/dataset`, while in the case of TFDS datasets it can be `tfds/dataset/builder`, e.g. `tfds/diabetic_retinopathy_detection/btgraham-300` (https://www.tensorflow.org/datasets/catalog/diabetic_retinopathy_detection#diabetic_retinopathy_detectionbtgraham-300).

This PR fixes this by taking whatever is split at line 10 after the first element (which is the source of the dataset) and joining it again with `/`.