### PR TITLE
fix: multistep lr decay epoch bugs

### DIFF
--- a/timm/scheduler/scheduler_factory.py
+++ b/timm/scheduler/scheduler_factory.py
@@ -71,7 +71,7 @@ def create_scheduler(args, optimizer):
     elif args.sched == 'multistep':
         lr_scheduler = MultiStepLRScheduler(
             optimizer,
-            decay_t=args.milestones,
+            decay_t=args.decay_milestones,
             decay_rate=args.decay_rate,
             warmup_lr_init=args.warmup_lr,
             warmup_t=args.warmup_epochs,

--- a/timm/scheduler/scheduler_factory.py
+++ b/timm/scheduler/scheduler_factory.py
@@ -71,7 +71,7 @@ def create_scheduler(args, optimizer):
     elif args.sched == 'multistep':
         lr_scheduler = MultiStepLRScheduler(
             optimizer,
-            decay_t=args.decay_epochs,
+            decay_t=args.milestones,
             decay_rate=args.decay_rate,
             warmup_lr_init=args.warmup_lr,
             warmup_t=args.warmup_epochs,

--- a/train.py
+++ b/train.py
@@ -171,6 +171,8 @@ parser.add_argument('--epoch-repeats', type=float, default=0., metavar='N',
                     help='epoch repeat multiplier (number of times to repeat dataset epoch per train epoch).')
 parser.add_argument('--start-epoch', default=None, type=int, metavar='N',
                     help='manual epoch number (useful on restarts)')
+parser.add_argument('--milestones', default=[30, 60], type=int, nargs='+', metavar="MILESTONES",
+                    help='list of epoch indices for multistep lr. must be increasing')
 parser.add_argument('--decay-epochs', type=float, default=100, metavar='N',
                     help='epoch interval to decay LR')
 parser.add_argument('--warmup-epochs', type=int, default=3, metavar='N',

--- a/train.py
+++ b/train.py
@@ -171,8 +171,8 @@ parser.add_argument('--epoch-repeats', type=float, default=0., metavar='N',
                     help='epoch repeat multiplier (number of times to repeat dataset epoch per train epoch).')
 parser.add_argument('--start-epoch', default=None, type=int, metavar='N',
                     help='manual epoch number (useful on restarts)')
-parser.add_argument('--milestones', default=[30, 60], type=int, nargs='+', metavar="MILESTONES",
-                    help='list of epoch indices for multistep lr. must be increasing')
+parser.add_argument('--decay-milestones', default=[30, 60], type=int, nargs='+', metavar="MILESTONES",
+                    help='list of decay epoch indices for multistep lr. must be increasing')
 parser.add_argument('--decay-epochs', type=float, default=100, metavar='N',
                     help='epoch interval to decay LR')
 parser.add_argument('--warmup-epochs', type=int, default=3, metavar='N',


### PR DESCRIPTION
Hi! I think `multistep` scheduler has some problems with `decay_t` parameters.

- bugs: when `multistep` is used as scheduler, `object of type float has no len()` error occurs. (see below pictures)
  ![image](https://user-images.githubusercontent.com/31476895/167066078-b407db5c-bf60-48c6-bbb3-0b703c22b674.png)
- reason: when `multistep` is used, `decay_epochs` is used for `decay_t`, but `decay_t` requires `list`, not `float`.
- how to reproduce: run following command (you should change `imageNet` to your imagenet folder)
  ```bash
  python3 train.py imageNet --model resnet50 --sched multistep --epochs 90 --decay-epochs 30 --decay-rate 0.1 --warmup-epoch 0
  ```
- how to solve it:
  - add `milestones` arguments (list of int)
  - change `decay_epochs` to `milestones` variable