### PR TITLE
use `Image.Resampling` namespace for PIL mapping

### DIFF
--- a/timm/data/transforms.py
+++ b/timm/data/transforms.py
@@ -36,12 +36,12 @@ class ToTensor:
 
 
 _pil_interpolation_to_str = {
-    Image.NEAREST: 'nearest',
-    Image.BILINEAR: 'bilinear',
-    Image.BICUBIC: 'bicubic',
-    Image.BOX: 'box',
-    Image.HAMMING: 'hamming',
-    Image.LANCZOS: 'lanczos',
+    Image.Resampling.NEAREST: 'nearest',
+    Image.Resampling.BILINEAR: 'bilinear',
+    Image.Resampling.BICUBIC: 'bicubic',
+    Image.Resampling.BOX: 'box',
+    Image.Resampling.HAMMING: 'hamming',
+    Image.Resampling.LANCZOS: 'lanczos',
 }
 _str_to_pil_interpolation = {b: a for a, b in _pil_interpolation_to_str.items()}
 

--- a/timm/data/transforms.py
+++ b/timm/data/transforms.py
@@ -35,14 +35,28 @@ class ToTensor:
         return torch.from_numpy(np_img).to(dtype=self.dtype)
 
 
-_pil_interpolation_to_str = {
-    Image.Resampling.NEAREST: 'nearest',
-    Image.Resampling.BILINEAR: 'bilinear',
-    Image.Resampling.BICUBIC: 'bicubic',
-    Image.Resampling.BOX: 'box',
-    Image.Resampling.HAMMING: 'hamming',
-    Image.Resampling.LANCZOS: 'lanczos',
-}
+# Pillow is deprecating the top-level resampling attributes (e.g., Image.BILINEAR) in
+# favor of the Image.Resampling enum. The top-level resampling attributes will be
+# removed in Pillow 10.
+if hasattr(Image, "Resampling"):
+    _pil_interpolation_to_str = {
+        Image.Resampling.NEAREST: 'nearest',
+        Image.Resampling.BILINEAR: 'bilinear',
+        Image.Resampling.BICUBIC: 'bicubic',
+        Image.Resampling.BOX: 'box',
+        Image.Resampling.HAMMING: 'hamming',
+        Image.Resampling.LANCZOS: 'lanczos',
+    }
+else:
+    _pil_interpolation_to_str = {
+        Image.NEAREST: 'nearest',
+        Image.BILINEAR: 'bilinear',
+        Image.BICUBIC: 'bicubic',
+        Image.BOX: 'box',
+        Image.HAMMING: 'hamming',
+        Image.LANCZOS: 'lanczos',
+    }
+
 _str_to_pil_interpolation = {b: a for a, b in _pil_interpolation_to_str.items()}
 
 
@@ -181,5 +195,3 @@ class RandomResizedCropAndInterpolation:
         format_string += ', ratio={0}'.format(tuple(round(r, 4) for r in self.ratio))
         format_string += ', interpolation={0})'.format(interpolate_str)
         return format_string
-
-


### PR DESCRIPTION
PIL version 9.1.0 shows a deprecation warning when accessing resampling constants via the `Image` namespace. The suggested namespace is `Image.Resampling`. This commit updates `_pil_interpolation_to_str` to use the `Image.Resampling` namespace.

```
/tmp/ipykernel_11959/698124036.py:2: DeprecationWarning: NEAREST is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.NEAREST or Dither.NONE instead.
  Image.NEAREST: 'nearest',
/tmp/ipykernel_11959/698124036.py:3: DeprecationWarning: BILINEAR is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BILINEAR instead.
  Image.BILINEAR: 'bilinear',
/tmp/ipykernel_11959/698124036.py:4: DeprecationWarning: BICUBIC is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BICUBIC instead.
  Image.BICUBIC: 'bicubic',
/tmp/ipykernel_11959/698124036.py:5: DeprecationWarning: BOX is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BOX instead.
  Image.BOX: 'box',
/tmp/ipykernel_11959/698124036.py:6: DeprecationWarning: HAMMING is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.HAMMING instead.
  Image.HAMMING: 'hamming',
/tmp/ipykernel_11959/698124036.py:7: DeprecationWarning: LANCZOS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
  Image.LANCZOS: 'lanczos',
```