### PR TITLE
ENH: replace star imports with imported names in train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -31,8 +31,11 @@ from torch.nn.parallel import DistributedDataParallel as NativeDDP
 from timm.data import create_dataset, create_loader, resolve_data_config, Mixup, FastCollateMixup, AugMixDataset
 from timm.models import create_model, safe_model_name, resume_checkpoint, load_checkpoint,\
     convert_splitbn_model, model_parameters
-from timm.utils import *
-from timm.loss import *
+from timm.utils import setup_default_logging, random_seed, set_jit_fuser, ModelEmaV2,\
+    get_outdir, CheckpointSaver, distribute_bn, update_summary, accuracy, AverageMeter,\
+    dispatch_clip_grad, reduce_tensor
+from timm.loss import JsdCrossEntropy, BinaryCrossEntropy, SoftTargetCrossEntropy, BinaryCrossEntropy,\
+    LabelSmoothingCrossEntropy
 from timm.optim import create_optimizer_v2, optimizer_kwargs
 from timm.scheduler import create_scheduler
 from timm.utils import ApexScaler, NativeScaler


### PR DESCRIPTION
this pull request replaces * imports with the imported names. this makes it clearer where functions are defined and does not pollute the namespace.