### PR TITLE
Revert "ENH: replace star imports with imported names in train.py"

### DIFF
--- a/train.py
+++ b/train.py
@@ -31,11 +31,8 @@ from torch.nn.parallel import DistributedDataParallel as NativeDDP
 from timm.data import create_dataset, create_loader, resolve_data_config, Mixup, FastCollateMixup, AugMixDataset
 from timm.models import create_model, safe_model_name, resume_checkpoint, load_checkpoint,\
     convert_splitbn_model, model_parameters
-from timm.utils import setup_default_logging, random_seed, set_jit_fuser, ModelEmaV2,\
-    get_outdir, CheckpointSaver, distribute_bn, update_summary, accuracy, AverageMeter,\
-    dispatch_clip_grad, reduce_tensor
-from timm.loss import JsdCrossEntropy, BinaryCrossEntropy, SoftTargetCrossEntropy, BinaryCrossEntropy,\
-    LabelSmoothingCrossEntropy
+from timm.utils import *
+from timm.loss import *
 from timm.optim import create_optimizer_v2, optimizer_kwargs
 from timm.scheduler import create_scheduler
 from timm.utils import ApexScaler, NativeScaler


### PR DESCRIPTION
Reverts rwightman/pytorch-image-models#1266

hi @rwightman - #1266 introduces potentially unwanted behavior. if the current version of `train.py` with the current release of `timm`, then an `ImportError` is raised because of `set_jit_fuser` (added in https://github.com/rwightman/pytorch-image-models/commit/f0f9eccda8dcf6fb546e762c544459a2771606c2).

one solution is to revert #1266. or if this is not a problem for you, we can leave this (and we can close this pr). i wanted to document this behavior here.