### PR TITLE
Add tif support

### DIFF
--- a/timm/data/parsers/constants.py
+++ b/timm/data/parsers/constants.py
@@ -1,1 +1,1 @@
-IMG_EXTENSIONS = ('.png', '.jpg', '.jpeg')
+IMG_EXTENSIONS = ('.png', '.jpg', '.jpeg', '.tif')


### PR DESCRIPTION
This small modification allows .tif files to be read in and used for training/validation/testing. The modification is pretty small and I hope it can be incorporated into master. This will help the remote sensing community to use the timm package for model training. If necessary I can write a small test to demonstrate that it works with .tif files.