### PR TITLE
Add missing output in Feature extraction docs

### DIFF
--- a/docs/feature_extraction.md
+++ b/docs/feature_extraction.md
@@ -90,6 +90,7 @@ print(f'Pooled shape: {o.shape}')
 ```
 Output:
 ```text
+Original shape: torch.Size([2, 1000])
 Pooled shape: torch.Size([2, 1024])
 ```
 


### PR DESCRIPTION
There are 2 print calls, but only one was included in the output. I've added the missing one.