### PR TITLE
(chore) Remove unused import `os` in benchmark.py

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -6,7 +6,6 @@ An inference and train step benchmark script for timm models.
 Hacked together by Ross Wightman (https://github.com/rwightman)
 """
 import argparse
-import os
 import csv
 import json
 import time


### PR DESCRIPTION
Remove unused import `os` in benchmark.py