### PR TITLE
strip `module.` and `model.` prefixes instead of  `module.` only

### DIFF
--- a/timm/models/helpers.py
+++ b/timm/models/helpers.py
@@ -37,8 +37,14 @@ def clean_state_dict(state_dict):
     # 'clean' checkpoint by removing .module prefix from state dict if it exists from parallel training
     cleaned_state_dict = OrderedDict()
     for k, v in state_dict.items():
-        name = k[7:] if k.startswith('module.') else k
-        cleaned_state_dict[name] = v
+        # strip `module.` and `model.` prefixes
+        if k.startswith('module'):
+            name = k[7:]
+        elif k.startswith('model'):
+            name = k[6:]
+        else:
+            name = k
+        new_state_dict[name] = v
     return cleaned_state_dict
 
 


### PR DESCRIPTION
Should Fix errors like 
RuntimeError: Error(s) in loading state_dict for EfficientDet:
    Missing key(s) in state_dict: "backbone.conv_stem.weight", "backbone.bn1.weight", ...
   Unexpected key(s) in state_dict: "model.model.backbone.conv_stem.weight", "model.model.backbone.bn1.weight", "model.model.backbone.bn1.bias", "model.model.backbone.bn1.running_mean", "model.model.backbone.bn1.running_var", "model.model.backbone.bn1.num_batches_tracked", "model.model.backbone.blocks.0.0.conv_dw.weight",