### PR TITLE
Take `no_emb_class` into account when calling  `resize_pos_embed`

### DIFF
--- a/timm/models/vision_transformer.py
+++ b/timm/models/vision_transformer.py
@@ -644,7 +644,7 @@ def checkpoint_filter_fn(state_dict, model, adapt_layer_scale=False):
             v = resize_pos_embed(
                 v,
                 model.pos_embed,
-                getattr(model, 'num_prefix_tokens', 1),
+                0 if getattr(model, 'no_embed_class') else getattr(model, 'num_prefix_tokens', 1),
                 model.patch_embed.grid_size
             )
         elif adapt_layer_scale and 'gamma_' in k:


### PR DESCRIPTION
 `num_prefix_tokens` gets overridden by `no_embed_class` [here](https://github.com/rwightman/pytorch-image-models/blob/d7b55a9429f3d56a991e604cbc2e9fdf1901612f/timm/models/vision_transformer.py#L372) when initializing `VisionTransformer`. However, `no_embed_class` is not considered when calling `rezie_post_embed`, which causes the mismatch between the shape of the resized embeddings and the shape of embedding in the initialized model.

This fix is required to load `deit3` models for different image sizes.