### PR TITLE
Fixes 1.0 crop reproducibility issue.

### DIFF
--- a/timm/data/transforms_factory.py
+++ b/timm/data/transforms_factory.py
@@ -145,6 +145,7 @@ def transforms_imagenet_eval(
             scale_size = tuple([int(x / crop_pct) for x in img_size])
     else:
         scale_size = int(math.floor(img_size / crop_pct))
+        scale_size = (scale_size, scale_size)
 
     tfl = [
         transforms.Resize(scale_size, interpolation=str_to_interp_mode(interpolation)),


### PR DESCRIPTION
## Issue
Some models' reported top-1 accuracy at 384x384 or larger resolutions are not reproducible with timm's validation script.
I.e. ConvNeXt-L @ 384 is reported to be 87.5%. Their own validation script produces 87.456%, which is correct.
timm's validation script produces a slightly lower score, 87.39%.

## Solution
After a bit of digging up, I found the culprit to be in the eval transforms.

transforms.CenterCrop automatically converts image size into a tuple, but transforms.Resize does not.
When running models on ImageNet at 384x384 with 1.0 crop_pct, this will result in transforms.Resize(384).
Some methods (i.e. ConvNeXt, Swin) implement this with transforms.Resize((384, 384)).
As a result their reported scores on ImageNet at 384 are not reproducible with timm's validation script.