### PR TITLE
Deploy docs from main not master

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -3,7 +3,7 @@ name: Build documentation
 on:
   push:
     branches:
-      - master
+      - main
       - doc-builder*
       - v*-release
 

--- a/hfdocs/source/_config.py
+++ b/hfdocs/source/_config.py
@@ -1,1 +1,0 @@
-default_branch_name = "master"


### PR DESCRIPTION
Since we updated the main branch here to "main", we have to update a couple things for docs to deploy correctly

- deleted `_config.py` which was pointing to default main branch as "master".
- updated `build_main_documentation` workflow so it triggers on commits to "main" branch