### PR TITLE
Fix typo of "sched-on-updates" argument

### DIFF
--- a/train.py
+++ b/train.py
@@ -714,7 +714,7 @@ def main():
     elif resume_epoch is not None:
         start_epoch = resume_epoch
     if lr_scheduler is not None and start_epoch > 0:
-        if args.step_on_updates:
+        if args.sched_on_updates:
             lr_scheduler.step_update(start_epoch * updates_per_epoch)
         else:
             lr_scheduler.step(start_epoch)


### PR DESCRIPTION
There was a small typo in the [train.py](https://github.com/rwightman/pytorch-image-models/commit/b1b024dfed5870cb1238c8c7c326d6ea8ef67300#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95R718) after introducing the new argument `sched-on-updates`.