### PR TITLE
:pencil2: fix typo

### DIFF
--- a/train.py
+++ b/train.py
@@ -97,7 +97,7 @@ group.add_argument('--class-map', default='', type=str, metavar='FILENAME',
 # Model parameters
 group = parser.add_argument_group('Model parameters')
 group.add_argument('--model', default='resnet50', type=str, metavar='MODEL',
-                    help='Name of model to train (default: "resnet50"')
+                    help='Name of model to train (default: "resnet50")')
 group.add_argument('--pretrained', action='store_true', default=False,
                     help='Start with pretrained version of specified network (if avail)')
 group.add_argument('--initial-checkpoint', default='', type=str, metavar='PATH',


### PR DESCRIPTION
Fix yet another missing back quote in `train.py`.