### PR TITLE
fix train args 'in_chanEs' typo

### DIFF
--- a/train.py
+++ b/train.py
@@ -407,7 +407,7 @@ def main():
 
     in_chans = 3
     if args.in_chans is not None:
-        in_chans = args.in_chanes
+        in_chans = args.in_chans
     elif args.input_size is not None:
         in_chans = args.input_size[0]
 


### PR DESCRIPTION
There's a small typo in the train script. Setting the `in-chans` argument leads to an error:

```
if args.in_chans is not None:
  in_chans = **args.in_chanes**  # "in_chanes" doesn't exist
```

This PR fixes it