### PR TITLE
Pin hf hub version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     keywords='pytorch pretrained models efficientnet mobilenetv3 mnasnet resnet vision transformer vit',
     packages=find_packages(exclude=['convert', 'tests', 'results']),
     include_package_data=True,
-    install_requires=['torch >= 1.7', 'torchvision', 'pyyaml', 'huggingface_hub'],
+    install_requires=['torch >= 1.7', 'torchvision', 'pyyaml', 'huggingface_hub<=0.10.1'],
     python_requires='>=3.6',
 )
 


### PR DESCRIPTION
Due to new release (0.11.0) coming soon, there will be some breaking changes. So to avoid that, we can pin the version for now of HF Hub, and issue a fix asap. 

