### PR TITLE
Use in-place operations for EMA

### DIFF
--- a/timm/utils/model_ema.py
+++ b/timm/utils/model_ema.py
@@ -117,10 +117,11 @@ class ModelEmaV2(nn.Module):
             for ema_v, model_v in zip(self.module.state_dict().values(), model.state_dict().values()):
                 if self.device is not None:
                     model_v = model_v.to(device=self.device)
-                ema_v.copy_(update_fn(ema_v, model_v))
+                if model_v.is_floating_point():
+                    update_fn(ema_v, model_v)
 
     def update(self, model):
-        self._update(model, update_fn=lambda e, m: self.decay * e + (1. - self.decay) * m)
+        self._update(model, update_fn=lambda e, m: e.mul_(self.decay).add_(m, alpha=1 - self.decay))
 
     def set(self, model):
         self._update(model, update_fn=lambda e, m: m)


### PR DESCRIPTION
Hi,

I noticed that the EMA used here is pretty slow, since it does not use in-place operations.
Using an in-place ops results in a ~50% faster EMA, however, it does not work with type-promotion. 
One workaround is to check whether a tensor from the model is floating point or not, with `Tensor.is_floating_point()`. I don't think there is any point in doing EMA on int tensors such as `num_batches_tracked` in BN.

Cheers!