### PR TITLE
Fix github source links in docs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -16,5 +16,6 @@ jobs:
       package_name: timm
       repo_owner: rwightman
       path_to_docs: pytorch-image-models/hfdocs/source
+      version_tag_suffix: ""
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}


### PR DESCRIPTION
Adds `version_tag_suffix` to the main doc workflow (its already in the pr doc build workflow). Without it, github source links have a `src/` part in them that breaks them.

