### PR TITLE
Add support to load safetensors weights

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch>=1.7
 torchvision
 pyyaml
 huggingface_hub
+safetensors>=0.2

--- a/timm/models/_helpers.py
+++ b/timm/models/_helpers.py
@@ -7,6 +7,7 @@ import os
 from collections import OrderedDict
 
 import torch
+import safetensors.torch
 
 import timm.models._builder
 
@@ -26,7 +27,12 @@ def clean_state_dict(state_dict):
 
 def load_state_dict(checkpoint_path, use_ema=True):
     if checkpoint_path and os.path.isfile(checkpoint_path):
-        checkpoint = torch.load(checkpoint_path, map_location='cpu')
+        # Check if safetensors or not and load weights accordingly
+        if str(checkpoint_path).endswith(".safetensors"):
+            checkpoint = safetensors.torch.load_file(checkpoint_path, device='cpu')
+        else:
+            checkpoint = torch.load(checkpoint_path, map_location='cpu')
+
         state_dict_key = ''
         if isinstance(checkpoint, dict):
             if use_ema and checkpoint.get('state_dict_ema', None) is not None:

--- a/timm/models/_hub.py
+++ b/timm/models/_hub.py
@@ -167,14 +167,14 @@ def load_state_dict_from_hf(model_id: str, filename: str = HF_WEIGHTS_NAME):
     for safe_filename in _get_safe_alternatives(filename):
         try:
             cached_safe_file = hf_hub_download(repo_id=hf_model_id, filename=safe_filename, revision=hf_revision)
-            _logger.warning(f"[{model_id}] Safe alternative available for '{filename}' (as '{safe_filename}'). Loading weights using safetensors.")
+            _logger.info(f"[{model_id}] Safe alternative available for '{filename}' (as '{safe_filename}'). Loading weights using safetensors.")
             return safetensors.torch.load_file(cached_safe_file, device="cpu")
         except EntryNotFoundError:
             pass
 
     # Otherwise, load using pytorch.load
     cached_file = hf_hub_download(hf_model_id, filename=filename, revision=hf_revision)
-    _logger.warning(f"[{model_id}] Safe alternative not found for '{filename}'. Loading weights using default pytorch.")
+    _logger.info(f"[{model_id}] Safe alternative not found for '{filename}'. Loading weights using default pytorch.")
     return torch.load(cached_file, map_location='cpu')
 
 


### PR DESCRIPTION
Follows discussion happening [here](https://huggingface.slack.com/archives/C04PRV8LH3J/p1676040500731159) (internal link). Goal is support [safetensors](https://huggingface.co/docs/safetensors/index) in timm for safers serialization/loading of the weights.

Default rule is _"load with safetensors whenever possible but still save to pytorch"_. This is the same as `transformers`.

Worth mentioning [this tool](https://huggingface.co/spaces/safetensors/convert) (thanks @osanseviero) to convert weights stored on the Huggingface Hub to safetensors. [See example](https://huggingface.co/timm/mobilenetv3_large_100.ra_in1k/discussions/1).

cc @rwightman @narsil @LysandreJik

### 1. Load from HF Hub (`load_state_dict_from_hf`)

When loading weights from the Huggingface Hub (i.e. when using `load_state_dict_from_hf`), we check if a `safetensors` file already exists or not. If yes, we load from it by default. If not, we load from the default pytorch binary. More precisely:
1. If filename is `pytorch_model.bin` (default), we look for file `model.safetensors`. If it doesn't exist, we look for file `pytorch_model.safetensors`.
2. If filename is custom but ends with `.bin` (e.g. `my_cool_timm_model.bin`), we look for a file with the same name but safetensors extension (e.g. `my_cool_timm_model.safetensors`)
3. Otherwise (or if safetensors files are not found), we load the .bin file.

=> worth case scenario, we have an extra cost of 2 HEAD calls to the Hub. I don't think it's too problematic (and we can always optimize this later).

Example (load from [this branch](https://huggingface.co/timm/mobilenetv3_large_100.ra_in1k/tree/refs%2Fpr%2F1)):
```py
import timm

model = timm.create_model('hf_hub:timm/mobilenetv3_large_100.ra_in1k@refs/pr/1', pretrained=True)
```

### 2. Load from local file (`load_state_dict`)

If filename extension is ".safetensors", load with it. Otherwise, load with pytorch (default behavior).

```py
import timm

tensors = timm.models.load_state_dict("path/to/folder/weights.safetensors")
```

### 3. Push to hub (`push_to_hf_hub`):

Added a parameter `safe_serialization` to the `push_to_hf_hub` helper. I took the same naming as in `transformers`. Value can be:
1. `True`: push weights with safetensors as `model.safetensors`.
2. `False`: push weights with pytorch as `pytorch_model.bin`. This is the default behavior.
3. `"both"`: push both safe and "unsafe" weights (as `model.safetensors` and `pytorch_model.bin`).

"both" naming feels a bit weird but it's mostly for internal usage, right?

```py
import timm

model = timm.create_model("resnet18")
timm.models.push_to_hf_hub(model, "resnet18-no-training-example", safe_serialization="both")
```

### 4. Script `avg_checkpoints.py`

Added a `--safetensors` boolean option, defaults to False.
If `--safetensors` is passed, the default output path become `"./average.safetensors"` instead of "./average.pth".
If `--safetensors` and `--ouput=xxx` are passed, we check if output file extension ends by `.safetensors`. I not I print a warning message but still continue the process.

### 5. Script `clean_checkpoint.py`

Added a `--safetensors` boolean option, defaults to False.
Output filename is not configurable. Filename ends either by `.pth` (default) or `.safetensors` (when requested).